### PR TITLE
PSDEVOPS-3529 greed matching

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -584,10 +584,7 @@ class ProductComponentRelation(TimeStampedModel):
 
 
 def get_product_streams_from_variants(variant_ids: list[str]):
-    query = Q()
-    for variant_id in variant_ids:
-        query = query | Q(name__contains=variant_id)
-    product_variants = ProductVariant.objects.filter(query)
+    product_variants = ProductVariant.objects.filter(name__in=variant_ids)
     product_streams = []
     for pv in product_variants:
         product_streams.extend(ProductNode.get_product_streams(pv))
@@ -597,10 +594,7 @@ def get_product_streams_from_variants(variant_ids: list[str]):
 def get_product_details(variant_ids: list[str], stream_ids: list[str]) -> dict[str, set[str]]:
     if variant_ids:
         stream_ids.extend(get_product_streams_from_variants(variant_ids))
-    query = Q()
-    for stream_id in stream_ids:
-        query = query | Q(name__contains=stream_id)
-    product_streams = ProductStream.objects.filter(query)
+    product_streams = ProductStream.objects.filter(name__in=stream_ids)
     product_details = defaultdict(set)
     for product_stream in product_streams:
         for ancestor in product_stream.pnodes.all().get_ancestors(include_self=True):
@@ -878,7 +872,7 @@ class Component(TimeStampedModel):
         variant_ids = self.get_product_variants()
         stream_ids = self.get_product_streams()
 
-        if not stream_ids:
+        if not variant_ids and not stream_ids:
             return []
 
         product_details = get_product_details(variant_ids, stream_ids)

--- a/corgi/tasks/management/commands/loadcomposedata.py
+++ b/corgi/tasks/management/commands/loadcomposedata.py
@@ -1,0 +1,53 @@
+import sys
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from corgi.tasks.brew import slow_fetch_brew_build
+from corgi.tasks.rhel_compose import get_all_builds, get_builds_by_compose
+
+
+class Command(BaseCommand):
+
+    help = "Fetch builds for composes"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "compose_names",
+            nargs="*",
+            type=str,
+            help="Names of composes to load",
+        )
+        parser.add_argument(
+            "-c",
+            "--celery",
+            action="store_true",
+            help="Schedule build for ingestion as celery task.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        build_ids = []
+
+        if options["compose_names"]:
+            compose_names = options["compose_names"]
+            self.stderr.write(self.style.NOTICE(f"Fetching builds for composes: {compose_names}"))
+            build_ids = get_builds_by_compose(compose_names)
+        else:
+            self.stderr.write(self.style.NOTICE("Fetching builds for all composes"))
+            build_ids = get_all_builds()
+
+        if not build_ids:
+            self.stderr.write(self.style.ERROR(f"No build IDs found for composes {compose_names}"))
+            sys.exit(1)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Fetching component data for builds: {', '.join(map(str, build_ids))}"
+            )
+        )
+
+        for build_id in build_ids:
+            id = int(build_id)
+            if options["celery"]:
+                slow_fetch_brew_build.delay(id)
+            else:
+                slow_fetch_brew_build(id)

--- a/corgi/tasks/rhel_compose.py
+++ b/corgi/tasks/rhel_compose.py
@@ -71,3 +71,24 @@ def save_compose(stream_name, compose_coords) -> None:
                     if created:
                         relation.type = ProductComponentRelation.Type.COMPOSE
                         relation.save()
+
+
+def get_builds_by_compose(compose_names):
+    return list(
+        ProductComponentRelation.objects.filter(
+            external_system_id__in=compose_names,
+            type=ProductComponentRelation.Type.COMPOSE,
+        )
+        .values_list("build_id", flat=True)
+        .distinct()
+    )
+
+
+def get_all_builds():
+    return list(
+        ProductComponentRelation.objects.filter(
+            type=ProductComponentRelation.Type.COMPOSE,
+        )
+        .values_list("build_id", flat=True)
+        .distinct()
+    )


### PR DESCRIPTION
Fixes a bug where components are eagerly matched to all products if they don't have any entry in ProductComposeRelations.

Also add `loadcomposedata` management command for loading builds in composes.