### PR TITLE
Use hasattr(), not getattr(), when checking exception object in boolean context

### DIFF
--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -31,7 +31,7 @@ def fatal_code(e):
     """Do not retry on 4xx responses."""
     # Handle requests.exceptions.RequestException
     # 408 is "Request Timeout" that Brew sometimes returns, which can be retried safely
-    if getattr(e, "response", None):
+    if hasattr(e, "response"):
         return 400 <= e.response.status_code < 500 and e.response.status_code != 408
 
 


### PR DESCRIPTION
getattr will return the requests.response object, and it will be evaluated as a boolean. If the response had a 200ish code, it evaluates to True. If the code was 400ish or similar, it evaluates to False.

So any failed request will not enter the if block I changed in the diff, and we skip checking whether the code is retryable or not. Instead we just retry all requests, which is dangerous.