### PR TITLE
PSDEVOPS-3468: Add minimal rhel modules support

### DIFF
--- a/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git---pkgs.devel.redhat.com-modules-nodejs-#e457a1b700c09c58beca7e979389a31c98cead34-redhat-nodejs-MIT-module].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git---pkgs.devel.redhat.com-modules-nodejs-#e457a1b700c09c58beca7e979389a31c98cead34-redhat-nodejs-MIT-module].yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fae76d26ab15915e5fb44bf5f35c462477c85e885c7f8314697a0154dae27ef
+size 48611

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -83,10 +83,10 @@ build_corpus = [
     # nodejs: brew buildID=1700497
     (
         1700497,
-        os.getenv("CORGI_TEST_CODE_URL"),
+        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}/modules/nodejs?#e457a1b700c09c58beca7e979389a31c98cead34",  # noqa
         "redhat",
-        "it's a module build of nodejs but I didn't bother to fill in the test data",
-        "",
+        "nodejs",
+        "MIT",
         "module",
         # TODO: complete above when support is added
     ),
@@ -114,7 +114,9 @@ def test_get_component_data(build_id, build_source, build_ns, build_name, licens
             Brew().get_component_data(build_id)
         return
     c = Brew().get_component_data(build_id)
-    if build_type == "maven":
+    if build_type == "module":
+        assert list(c.keys()) == ["type", "namespace", "meta", "analysis_meta", "build_meta"]
+    elif build_type == "maven":
         assert list(c.keys()) == ["type", "namespace", "meta", "build_meta"]
     elif build_type == "image":
         assert list(c.keys()) == [


### PR DESCRIPTION
This PR enables ingestion of rhel modules ... for now we only create the root component node and associated RHEL_MODULE component.

Future stories will need to provide more detail and how we might populate component tree underneath RHEL_MODULE (for now its provided in meta data).
