### PR TITLE
PSDEVOPS-3814: Try to fix deadlock when creating ProductComponentRelations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+junit.xml
 nosetests.xml
 coverage.xml
 *.cover

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,15 +46,20 @@ test:
   script:
     - dnf --disableplugin=subscription-manager --nodocs -y install python39 python39-devel gcc krb5-devel postgresql-devel
     - python3.9 -m pip install tox
-    - tox -e corgi -- --record-mode=none --cov-report term  # Do not create any VCR cassettes in CI
+    - tox -e corgi -- --record-mode=none --cov-report term --junitxml=junit.xml  # Do not create any VCR cassettes in CI
   except:
     refs:
       - schedules
+  # report coverage lines like 'TOTAL    2962    882    70%'
+  coverage: '/TOTAL(?:\s+\d+\s+\d+\s+)(\d+)%/'
   artifacts:
+      when: always
       reports:
         coverage_report:
           coverage_format: cobertura
           path: coverage.xml
+        junit:
+          - junit.xml
       expire_in: 1 week
 
 test-migrations:

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -747,27 +747,13 @@ class ProductStreamSerializer(serializers.ModelSerializer):
                 )
         return p
 
-    def get_relations(self, instance):
-        related_external_system_ids = (
-            ProductComponentRelation.objects.filter(product_ref=instance.name)
-            .distinct()
-            .values_list("external_system_id", flat=True)
-        )
-        relations = []
-        for external_system_id in related_external_system_ids:
-            pcr = ProductComponentRelation.objects.filter(
-                external_system_id=external_system_id
-            ).first()
-            if pcr:
-                relations.append(
-                    {
-                        "type": pcr.type,
-                        "external_system_id": pcr.external_system_id,
-                    }
-                )
-        if relations:
-            return relations
-        return None
+    @staticmethod
+    def get_relations(instance) -> list[dict[str, str]]:
+        related_pcrs = ProductComponentRelation.objects.filter(product_ref=instance.name).distinct()
+        relations = [
+            {"type": pcr.type, "external_system_id": pcr.external_system_id} for pcr in related_pcrs
+        ]
+        return relations
 
     @staticmethod
     def get_build_count(instance):
@@ -880,27 +866,13 @@ class ProductVariantSerializer(serializers.ModelSerializer):
                 )
         return p
 
-    def get_relations(self, instance):
-        related_external_system_ids = (
-            ProductComponentRelation.objects.filter(product_ref=instance.name)
-            .distinct()
-            .values_list("external_system_id", flat=True)
-        )
-        relations = []
-        for external_system_id in related_external_system_ids:
-            pcr = ProductComponentRelation.objects.filter(
-                external_system_id=external_system_id
-            ).first()
-            if pcr:
-                relations.append(
-                    {
-                        "type": pcr.type,
-                        "external_system_id": pcr.external_system_id,
-                    }
-                )
-        if relations:
-            return relations
-        return None
+    @staticmethod
+    def get_relations(instance) -> list[dict[str, str]]:
+        related_pcrs = ProductComponentRelation.objects.filter(product_ref=instance.name).distinct()
+        relations = [
+            {"type": pcr.type, "external_system_id": pcr.external_system_id} for pcr in related_pcrs
+        ]
+        return relations
 
     @staticmethod
     def get_build_count(instance):

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -87,14 +87,18 @@ def load_errata(errata_names: list[str]) -> list[int]:
         else:
             erratum_id = int(erratum_name)
         # Get all the PCR with errata_id
-        relation_build_ids = ProductComponentRelation.objects.filter(
-            external_system_id=erratum_id
-        ).values_list("build_id", flat=True)
+        relation_build_ids = list(
+            ProductComponentRelation.objects.filter(external_system_id=erratum_id).values_list(
+                "build_id", flat=True
+            )
+        )
         # Check is we have software builds for all of them
         if (
+            # Skip loading erratum if we have all its builds in DB already
+            # But handle case / don't skip it when num_build_ids == num_builds == 0
             0
             < len(relation_build_ids)
-            == SoftwareBuild.objects.filter(build_id__in=list(relation_build_ids)).count()
+            == SoftwareBuild.objects.filter(build_id__in=relation_build_ids).count()
         ):
             logger.info("Already processed %s", erratum_id)
             continue

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -104,16 +104,17 @@ def load_errata(errata_names: list[str]) -> list[int]:
             for build_obj in build_objects:
                 for build_id, errata_components in build_obj.items():
                     build_ids.add(int(build_id))
-                    pcr, created = ProductComponentRelation.objects.get_or_create(
+                    _, created = ProductComponentRelation.objects.get_or_create(
                         external_system_id=erratum_id,
                         product_ref=variant_id,
                         build_id=build_id,
+                        defaults={
+                            "type": ProductComponentRelation.Type.ERRATA,
+                            "meta_attr": {"components": errata_components},
+                        },
                     )
                     if created:
                         created_relations += 1
-                        pcr.type = ProductComponentRelation.Type.ERRATA
-                        pcr.meta_attr = {"components": errata_components}
-                        pcr.save()
     logger.info("Saved %s new product component relations", created_relations)
     for build_id in build_ids:
         app.send_task("corgi.tasks.brew.slow_fetch_brew_build", args=[build_id])

--- a/corgi/tasks/rhel_compose.py
+++ b/corgi/tasks/rhel_compose.py
@@ -63,15 +63,12 @@ def save_compose(stream_name, compose_coords) -> None:
                             build_id = rpm_data["build_id"]
                             # found the build_id, stop iterating filenames
                             break
-                    relation, created = ProductComponentRelation.objects.get_or_create(
+                    ProductComponentRelation.objects.get_or_create(
                         external_system_id=compose_id,
                         product_ref=stream_name,
                         build_id=build_id,
+                        defaults={"type": ProductComponentRelation.Type.COMPOSE},
                     )
-                    # Don't include type in get_or_create to avoid slow read of field outside index
-                    if created:
-                        relation.type = ProductComponentRelation.Type.COMPOSE
-                        relation.save()
 
 
 def get_builds_by_compose(compose_names):

--- a/openapi.yml
+++ b/openapi.yml
@@ -2102,7 +2102,11 @@ components:
           type: string
           readOnly: true
         relations:
-          type: string
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
           readOnly: true
         tags:
           type: array
@@ -2185,7 +2189,11 @@ components:
             $ref: '#/components/schemas/Tag'
           readOnly: true
         relations:
-          type: string
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
           readOnly: true
         products:
           type: string

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -83,12 +83,12 @@ build_corpus = [
     # nodejs: brew buildID=1700497
     (
         1700497,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}/modules/nodejs?#e457a1b700c09c58beca7e979389a31c98cead34",  # noqa
+        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+        f"/modules/nodejs?#e457a1b700c09c58beca7e979389a31c98cead34",
         "redhat",
         "nodejs",
         "MIT",
         "module",
-        # TODO: complete above when support is added
     ),
     # cryostat-rhel8-operator-container:
     # brew buildID=1841202


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Review appreciated. Without a traceback it's hard to know what the dependent code / transaction was waiting for. CONTEXT below indicates that inserting fails:

OperationalError('deadlock detected
DETAIL: Process 3580 waits for ShareLock on transaction 834584; blocked by process 3616.
Process 3616 waits for ShareLock on transaction 833789; blocked by process 3580.

HINT: See server log for query details.

CONTEXT: while inserting index tuple (5740,87) in relation "unique_productcomponentrelation"
')

There are only two places in the code where ProductComponentRelations get created, as far as I can tell. I've changed these to use defaults= inside the get_or_create, so that insert is fully atomic.

I then cleaned up logic that tries to access or read from ProductComponentRelations, to avoid evaluating a queryset multiple times or making many calls to the DB when only one is needed. In other words, all reads of PCR data should be atomic as well, so there should be no more race conditions or deadlocks.

I don't see any place where PCRs get updated or deleted. Did I miss these, or are we only inserting this data and never changing it after it's been created?