### PR TITLE
PSDEVOPS-3708: Enable daily monitoring email now that UMB tasks run automatically

### DIFF
--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -1,7 +1,11 @@
 import logging
+from datetime import timedelta
 
+from celery.signals import beat_init
 from django.conf import settings
 from django.core.mail import EmailMessage
+from django.utils import timezone
+from django_celery_beat.models import CrontabSchedule, IntervalSchedule, PeriodicTask
 from django_celery_results.models import TaskResult
 
 from config.celery import app
@@ -9,6 +13,44 @@ from config.celery import app
 from .common import get_last_success_for_task, running_local
 
 logger = logging.getLogger(__name__)
+
+
+@beat_init.connect
+def setup_periodic_tasks(sender, **kwargs):
+    def upsert_cron_task(module, task, **kwargs):
+        crontab, _ = CrontabSchedule.objects.get_or_create(timezone=timezone.utc, **kwargs)
+        PeriodicTask.objects.get_or_create(
+            name=task, task=f"corgi.tasks.{module}.{task}", defaults={"crontab": crontab}
+        )
+
+    def upsert_interval_task(module, task, hours=None, minutes=None):
+        if hours:
+            interval, _ = IntervalSchedule.objects.get_or_create(
+                every=hours, period=IntervalSchedule.HOURS
+            )
+        elif minutes:
+            interval, _ = IntervalSchedule.objects.get_or_create(
+                every=minutes, period=IntervalSchedule.MINUTES
+            )
+        else:
+            raise ValueError(f"No interval value was specified when setting up {task} task")
+
+        PeriodicTask.objects.get_or_create(
+            name=task, task=f"corgi.tasks.{module}.{task}", defaults={"interval": interval}
+        )
+
+    # Wipe old schedules
+    CrontabSchedule.objects.all().delete()
+    IntervalSchedule.objects.all().delete()
+
+    # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
+    # task at all: https://github.com/celery/django-celery-beat/issues/221
+    upsert_cron_task("monitoring", "email_failed_tasks", hour=10, minute=45)
+
+    # Automatic task result expiration is currently disabled
+    # We are required to keep UMB task results
+    # Only run manually if DB is running out of space, or similar
+    # upsert_cron_task("monitoring", "expire_task_results", hour=13, minute=0)
 
 
 @app.task(autoretry_for=(Exception,), retry_backoff=900, retry_jitter=False)
@@ -44,3 +86,18 @@ def email_failed_tasks():
         from_email=settings.SERVER_EMAIL,
     )
     email.send()
+
+
+@app.task
+def expire_task_results():
+    """Delete task results older than 30 days.
+
+    To prevent the task results table to grow to huge numbers, remove any results that are
+    30 days or older. This job mimics the built-in celery.backend_cleanup job but works with
+    our schedules and is a bit more transparent in what it actually does.
+    """
+    expired_on = timezone.now() - timedelta(days=30)
+    removed_count, _ = TaskResult.objects.filter(date_done__lt=expired_on).delete()
+    logger.info("Removed %s expired task results", removed_count)
+
+    return f"Removed {removed_count} expired task results"


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Follow-up PR that will send us daily emails about failed tasks, once we turn on UMB tasks that will run periodically.