### PR TITLE
Minor: remove unused product taxonomy in component object

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -871,25 +871,6 @@ class Component(TimeStampedModel):
                     channels.append(descendant.obj.name)
         return list(set(channels))
 
-    # TODO remove this? Force the use of SoftwareBuild.save_product_taxnonomy instead
-    def save_product_taxonomy(self):
-        variant_ids = self.get_product_variants()
-        stream_ids = self.get_product_streams()
-
-        if not variant_ids and not stream_ids:
-            return []
-
-        product_details = get_product_details(variant_ids, stream_ids)
-
-        # Since we have all variant ids for this component, we can replace any existing product
-        # details
-        self.products = list(set(product_details["products"]))
-        self.product_versions = list(set(product_details["product_versions"]))
-        self.product_streams = list(set(product_details["product_streams"]))
-        self.channels = self.get_channels()
-        self.product_variants = list(set(variant_ids))
-        self.save()
-
     def get_provides(self, include_dev=True):
         """return all descendants with PROVIDES ComponentNode type"""
         provides = []

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -203,8 +203,26 @@ def test_product_component_relations():
     srpm_cnode, _ = srpm.cnodes.get_or_create(
         type=ComponentNode.ComponentNodeType.SOURCE, parent=None
     )
-    srpm.save_product_taxonomy()
-    assert ps1.ofuri in srpm.product_streams
+    sb.save_product_taxonomy()
+    c = Component.objects.get(uuid=srpm.uuid)
+    assert ps1.ofuri in c.product_streams
+
+
+def test_product_component_relations_errata():
+    build_id = 1754635
+    sb = SoftwareBuildFactory(build_id=build_id)
+    ProductComponentRelation.objects.create(
+        type=ProductComponentRelation.Type.ERRATA, product_ref="Base8-test", build_id=build_id
+    )
+    p1, ps1, ps2, ps3, pv1a, pv1b = create_product_hierarchy()
+    relate_product_hierarchy(p1, ps1, ps2, ps3, pv1a, pv1b)
+    srpm = ComponentFactory(software_build=sb, type=Component.Type.SRPM)
+    srpm_cnode, _ = srpm.cnodes.get_or_create(
+        type=ComponentNode.ComponentNodeType.SOURCE, parent=None
+    )
+    sb.save_product_taxonomy()
+    c = Component.objects.get(uuid=srpm.uuid)
+    assert ps3.ofuri in c.product_streams
 
 
 def test_get_upstream():


### PR DESCRIPTION
removes Component save_product_taxonomy which is an older code path