### PR TITLE
PSDEVOPS-3750 - generically handle throwing 400 or 404 in REST API

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -269,6 +269,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 10,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "corgi.api.exception_handlers.exception_handler",
 }
 
 

--- a/corgi/api/exception_handlers.py
+++ b/corgi/api/exception_handlers.py
@@ -1,0 +1,11 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.serializers import as_serializer_error
+from rest_framework.views import exception_handler as drf_exception_handler
+
+
+def exception_handler(exc, context):
+    # from https://stackoverflow.com/a/67185502
+    if isinstance(exc, DjangoValidationError):
+        exc = DRFValidationError(as_serializer_error(exc))
+    return drf_exception_handler(exc, context)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -431,3 +431,8 @@ def test_api_component_404(client, api_path):
         f"{api_path}/components?purl=pkg:rpm/redhat/non-existent-fake-libs@3.26.0-15.el8?arch=x86_64"  # noqa
     )
     assert response.status_code == 404
+
+
+def test_api_component_400(client, api_path):
+    response = client.get(f"{api_path}/components?type=NONEXISTANTTYPE")
+    assert response.status_code == 400


### PR DESCRIPTION
This PR provides some generic django exception handling eg. if an entity does not exist we should now throw a 404 and if we provide bad/malformed input throw a 400.