### PR TITLE
PSDEVOPS-3622 - minimal coverage report

### DIFF
--- a/corgi/api/urls.py
+++ b/corgi/api/urls.py
@@ -7,6 +7,7 @@ from .views import (
     ChannelView,
     ComponentTaxonomyView,
     ComponentView,
+    CoverageReportView,
     ProductStreamView,
     ProductTaxonomyView,
     ProductVariantView,
@@ -26,6 +27,7 @@ router.register(r"product_streams", ProductStreamView)
 router.register(r"product_variants", ProductVariantView)
 router.register(r"channels", ChannelView)
 router.register(r"status", StatusView, basename="status")
+router.register(r"reports/coverage", CoverageReportView, basename="coverage-reports")
 
 urlpatterns = [
     # v1 API

--- a/openapi.yml
+++ b/openapi.yml
@@ -1204,6 +1204,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/Product'
           description: ''
+  /api/v1/reports/coverage:
+    get:
+      operationId: v1_reports_coverage_retrieve
+      description: View for api/v1/reports/coverage
+      tags:
+      - v1
+      responses:
+        '200':
+          description: No response body
+  /api/v1/reports/coverage/{uuid}:
+    get:
+      operationId: v1_reports_coverage_retrieve_2
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this product.
+        required: true
+      tags:
+      - v1
+      responses:
+        '200':
+          description: No response body
   /api/v1/schema:
     get:
       operationId: v1_schema_retrieve


### PR DESCRIPTION
Generates minimal coverage report on products (versions, streams) that have at least one build against them, denoting # of builds, # of components and latest build dt . 

**Note** - It is likely that this report will evolve in future epics. 


