### PR TITLE
remove deploy stage step from gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,6 @@
 stages:
   - lint
   - test
-  - deploy-stage
-
-include:
-  - project: 'product-security/dev/component-registry-ops'
-    ref: main
-    file: '/templates/gitlab/ansible-run.yml'
 
 before_script:
     - export LANG=en_US.UTF-8
@@ -33,11 +27,6 @@ before_script:
     - export CORGI_PRODSEC_DASHBOARD_URL
     - export PIP_INDEX_URL
     - export ROOT_CA_URL
-
-deploy-stage:
-  stage: deploy-stage
-  extends:
-    - .ansible-run
 
 test:
   stage: test


### PR DESCRIPTION
This step is failing on main branch with:

```
$ cd /etc/pki/ca-trust/source/anchors/ && curl -O "${ROOT_CA_URL}"; cd -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file RH-IT-Root-CA.crt: Permission denied
100  1517  100  1517    0     0  15440      0 --:--:-- --:--:-- --:--:-- 15323
curl: (23) Failure writing output to destination
```
 See jobs/1138628