### PR TITLE
increase sca task timeout to 30m

### DIFF
--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -53,7 +53,7 @@ def save_component(component: dict[str, Any], parent: ComponentNode):
     return created
 
 
-@app.task
+@app.task(soft_time_limit=1800)
 def slow_software_composition_analysis(build_id: int):
     logger.info("Started software composition analysis for %s", build_id)
     software_build = SoftwareBuild.objects.get(build_id=build_id)


### PR DESCRIPTION
After a local run of `loadbrewdata -s rhacm-2.4.z` I got 81 failed tasks, 80 of which where soft time outs from SCA task. That is out of 628 SCA tasks. That's roughly 13% of SCA tasks timing out.

