### PR TITLE
PSDEVOPS-3745, PSDEVOPS-3755: Misc fixes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -192,7 +192,6 @@ DATABASES = {
         "PASSWORD": os.getenv("CORGI_DB_PASSWORD", "test"),
         "HOST": os.getenv("CORGI_DB_HOST", "localhost"),
         "PORT": os.getenv("CORGI_DB_PORT", "5432"),
-        "CONN_MAX_AGE": None,
     }
 }
 
@@ -212,7 +211,7 @@ STATIC_ROOT = str(BASE_DIR / "staticfiles")
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Celery config
-CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://corgi-redis:6379")
+CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://redis:6379")
 
 CELERY_RESULT_BACKEND = "django-db"
 # Retry tasks due to Postgres failures instead of immediately re-raising exceptions

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -76,6 +76,7 @@ CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",
     "https://cdnjs.cloudflare.com",
+    "https://cdn.jsdelivr.net",
 )
 CSP_FONT_SRC = (
     "'self'",
@@ -85,11 +86,17 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-inline'",
     "https://cdnjs.cloudflare.com",
+    "https://cdn.jsdelivr.net",
 )
-CSP_IMG_SRC = ("'self'",)
+CSP_IMG_SRC = (
+    "'self'",
+    "https://cdn.jsdelivr.net",
+)
 CSP_DEFAULT_SRC = (
     "'self'",
     "data:",
+    # 'self' should be same as below, but CSP still reports errors
+    f"https://{CORGI_DOMAIN}",
 )
 
 # RFC 5322 datetime format used in web UIs, nicer to read than ISO8601

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -532,7 +532,7 @@ class ProductSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_build_count(instance):
-        return len(instance.builds)
+        return instance.builds.count()
 
     class Meta:
         model = Product
@@ -639,7 +639,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_build_count(instance):
-        return len(instance.builds)
+        return instance.builds.count()
 
     class Meta:
         model = ProductVersion
@@ -746,7 +746,7 @@ class ProductStreamSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_build_count(instance):
-        return len(instance.builds)
+        return instance.builds.count()
 
     class Meta:
         model = ProductStream
@@ -854,7 +854,7 @@ class ProductVariantSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_build_count(instance):
-        return len(instance.builds)
+        return instance.builds.count()
 
     class Meta:
         model = ProductVariant

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       retries: 3
 
   redis:
-    container_name: corgi-redis
-    hostname: corgi-redis
+    container_name: redis
+    hostname: redis
     # Keep this in sync with openshift/playbooks/redis.yml
     image: "registry.redhat.io/rhel8/redis-6:1"
     ports:

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -3,6 +3,8 @@ import logging
 
 import pytest
 
+from corgi.core.models import ProductComponentRelation
+
 from .factories import (
     ComponentFactory,
     ProductComponentRelationFactory,
@@ -27,7 +29,9 @@ def test_product_manifest_properties():
 
     build = SoftwareBuildFactory(build_id=1)
     component = ComponentFactory(software_build=build)
-    ProductComponentRelationFactory(build_id="1", product_ref="1")
+    ProductComponentRelationFactory(
+        build_id="1", product_ref="1", type=ProductComponentRelation.Type.ERRATA
+    )
 
     build.save_component_taxonomy()
     build.save_product_taxonomy()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,9 +34,9 @@ def test_product_related_errata():
         type=ProductComponentRelation.Type.ERRATA, product_ref="Base"
     )
     p = ProductFactory()
-    relations = p.get_related_errata(["Base"], "external_system_id")
+    relations = p.get_product_component_relations(["Base"], only_errata=True)
     assert relations.exists()
-    relations = p.get_related_errata(["rhel"])
+    relations = p.get_product_component_relations(["rhel"], only_errata=True)
     assert not relations.exists()
 
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This has two quick bugfixes for the mentioned tickets, as well as cleanup for some overridden properties that I proposed to Jim yesterday. This uncovered a bug in get_related_errata(), which is really the same as get_product_component_relations() with some extra filtering added, so I deduped both into the same method and fixed the incorrect filtering logic.

I didn't end up adding tests for the Content Security Policy since:
1) Currently, we only really test the API and not the frontent / views
2) We'd need a different test for each view / page
3) The list of allowed resources / external JS libraries we use is relatively static and not likely to change much