### PR TITLE
Loadproductdata allstreams

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -218,7 +218,6 @@ class SoftwareBuild(TimeStampedModel):
             for d in component.cnodes.all().get_descendants(include_self=True):
                 if not d.obj:
                     continue
-                d.obj.product_variants = d.obj.get_product_variants()
                 for a in ["products", "product_versions", "product_streams"]:
                     # Since we're only setting the product details for a specific build id we need
                     # to ensure we are only updating, not replacing the existing product details.

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -35,11 +35,10 @@ def link_stream_using_brew_tag(brew_tag: str, stream_name: str, inherit: bool = 
         product_variant, _ = ProductVariant.objects.get_or_create(name=variant)
         product_stream_node = ProductNode.objects.get(object_id=product_stream.pk)
         product_variant.pnodes.get_or_create(parent=product_stream_node)
-        product_stream = ProductStream.objects.get(uuid=product_stream.pk)
-        product_stream.save_product_taxonomy()
-        product_stream.save()
         product_variant.save_product_taxonomy()
         product_variant.save()
+    product_stream.save_product_taxonomy()
+    product_stream.save()
 
 
 def save_product_components_for_builds(build_ids: list[int]) -> QuerySet:

--- a/corgi/tasks/management/commands/loadproductdata.py
+++ b/corgi/tasks/management/commands/loadproductdata.py
@@ -12,6 +12,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
+            "-a",
+            "--all-streams",
+            dest="all_streams",
+            action="store_true",
+            help="Assign to stream",
+        )
+        parser.add_argument(
             "-s",
             "--stream",
             dest="stream",
@@ -28,6 +35,17 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if options["all_streams"]:
+            ps_with_tags = ProductStreamTag.objects.values("product_stream").distinct()
+            for ps in ProductStream.objects.filter(pk__in=ps_with_tags):
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Linking {ps.name} with brew tags from Product Definitions",
+                    )
+                )
+                self.link_all_tags_for_stream(ps)
+                return
+
         if options["stream"]:
             product_stream = ProductStream.objects.get(name=options["stream"])
 
@@ -37,12 +55,10 @@ class Command(BaseCommand):
                         "No tag specified, getting tags from ProductStreamTags",
                     )
                 )
-                for tag in ProductStreamTag.objects.filter(product_stream=product_stream):
-                    # ProductStreamTag values are strings
-                    inherit = tag.value == "True"
-                    self.link_stream_with_tag(product_stream.name, tag.name, inherit)
+                self.link_all_tags_for_stream(product_stream)
             else:
                 self.link_stream_with_tag(product_stream.name, options["tag"], options["inherit"])
+                return
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -64,6 +80,12 @@ class Command(BaseCommand):
             )
         )
         load_composes()
+
+    def link_all_tags_for_stream(self, product_stream):
+        for tag in ProductStreamTag.objects.filter(product_stream=product_stream):
+            # ProductStreamTag values are strings
+            inherit = tag.value == "True"
+            self.link_stream_with_tag(product_stream.name, tag.name, inherit)
 
     def link_stream_with_tag(self, stream: str, brew_tag: str, inherit: bool = False):
         link_stream_using_brew_tag(brew_tag, stream, inherit)


### PR DESCRIPTION
This adds a management command which uses product-definitions brew_tags to find and link builds to product streams.

It also fixes a bug in SoftwareBuild.save_product_taxonomy which was calling get_product_variants twice. 