### PR TITLE
PSDEVOPS-3839 improve workflow for errata ingestion

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -56,7 +56,8 @@ def slow_fetch_brew_build(build_id: int):
 
     # Once we have the full component tree loaded
     softwarebuild.save_component_taxonomy()
-    # We don't call save_product_taxonomy here to reduce CPU cycles and allow async call of load_errata task
+    # We don't call save_product_taxonomy here to reduce CPU cycles and
+    # allow async call of load_errata task
 
     # for builds with errata tags set ProductComponentRelation
     # get_component_data always calls _extract_advisory_ids to set tags, but list may be empty

--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             errata_ids = options["errata_ids"]
             for erratum_id in errata_ids:
                 self.stdout.write(self.style.SUCCESS(f"Loading Errata {erratum_id}"))
-                load_errata([erratum_id])
+                load_errata(erratum_id)
         elif options["repos"]:
             update_variant_repos()
         else:

--- a/corgi/tasks/management/commands/loadproductdata.py
+++ b/corgi/tasks/management/commands/loadproductdata.py
@@ -1,7 +1,6 @@
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import BaseCommand
 
-from corgi.core.models import ProductStream, ProductStreamTag
-from corgi.tasks.errata_tool import link_stream_using_brew_tag, load_et_products
+from corgi.tasks.errata_tool import load_et_products
 from corgi.tasks.prod_defs import update_products
 from corgi.tasks.rhel_compose import load_composes
 
@@ -10,56 +9,7 @@ class Command(BaseCommand):
 
     help = "Fetch product data from Product Definitions."
 
-    def add_arguments(self, parser: CommandParser) -> None:
-        parser.add_argument(
-            "-a",
-            "--all-streams",
-            dest="all_streams",
-            action="store_true",
-            help="Assign to stream",
-        )
-        parser.add_argument(
-            "-s",
-            "--stream",
-            dest="stream",
-            help="Assign to stream",
-        )
-        parser.add_argument(
-            "-t",
-            "--tag",
-            dest="tag",
-            help="Fetch variants for specific Brew tag",
-        )
-        parser.add_argument(
-            "-i", "--inherit", dest="inherit", action="store_true", help="Fetch inherited Brew tags"
-        )
-
     def handle(self, *args, **options):
-        if options["all_streams"]:
-            ps_with_tags = ProductStreamTag.objects.values("product_stream").distinct()
-            for ps in ProductStream.objects.filter(pk__in=ps_with_tags):
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Linking {ps.name} with brew tags from Product Definitions",
-                    )
-                )
-                self.link_all_tags_for_stream(ps)
-                return
-
-        if options["stream"]:
-            product_stream = ProductStream.objects.get(name=options["stream"])
-
-            if not options["tag"]:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        "No tag specified, getting tags from ProductStreamTags",
-                    )
-                )
-                self.link_all_tags_for_stream(product_stream)
-            else:
-                self.link_stream_with_tag(product_stream.name, options["tag"], options["inherit"])
-                return
-
         self.stdout.write(
             self.style.SUCCESS(
                 "Loading products from ET",
@@ -80,12 +30,3 @@ class Command(BaseCommand):
             )
         )
         load_composes()
-
-    def link_all_tags_for_stream(self, product_stream):
-        for tag in ProductStreamTag.objects.filter(product_stream=product_stream):
-            # ProductStreamTag values are strings
-            inherit = tag.value == "True"
-            self.link_stream_with_tag(product_stream.name, tag.name, inherit)
-
-    def link_stream_with_tag(self, stream: str, brew_tag: str, inherit: bool = False):
-        link_stream_using_brew_tag(brew_tag, stream, inherit)

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -120,6 +120,7 @@ def update_products() -> None:
                             et_pvs = CollectorErrataProductVersion.objects.filter(
                                 brew_tags__contains=[trimmed_brew_tag]
                             )
+                            # TODO add a BREW_TAG productcomposerelation instead of ProductStreamTag
                             # If we didn't find a match in ET collector models create a
                             # ProductSteamTag for later processing
                             if len(et_pvs) == 0:

--- a/tests/cassettes/test_errata_data/test_save_product_component_for_errata[77149-1].yaml
+++ b/tests/cassettes/test_errata_data/test_save_product_component_for_errata[77149-1].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a885b9380d8d4805ea4d49278d53ae1cfd05afef2ed9ed940ac45ddbcecb405
-size 4207

--- a/tests/cassettes/test_errata_data/test_save_product_component_for_errata[RHBA-2021-2382-3].yaml
+++ b/tests/cassettes/test_errata_data/test_save_product_component_for_errata[RHBA-2021-2382-3].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:539ef2dfc11e1e9e7c9e395c37da9f27f8c475ceb1cbed54ade1975f6b0fc109
-size 50855

--- a/tests/cassettes/test_errata_data/test_save_product_component_for_errata[RHBA-2021-2382-5].yaml
+++ b/tests/cassettes/test_errata_data/test_save_product_component_for_errata[RHBA-2021-2382-5].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5651ba8feacb20871b8081d74db540d5f6750291a355d344464776ae3957c589
-size 71772

--- a/tests/cassettes/test_errata_data/test_save_product_component_for_errata[test-0].yaml
+++ b/tests/cassettes/test_errata_data/test_save_product_component_for_errata[test-0].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42a03cb06da9fa411b21380b1be82ceb47df73d79b2194753fdb741fd5e00376
-size 4774

--- a/tests/test_errata_data.py
+++ b/tests/test_errata_data.py
@@ -1,8 +1,8 @@
+import os
 from unittest.mock import patch
 
 import pytest
 
-from corgi.collectors.errata_tool import ErrataTool
 from corgi.core.models import (
     Channel,
     ProductComponentRelation,
@@ -82,14 +82,111 @@ def test_update_variant_repos():
 
 
 # id, no_of_obj
-errata_details = [("77149", 1), ("RHBA-2021:2382", 3), ("test", 0)]
+errata_details = [
+    (
+        "77149",
+        """    {
+          "RHEL-8.4.0.Z.MAIN+EUS": {
+            "name": "RHEL-8.4.0.Z.MAIN+EUS",
+            "description": "Red Hat Enterprise Linux 8",
+            "builds": [
+              {
+                "ca-certificates-2021.2.50-80.0.el8_4": {
+                  "nvr": "ca-certificates-2021.2.50-80.0.el8_4",
+                  "nevr": "ca-certificates-0:2021.2.50-80.0.el8_4",
+                  "id": 1636922,
+                  "is_module": false,
+                  "variant_arch": {
+                    "BaseOS-8.4.0.Z.MAIN.EUS": {
+                      "SRPMS": [
+                        "ca-certificates-2021.2.50-80.0.el8_4.src.rpm"
+                      ],
+                      "noarch": [
+                        "ca-certificates-2021.2.50-80.0.el8_4.noarch.rpm"
+                      ]
+                    }
+                  },
+                  "added_by": null
+                }
+              }
+            ]
+          }
+    }""",
+        1,
+    ),
+    (
+        "77150",
+        """{
+            "RHEL-7-dotNET-3.1": {
+              "name": "RHEL-7-dotNET-3.1",
+              "description": ".NET Core on Red Hat Enterprise Linux",
+              "builds": [
+                {
+                  "rh-dotnet31-runtime-container-3.1-18": {
+                    "nvr": "rh-dotnet31-runtime-container-3.1-18",
+                    "nevr": "rh-dotnet31-runtime-container-0:3.1-18",
+                    "id": 1628352,
+                    "is_module": false,
+                    "variant_arch": {
+                      "7Server-dotNET-3.1": {
+                        "multi": [
+                          "docker-image-sha256:20952dbe8bf1159496be299778aaf44a5e50880f10c7689a38c3113c64b70d11.x86_64.tar.gz"
+                        ]
+                      }
+                    },
+                    "added_by": null
+                  }
+                },
+                {
+                  "rh-dotnet31-container-3.1-18": {
+                    "nvr": "rh-dotnet31-container-3.1-18",
+                    "nevr": "rh-dotnet31-container-0:3.1-18",
+                    "id": 1628358,
+                    "is_module": false,
+                    "variant_arch": {
+                      "7Server-dotNET-3.1": {
+                        "multi": [
+                          "docker-image-sha256:5f398886270c47b7d8c25f06093202d50cd49866e6f8dee48b6535e9ca144c6f.x86_64.tar.gz"
+                        ]
+                      }
+                    },
+                    "added_by": null
+                  }
+                },
+                {
+                  "rh-dotnet31-jenkins-agent-container-3.1-27": {
+                    "nvr": "rh-dotnet31-jenkins-agent-container-3.1-27",
+                    "nevr": "rh-dotnet31-jenkins-agent-container-0:3.1-27",
+                    "id": 1628450,
+                    "is_module": false,
+                    "variant_arch": {
+                      "7Server-dotNET-3.1": {
+                        "multi": [
+                          "docker-image-sha256:883da35d429fae52f0c1b2e7e9e36368d71577baa2334d5e9efc6d1f12d1c898.x86_64.tar.gz"
+                        ]
+                      }
+                    },
+                    "added_by": null
+                  }
+                }
+              ]
+            }
+        }""",
+        3,
+    ),
+]
 
 
-@pytest.mark.vcr
 @patch("config.celery.app.send_task")
-@pytest.mark.parametrize("errata_name, no_of_objs", errata_details)
-def test_save_product_component_for_errata(mock_send, errata_name, no_of_objs):
-    load_errata([errata_name])
-    errata_id = ErrataTool().normalize_erratum_id(errata_name)
-    pcr = ProductComponentRelation.objects.filter(external_system_id=errata_id)
+@pytest.mark.parametrize("erratum_id, build_list, no_of_objs", errata_details)
+def test_save_product_component_for_errata(
+    mock_send, erratum_id, build_list, no_of_objs, requests_mock
+):
+    build_list_url = (
+        f"{os.getenv('CORGI_ERRATA_TOOL_URL')}/api/v1/erratum/{erratum_id}/builds_list.json"
+    )
+    requests_mock.get(build_list_url, text=build_list)
+    load_errata(erratum_id)
+    pcr = ProductComponentRelation.objects.filter(external_system_id=erratum_id)
     assert len(pcr) == no_of_objs
+    assert mock_send.call_count == no_of_objs


### PR DESCRIPTION
This simplifies load Brew builds and associating them with Errata and prevents a deadlock where load_errata called slow_fetch_brew_build synchronously, and prevented the other from progressing due to load_errata being in a DB transaction. 

I removed the 'loadproductdata' mgnt options -stream, -tag, and -allstreams and related code, as it no longer works since simplifying load_errata to only handle a single erratum_name. I think we should create a new type in ProductComponentRelation called BREW_TAG for this type of link instead of using brew_tags to find an link product variants to streams.

We still need to come up with a solution for save_product_taxonomy when ingesting composes. I created PSDEVOPS-3849 as a follow up task for that.