### PR TITLE
Fix SCA SoftTimeLimitExceeded, and move it to slow queue to keep fast queue fast

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -224,7 +224,7 @@ CELERY_RESULT_BACKEND_MAX_RETRIES = 2
 CELERY_DEFAULT_RATE_LIMIT = "8/m"
 # Set a global 15-minute task timeout. Override this on individual tasks by decorating them with:
 # @app.task(soft_time_limit=<TIME_IN_SECONDS>)
-CELERY_TASK_SOFT_TIME_LIMIT = 900
+CELERY_TASK_SOFT_TIME_LIMIT = 3600
 
 CELERY_WORKER_CONCURRENCY = 1  # defaults to CPU core count, which breaks in OpenShift
 

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -8,7 +8,7 @@ from corgi.collectors.brew import Brew, BrewBuildTypeNotSupported
 from corgi.core.models import Component, ComponentNode, SoftwareBuild
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 from corgi.tasks.errata_tool import load_errata
-from corgi.tasks.sca import software_composition_analysis
+from corgi.tasks.sca import slow_software_composition_analysis
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True):
         [slow_fetch_brew_build.delay(build_id) for build_id in build["nested_builds"]]
 
     logger.info("Requesting software composition analysis for %s", build_id)
-    software_composition_analysis.delay(build_id)
+    slow_software_composition_analysis.delay(build_id)
 
     logger.info("Finished fetching brew build: %s", build_id)
 

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -55,7 +55,7 @@ def save_component(component: dict[str, Any], parent: ComponentNode):
 
 
 @app.task
-def software_composition_analysis(build_id: int):
+def slow_software_composition_analysis(build_id: int):
     logger.info("Started software composition analysis for %s", build_id)
     try:
         software_build = SoftwareBuild.objects.get(build_id=build_id)

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -587,7 +587,7 @@ def test_extract_image_components():
 
 
 @pytest.mark.vcr(match_on=["method", "scheme", "host", "port", "path", "body"])
-@patch("corgi.tasks.sca.software_composition_analysis.delay")
+@patch("corgi.tasks.sca.slow_software_composition_analysis.delay")
 def test_fetch_rpm_build(mock_sca):
     slow_fetch_brew_build(1705913)
     srpm = Component.objects.get(name="cockpit", type=Component.Type.SRPM)

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -11,7 +11,7 @@ from corgi.tasks.sca import (
     _download_lookaside_sources,
     _get_distgit_sources,
     _scan_remote_sources,
-    software_composition_analysis,
+    slow_software_composition_analysis,
 )
 from tests.factories import ComponentFactory, SoftwareBuildFactory
 
@@ -148,7 +148,7 @@ def test_download_lookaside_sources(
         assert downloaded_sources == []
 
 
-software_composition_analysis_test_data = [
+slow_software_composition_analysis_test_data = [
     # Dummy tar files are prefetch to
     # tests/data/rpms/cri-o/1e52fcdc84be253b5094b942c2fec23d7636d644.tar (with only sources)
     # tests/data/rpms/cri-o/cri-o-41c0779.tar.gz/sha516/<sha256>/cri-o-41c0779.tar.gz (empty file)
@@ -183,11 +183,11 @@ software_composition_analysis_test_data = [
 
 @pytest.mark.parametrize(
     "build_id,package_name,dist_git_source,syft_results,expected_purl",
-    software_composition_analysis_test_data,
+    slow_software_composition_analysis_test_data,
 )
 # mock the syft call to avoid having to have actual source code for the test
 @patch("subprocess.check_output")
-def test_software_composition_analysis(
+def test_slow_software_composition_analysis(
     mock_syft,
     build_id,
     package_name,
@@ -212,7 +212,7 @@ def test_software_composition_analysis(
     assert not Component.objects.filter(purl=expected_purl).exists()
     with open(syft_results, "r") as mock_scan_results:
         mock_syft.return_value = mock_scan_results.read()
-    software_composition_analysis(build_id)
+    slow_software_composition_analysis(build_id)
     assert Component.objects.filter(purl=expected_purl).exists()
     if package_name.endswith("-container"):
         root_component = Component.objects.get(


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs We've been seeing the SoftTimeLimitExceeded error a lot recently for the SCA task, so rather than letting it constantly fail, I've increased our Celery task timeout to 1 hour (to match other apps).

I've also moved the SCA task to the slow queue, so that other fast tasks can complete quickly and avoid being blocked. But ingest of new builds from Brew will still be slowed down by this change (potentially up to 4 times slower). Is this the right approach here, or do we need to reopen the "Corgi performance regression" ticket to figure out why save_component_taxonomy takes forever?

Note the SCA task slowness is also seen locally when running tests, and there was a recent regression which bumped the SCA test runtime from 2 minutes to 7 minutes. The slowest tests are:

405s calling test_sca.py::test_software_composition_analysis[1898406
23s calling test_sca.py::test_scan_remote_sources

47s calling test_brew_collector.py::test_fetch_container_build_components

40s calling test_products.py::test_products

15s calling test_errata_data.py::test_update_variant_repos
