### PR TITLE
PSDEVOPS-3853 use links for results from products

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -455,6 +455,8 @@ class ComponentListSerializer(serializers.ModelSerializer):
 class ProductSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
     components = serializers.SerializerMethodField()
+    upstreams = serializers.SerializerMethodField()
+    builds = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -537,6 +539,18 @@ class ProductSerializer(serializers.ModelSerializer):
             return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
         return None
 
+    def get_upstreams(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}&type=UPSTREAM"  # noqa
+        return None
+
+    def get_builds(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/builds?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_build_count(instance):
         return instance.builds.count()
@@ -549,17 +563,15 @@ class ProductSerializer(serializers.ModelSerializer):
             "ofuri",
             "name",
             "description",
-            "coverage",
+            # "coverage",
             "build_count",
+            "builds",
             "components",
-            "manifest",
-            "upstream",
+            "upstreams",
             "tags",
             "product_versions",
             "product_streams",
             "product_variants",
-            "errata",
-            "builds",
             "channels",
             "meta_attr",
         ]
@@ -568,6 +580,8 @@ class ProductSerializer(serializers.ModelSerializer):
 class ProductVersionSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
     components = serializers.SerializerMethodField()
+    upstreams = serializers.SerializerMethodField()
+    builds = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -650,6 +664,24 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
         return None
 
+    def get_upstreams(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}&type=UPSTREAM"  # noqa
+        return None
+
+    def get_manifest(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/product_versions/{instance.uuid}/manifest"  # noqa
+        return None
+
+    def get_builds(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/builds?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_build_count(instance):
         return instance.builds.count()
@@ -662,17 +694,15 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "ofuri",
             "name",
             "description",
-            "coverage",
+            # "coverage",
             "build_count",
+            "builds",
             "components",
-            "manifest",
-            "upstream",
+            "upstreams",
             "tags",
             "products",
             "product_streams",
             "product_variants",
-            "errata",
-            "builds",
             "channels",
             "meta_attr",
         ]
@@ -681,6 +711,9 @@ class ProductVersionSerializer(serializers.ModelSerializer):
 class ProductStreamSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
     components = serializers.SerializerMethodField()
+    upstreams = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField()
+    builds = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -765,6 +798,24 @@ class ProductStreamSerializer(serializers.ModelSerializer):
             return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
         return None
 
+    def get_upstreams(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}&type=UPSTREAM"  # noqa
+        return None
+
+    def get_manifest(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/product_streams/{instance.uuid}/manifest"  # noqa
+        return None
+
+    def get_builds(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/builds?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_relations(instance):
         relations = list()
@@ -792,17 +843,17 @@ class ProductStreamSerializer(serializers.ModelSerializer):
             "name",
             "cpe",
             "description",
-            "coverage",
+            # "coverage",
             "build_count",
-            "components",
+            "builds",
             "manifest",
-            "upstream",
+            "components",
+            "upstreams",
             "relations",
             "tags",
             "products",
             "product_versions",
             "product_variants",
-            "errata",
             "builds",
             "channels",
             "meta_attr",
@@ -812,6 +863,9 @@ class ProductStreamSerializer(serializers.ModelSerializer):
 class ProductVariantSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
     components = serializers.SerializerMethodField()
+    upstreams = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField()
+    builds = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -896,6 +950,24 @@ class ProductVariantSerializer(serializers.ModelSerializer):
             return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
         return None
 
+    def get_upstreams(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}&type=UPSTREAM"  # noqa
+        return None
+
+    def get_manifest(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/product_variants/{instance.uuid}/manifest"  # noqa
+        return None
+
+    def get_builds(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/builds?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_relations(instance):
         relations = list()
@@ -923,16 +995,15 @@ class ProductVariantSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "build_count",
-            "components",
+            "builds",
             "manifest",
-            "upstream",
+            "components",
+            "upstreams",
             "tags",
             "relations",
             "products",
             "product_versions",
             "product_streams",
-            "errata",
-            "builds",
             "channels",
             "meta_attr",
         ]

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -454,7 +454,7 @@ class ComponentListSerializer(serializers.ModelSerializer):
 
 class ProductSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
-    components = ComponentListSerializer(many=True, read_only=True)
+    components = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -531,6 +531,12 @@ class ProductSerializer(serializers.ModelSerializer):
                 )
         return p
 
+    def get_components(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_build_count(instance):
         return instance.builds.count()
@@ -545,6 +551,9 @@ class ProductSerializer(serializers.ModelSerializer):
             "description",
             "coverage",
             "build_count",
+            "components",
+            "manifest",
+            "upstream",
             "tags",
             "product_versions",
             "product_streams",
@@ -552,16 +561,13 @@ class ProductSerializer(serializers.ModelSerializer):
             "errata",
             "builds",
             "channels",
-            "components",
-            "manifest",
-            "upstream",
             "meta_attr",
         ]
 
 
 class ProductVersionSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
-    components = ComponentListSerializer(many=True, read_only=True)
+    components = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -638,6 +644,12 @@ class ProductVersionSerializer(serializers.ModelSerializer):
                 )
         return p
 
+    def get_components(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_build_count(instance):
         return instance.builds.count()
@@ -652,6 +664,9 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "description",
             "coverage",
             "build_count",
+            "components",
+            "manifest",
+            "upstream",
             "tags",
             "products",
             "product_streams",
@@ -659,16 +674,13 @@ class ProductVersionSerializer(serializers.ModelSerializer):
             "errata",
             "builds",
             "channels",
-            "components",
-            "manifest",
-            "upstream",
             "meta_attr",
         ]
 
 
 class ProductStreamSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
-    components = ComponentListSerializer(many=True, read_only=True)
+    components = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -747,6 +759,12 @@ class ProductStreamSerializer(serializers.ModelSerializer):
                 )
         return p
 
+    def get_components(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_relations(instance):
         relations = list()
@@ -776,6 +794,9 @@ class ProductStreamSerializer(serializers.ModelSerializer):
             "description",
             "coverage",
             "build_count",
+            "components",
+            "manifest",
+            "upstream",
             "relations",
             "tags",
             "products",
@@ -784,16 +805,13 @@ class ProductStreamSerializer(serializers.ModelSerializer):
             "errata",
             "builds",
             "channels",
-            "components",
-            "manifest",
-            "upstream",
             "meta_attr",
         ]
 
 
 class ProductVariantSerializer(serializers.ModelSerializer):
     tags = TagSerializer(many=True, read_only=True)
-    components = ComponentListSerializer(many=True, read_only=True)
+    components = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
 
@@ -872,6 +890,12 @@ class ProductVariantSerializer(serializers.ModelSerializer):
                 )
         return p
 
+    def get_components(self, instance):
+        request = self.context.get("request")
+        if request and "HTTP_HOST" in request.META:
+            return f"{request.scheme}://{request.META['HTTP_HOST']}/api/{CORGI_API_VERSION}/components?ofuri={instance.ofuri}"  # noqa
+        return None
+
     @staticmethod
     def get_relations(instance):
         relations = list()
@@ -899,6 +923,9 @@ class ProductVariantSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "build_count",
+            "components",
+            "manifest",
+            "upstream",
             "tags",
             "relations",
             "products",
@@ -907,9 +934,6 @@ class ProductVariantSerializer(serializers.ModelSerializer):
             "errata",
             "builds",
             "channels",
-            "components",
-            "manifest",
-            "upstream",
             "meta_attr",
         ]
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1807,17 +1807,6 @@ components:
       - upstreams
       - uuid
       - version
-    ComponentList:
-      type: object
-      properties:
-        link:
-          type: string
-          readOnly: true
-        purl:
-          type: string
-          maxLength: 1024
-      required:
-      - link
     PaginatedAppStreamLifeCycleList:
       type: object
       properties:
@@ -2015,10 +2004,16 @@ components:
           type: string
         description:
           type: string
-        coverage:
+        build_count:
           type: string
           readOnly: true
-        build_count:
+        builds:
+          type: string
+          readOnly: true
+        components:
+          type: string
+          readOnly: true
+        upstreams:
           type: string
           readOnly: true
         tags:
@@ -2035,28 +2030,11 @@ components:
         product_variants:
           type: string
           readOnly: true
-        errata:
-          type: string
-          readOnly: true
-        builds:
-          type: string
-          readOnly: true
         channels:
           type: array
           items:
             type: string
             maxLength: 200
-        components:
-          type: array
-          items:
-            $ref: '#/components/schemas/ComponentList'
-          readOnly: true
-        manifest:
-          type: string
-          readOnly: true
-        upstream:
-          type: string
-          readOnly: true
         meta_attr:
           type: object
           additionalProperties: {}
@@ -2064,16 +2042,13 @@ components:
       - build_count
       - builds
       - components
-      - coverage
-      - errata
       - link
-      - manifest
       - name
       - product_streams
       - product_variants
       - product_versions
       - tags
-      - upstream
+      - upstreams
       - uuid
     ProductStream:
       type: object
@@ -2095,10 +2070,19 @@ components:
           maxLength: 1000
         description:
           type: string
-        coverage:
+        build_count:
           type: string
           readOnly: true
-        build_count:
+        builds:
+          type: string
+          readOnly: true
+        manifest:
+          type: string
+          readOnly: true
+        components:
+          type: string
+          readOnly: true
+        upstreams:
           type: string
           readOnly: true
         relations:
@@ -2118,28 +2102,11 @@ components:
         product_variants:
           type: string
           readOnly: true
-        errata:
-          type: string
-          readOnly: true
-        builds:
-          type: string
-          readOnly: true
         channels:
           type: array
           items:
             type: string
             maxLength: 200
-        components:
-          type: array
-          items:
-            $ref: '#/components/schemas/ComponentList'
-          readOnly: true
-        manifest:
-          type: string
-          readOnly: true
-        upstream:
-          type: string
-          readOnly: true
         meta_attr:
           type: object
           additionalProperties: {}
@@ -2147,8 +2114,6 @@ components:
       - build_count
       - builds
       - components
-      - coverage
-      - errata
       - link
       - manifest
       - name
@@ -2157,7 +2122,7 @@ components:
       - products
       - relations
       - tags
-      - upstream
+      - upstreams
       - uuid
     ProductVariant:
       type: object
@@ -2179,6 +2144,18 @@ components:
         build_count:
           type: string
           readOnly: true
+        builds:
+          type: string
+          readOnly: true
+        manifest:
+          type: string
+          readOnly: true
+        components:
+          type: string
+          readOnly: true
+        upstreams:
+          type: string
+          readOnly: true
         tags:
           type: array
           items:
@@ -2196,28 +2173,11 @@ components:
         product_streams:
           type: string
           readOnly: true
-        errata:
-          type: string
-          readOnly: true
-        builds:
-          type: string
-          readOnly: true
         channels:
           type: array
           items:
             type: string
             maxLength: 200
-        components:
-          type: array
-          items:
-            $ref: '#/components/schemas/ComponentList'
-          readOnly: true
-        manifest:
-          type: string
-          readOnly: true
-        upstream:
-          type: string
-          readOnly: true
         meta_attr:
           type: object
           additionalProperties: {}
@@ -2225,7 +2185,6 @@ components:
       - build_count
       - builds
       - components
-      - errata
       - link
       - manifest
       - name
@@ -2234,7 +2193,7 @@ components:
       - products
       - relations
       - tags
-      - upstream
+      - upstreams
       - uuid
     ProductVersion:
       type: object
@@ -2253,10 +2212,16 @@ components:
           type: string
         description:
           type: string
-        coverage:
+        build_count:
           type: string
           readOnly: true
-        build_count:
+        builds:
+          type: string
+          readOnly: true
+        components:
+          type: string
+          readOnly: true
+        upstreams:
           type: string
           readOnly: true
         tags:
@@ -2273,28 +2238,11 @@ components:
         product_variants:
           type: string
           readOnly: true
-        errata:
-          type: string
-          readOnly: true
-        builds:
-          type: string
-          readOnly: true
         channels:
           type: array
           items:
             type: string
             maxLength: 200
-        components:
-          type: array
-          items:
-            $ref: '#/components/schemas/ComponentList'
-          readOnly: true
-        manifest:
-          type: string
-          readOnly: true
-        upstream:
-          type: string
-          readOnly: true
         meta_attr:
           type: object
           additionalProperties: {}
@@ -2302,16 +2250,13 @@ components:
       - build_count
       - builds
       - components
-      - coverage
-      - errata
       - link
-      - manifest
       - name
       - product_streams
       - product_variants
       - products
       - tags
-      - upstream
+      - upstreams
       - uuid
     Relation:
       type: object


### PR DESCRIPTION
This commit replaces arrays of data with links as per PSDEVOPS-3853:

* manifest -> /api/v1/{product_streams|product_variants}/{uuid}/manifest
* components -> /api/v1/components?ofuri={}
* upstreams -> /api/v1/components?ofuri={}&type=UPSTREAM

which avoids having to return gigantic http response payloads.

While I was in the area I reordered attributes as well as exclude manifest links on Products and Product Versions (as they make no sense). Generally, deactivated anything that slows down processing of the response.

**Note** - there will be more work in REST API area to include/exclude data ... this is the minimal amount of work to ensure endpoints are usable.