### PR TITLE
PSDEVOPS-3839: Speed up performance

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -222,7 +222,9 @@ CELERY_RESULT_BACKEND = "django-db"
 CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
 CELERY_RESULT_BACKEND_MAX_RETRIES = 2
 CELERY_DEFAULT_RATE_LIMIT = "8/m"
-CELERYD_SOFT_TIME_LIMIT = 300
+# Set a global 15-minute task timeout. Override this on individual tasks by decorating them with:
+# @app.task(soft_time_limit=<TIME_IN_SECONDS>)
+CELERY_TASK_SOFT_TIME_LIMIT = 900
 
 CELERY_WORKER_CONCURRENCY = 1  # defaults to CPU core count, which breaks in OpenShift
 

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -706,9 +706,8 @@ class Brew:
         return component
 
     def get_builds_with_tag(self, brew_tag: str, inherit: bool = False) -> list[int]:
-        brew = self.get_koji_session()
         try:
-            builds = brew.listTagged(brew_tag, inherit=inherit)
+            builds = self.koji_session.listTagged(brew_tag, inherit=inherit)
             return [b["build_id"] for b in builds]
         except koji.GenericError as exc:
             logger.warning("Couldn't find brew builds with tag %s: %s", brew_tag, exc)

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -155,15 +155,17 @@ def save_component(component, parent, softwarebuild=None):
 
 def save_srpm(softwarebuild, build_data) -> ComponentNode:
     obj, created = Component.objects.get_or_create(
-        type=Component.Type.SRPM,
         name=build_data["meta"].get("name"),
+        type=Component.Type.SRPM,
+        arch=build_data["meta"].get("arch", ""),
         version=build_data["meta"].get("version", ""),
         release=build_data["meta"].get("release", ""),
-        arch=build_data["meta"].get("arch", ""),
-        license=build_data["meta"].get("license", ""),
-        description=build_data["meta"].get("description", ""),
-        software_build=softwarebuild,
-        meta_attr=build_data["meta"],
+        defaults={
+            "license": build_data["meta"].get("license", ""),
+            "description": build_data["meta"].get("description", ""),
+            "software_build": softwarebuild,
+            "meta_attr": build_data["meta"],
+        },
     )
     node, _ = obj.cnodes.get_or_create(
         type=ComponentNode.ComponentNodeType.SOURCE,
@@ -200,15 +202,16 @@ def process_image_components(image):
 
 
 def save_container(softwarebuild, build_data) -> ComponentNode:
-
     obj, created = Component.objects.get_or_create(
-        type=Component.Type.CONTAINER_IMAGE,
         name=build_data["meta"]["name"],
+        type=Component.Type.CONTAINER_IMAGE,
+        arch="noarch",
         version=build_data["meta"]["version"],
         release=build_data["meta"]["release"],
-        arch="noarch",
-        software_build=softwarebuild,
-        meta_attr=build_data["meta"],
+        defaults={
+            "software_build": softwarebuild,
+            "meta_attr": build_data["meta"],
+        },
     )
     root_node, _ = obj.cnodes.get_or_create(
         type=ComponentNode.ComponentNodeType.SOURCE,
@@ -232,13 +235,15 @@ def save_container(softwarebuild, build_data) -> ComponentNode:
     if "image_components" in build_data:
         for image in build_data["image_components"]:
             obj, created = Component.objects.get_or_create(
-                type=Component.Type.CONTAINER_IMAGE,
                 name=image["meta"].pop("name"),
+                type=Component.Type.CONTAINER_IMAGE,
+                arch=image["meta"].pop("arch"),
                 version=image["meta"].pop("version"),
                 release=image["meta"].pop("release"),
-                arch=image["meta"].pop("arch"),
-                software_build=softwarebuild,
-                meta_attr=image["meta"],
+                defaults={
+                    "software_build": softwarebuild,
+                    "meta_attr": image["meta"],
+                },
             )
             image_arch_node, _ = obj.cnodes.get_or_create(
                 type=ComponentNode.ComponentNodeType.PROVIDES,
@@ -278,15 +283,17 @@ def recurse_components(component, parent):
 
 def save_module(softwarebuild, build_data) -> ComponentNode:
     obj, created = Component.objects.get_or_create(
-        type=Component.Type.RHEL_MODULE,
         name=build_data["meta"]["name"],
+        type=Component.Type.RHEL_MODULE,
+        arch=build_data["meta"].get("arch", ""),
         version=build_data["meta"].get("version", ""),
         release=build_data["meta"].get("release", ""),
-        arch=build_data["meta"].get("arch", ""),
-        license=build_data["meta"].get("license", ""),
-        description=build_data["meta"].get("description", ""),
-        software_build=softwarebuild,
-        meta_attr=build_data["meta"]["components"],
+        defaults={
+            "license": build_data["meta"].get("license", ""),
+            "description": build_data["meta"].get("description", ""),
+            "software_build": softwarebuild,
+            "meta_attr": build_data["meta"]["components"],
+        },
     )
     node, _ = obj.cnodes.get_or_create(
         type=ComponentNode.ComponentNodeType.SOURCE,

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -144,8 +144,7 @@ def update_variant_repos() -> None:
         pv_channels = []
         for repo in et_variant_data["repos"]:
             repo, _ = Channel.objects.get_or_create(
-                type=Channel.Type.CDN_REPO,
-                name=repo,
+                name=repo, defaults={"type": Channel.Type.CDN_REPO}
             )
             pv_channels.append(repo.name)
             # TODO: investigate whether we need to delete CDN repos that were removed from a

--- a/corgi/tasks/management/commands/loadbrewdata.py
+++ b/corgi/tasks/management/commands/loadbrewdata.py
@@ -35,9 +35,9 @@ class Command(BaseCommand):
         if options["build_ids"]:
             build_ids = options["build_ids"]
         elif options["brew_tag"]:
-            brew = Brew().get_koji_session()
+            brew = Brew()
             try:
-                builds = brew.listTagged(options["brew_tag"])
+                builds = brew.koji_session.listTagged(options["brew_tag"])
             except GenericError as exc:
                 self.stderr.write(self.style.ERROR(str(exc)))
                 sys.exit(1)

--- a/scripts/schema-check.sh
+++ b/scripts/schema-check.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./manage.py spectacular --file openapi.yml --settings=config.settings.test &> /dev/null && git diff --quiet openapi.yml &> /dev/null

--- a/tox.ini
+++ b/tox.ini
@@ -86,13 +86,14 @@ commands = bandit -r corgi
 [testenv:radon]
 # NOTE: radon module cannot read from pyproject.toml just yet
 deps = -r requirements/lint.txt
-commands = radon cc --ignore apps,src,venv --exclude tests/*.py --min "C" .
-    radon mi --ignore src,venv --exclude tests/*.py --min "C" .
+commands = radon cc --ignore tests,venv --min "C" .
+    radon mi --ignore tests,venv --min "C" .
 
 [testenv:schema]
 deps = -r requirements/base.txt
-allowlist_externals = bash
-commands = /usr/bin/bash -c './scripts/schema-check.sh'
+allowlist_externals = git
+commands = python3 manage.py spectacular --file openapi.yml
+    /usr/bin/git diff --quiet openapi.yml
 
 [testenv:pip-audit]
 deps = -r requirements/lint.txt


### PR DESCRIPTION
Outdated, incorrect: @RedHatProductSecurity/corgi-devs This change should prevent duplicate rows from being inserted into our DB, which will prevent "ModelName.MultipleObjectsReturnedError" when using "ModelName.get". Note that we may have to clean up any existing duplicate rows before the error goes away, but this fix will keep things from getting worse / more duplicates from being added.

Still accurate: It also improves performance slightly, since using get_or_create with only indexed keyword arguments, and moving unindexed keyword arguments to the defaults= dict, speeds up the database operations. The exact reason is that get_or_create first tries to SELECT a row with matching field values / keyword arguments. The defaults= dict is ignored for this step. If no matching row is found, get_or_create then tries to INSERT a row using the provided keyword arguments and the values in the defaults dict. AKA the defaults= dict is not used for the get_ logic, only the _or_create logic.

Since we only provide indexed fields as keyword arguments, the SELECT query for the get_ logic can now use an index scan, instead of being forced to do a whole table scan to match against the unindexed fields. A whole table scan can be very slow for text fields / large tables with lots of data, although Jason's recent MR was a much better improvement :)