### PR TITLE
load only latest builds in a tag by default

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -705,9 +705,11 @@ class Brew:
         component["build_meta"] = {"build_info": build, "type_info": build_type_info}
         return component
 
-    def get_builds_with_tag(self, brew_tag: str, inherit: bool = False) -> list[int]:
+    def get_builds_with_tag(
+        self, brew_tag: str, inherit: bool = False, latest: bool = True
+    ) -> list[int]:
         try:
-            builds = self.koji_session.listTagged(brew_tag, inherit=inherit)
+            builds = self.koji_session.listTagged(brew_tag, inherit=inherit, latest=latest)
             return [b["build_id"] for b in builds]
         except koji.GenericError as exc:
             logger.warning("Couldn't find brew builds with tag %s: %s", brew_tag, exc)

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -312,7 +312,8 @@ def load_brew_tags() -> None:
     for ps in ProductStream.objects.all():
         brew = Brew()
         for brew_tag, inherit in ps.brew_tags.items():
-            builds = brew.get_builds_with_tag(brew_tag, inherit)
+            # Always load all builds in tag when saving relations
+            builds = brew.get_builds_with_tag(brew_tag, inherit=inherit, latest=False)
             no_of_created = 0
             for build in builds:
                 _, created = ProductComponentRelation.objects.get_or_create(

--- a/corgi/tasks/management/commands/loadbrewdata.py
+++ b/corgi/tasks/management/commands/loadbrewdata.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
             "-s",
             "--stream",
             dest="stream",
-            help="Fetch builds by tag from product stream",
+            help="Fetch latest builds by tag from product stream",
         )
         parser.add_argument(
             "-i",


### PR DESCRIPTION
This makes ingestion work similar to deptopia. Latest will move as time goes by, so we'll still need a search function for latest.