### PR TITLE
Fix detect-secrets slowness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,9 @@ test:
     - dnf --disableplugin=subscription-manager --nodocs -y install python39 python39-devel gcc krb5-devel postgresql-devel
     - python3.9 -m pip install tox
     - tox -e corgi -- --record-mode=none --cov-report term --junitxml=junit.xml  # Do not create any VCR cassettes in CI
+  except:
+    refs:
+      - schedules
   # report coverage lines like 'TOTAL    2962    882    70%'
   coverage: '/TOTAL(?:\s+\d+\s+\d+\s+)(\d+)%/'
   artifacts:
@@ -78,51 +81,78 @@ test-migrations:
     - dnf --disableplugin=subscription-manager --nodocs -y install python39 python39-devel gcc krb5-devel postgresql-devel
     - python3.9 -m pip install tox
     - tox -e corgi-migrations
+  except:
+    refs:
+      - schedules
 
 mypy:
   stage: test
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e mypy
+  except:
+    refs:
+      - schedules
 
 schema:
   stage: test
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e schema
+  except:
+    refs:
+      - schedules
 
 flake8:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e flake8
+  except:
+    refs:
+      - schedules
 
 black:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e black
+  except:
+    refs:
+      - schedules
 
 isort:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e isort
+  except:
+    refs:
+      - schedules
 
 bandit:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e bandit
+  except:
+    refs:
+      - schedules
 
 radon:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e radon
+  except:
+    refs:
+      - schedules
 
 secrets:
   stage: lint
   image: $PYTHON_TOX_IMAGE_LATEST
   script:
     - tox -e secrets
+  only:
+    refs:
+      - schedules

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bandit,black,flake8,isort,mypy,radon,schema,corgi,corgi-migrations
+envlist = bandit,black,flake8,isort,mypy,radon,schema,secrets,corgi,corgi-migrations
 skipsdist = true
 
 [testenv]
@@ -98,4 +98,8 @@ commands = python3 manage.py spectacular --file openapi.yml
 [testenv:secrets]
 deps = -r requirements/lint.txt
 allowlist_externals = bash
-commands = /usr/bin/bash -c 'detect-secrets-hook --baseline .secrets.baseline $(git ls-files)'
+# Check only files in the current branch which have changed, compared to the main branch, for secrets
+# Scan all files for secrets if the first form fails, since Gitlab CI uses shallow clone and does not have a "main" ref
+commands = /usr/bin/bash -c 'detect-secrets-hook --baseline .secrets.baseline $(\
+    git diff --name-only "origin/main..HEAD" || \
+    git ls-files)'


### PR DESCRIPTION
@mprpic Looks like your recent MR to remove pip-audit also removed the daily scheduled detect-secrets CI job, as well as the "only: refs: schedules" logic for detect-secrets in .gitlab-ci.yml. That "only:" block made it run only once a day, instead of on every PR.

This change should make it faster (only scan changed files instead of the whole tree), or I could just add back the "only:" block and the daily detect-secrets CI job to keep PRs fast.