### PR TITLE
CORGI-88: Fix MultipleObjectsReturned by using tree_id as extra lookup kwarg

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -32,6 +32,11 @@ class ProductNode(MPTTModel, TimeStampedModel):
 
     class MPTTMeta:
         level_attr = "level"
+        # Make get_or_create with object_id, tree_id kwargs atomic so it doesn't insert duplicates
+        constraints = [
+            models.UniqueConstraint(name="unique_productnode", fields=("object_id", "tree_id")),
+        ]
+        indexes = [models.Index(fields=("object_id", "tree_id"))]
 
     # Tree-traversal methods for product-related models below.
     #
@@ -46,6 +51,7 @@ class ProductNode(MPTTModel, TimeStampedModel):
     #
     # - Each method assumes that an object model will always link to a single ProductNode (thus
     #   the use of `pnodes.first()`).
+    #   TODO: Need to revisit, we have ProductVariants which are linked to two separate streams
     #
     # - The `values_list()` query relies on the GenericRelation of each model's pnodes
     #   attribute's related query name.

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -80,6 +80,7 @@ def update_products() -> None:
                 )
                 product_version_node, _ = ProductNode.objects.get_or_create(
                     object_id=product_version.pk,
+                    tree_id=product_node.tree_id,
                     defaults={
                         "parent": product_node,
                         "obj": product_version,
@@ -103,6 +104,7 @@ def update_products() -> None:
                     )
                     product_stream_node, _ = ProductNode.objects.get_or_create(
                         object_id=product_stream.pk,
+                        tree_id=product_version_node.tree_id,
                         defaults={
                             "parent": product_version_node,
                             "obj": product_stream,
@@ -159,8 +161,10 @@ def update_products() -> None:
                                             }
                                         },
                                     )
+                                    # TODO: Why are there two places that create a variant node?
                                     ProductNode.objects.get_or_create(
                                         object_id=product_variant.pk,
+                                        tree_id=product_stream_node.tree_id,
                                         defaults={
                                             "parent": product_stream_node,
                                             "obj": product_variant,
@@ -191,6 +195,7 @@ def update_products() -> None:
                                 )
                                 ProductNode.objects.get_or_create(
                                     object_id=product_variant.pk,
+                                    tree_id=product_stream_node.tree_id,
                                     defaults={
                                         "parent": product_stream_node,
                                         "obj": product_variant,


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This is definitely not ready to merge, but I wanted to use the code here as a starting point for discussion. After some investigation, it looks like ProductVariants can be linked to multiple ProductStreams in different trees. See CORGI-25 for notes and details.

Given that's the case, I added a tree_id= kwarg to all ProductNode.objects.get_or_create() lookups, which should prevent the MultipleObjectsReturned error we've been seeing. AKA we use the tree_id of the parent node to choose which tree to return objects from. But there are other possible bugs, since ProductModel's saveProductTaxonomy uses helper methods from the ProductNode class.

Those helper methods assume each ProductModel instance has exactly one linked ProductNode, and use product_model_instance.linked_product_nodes.first() as a result. But this isn't true for (at least) a ProductVariant, which could have multiple ProductNodes, one for each ProductStream it's linked to / tree it's a part of. So whenever we call saveProductTaxonomy() for some ProductVariant, we're probably saving the taxonomy for only one tree / ProductStream, and silently ignoring the other.

I'm not sure what the right fix is here. Should we just loop over all linked nodes in every tree, and return the names of each linked object to be saved? I'm afraid that will mess up our tree, since it won't look like a tree anymore (a node will have multiple parents). Thoughts appreciated.