### PR TITLE
PSDEVOPS-3805: Schedule update of product data periodically

### DIFF
--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -45,6 +45,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
     # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
     # task at all: https://github.com/celery/django-celery-beat/issues/221
+    upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
+    upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
+    upsert_cron_task("rhel_compose", "load_composes", hour=2, minute=0)
     upsert_cron_task("monitoring", "email_failed_tasks", hour=10, minute=45)
 
     # Automatic task result expiration is currently disabled


### PR DESCRIPTION
@jasinner I went ahead and did this since it was a very quick change, but feel free to tweak if the update should run more than once a day, or if the order should be different. I copied the order the "loadproductdata" command uses, but not sure if that's right.