### PR TITLE
CORGI-152 load errata loop

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -13,7 +13,7 @@ from corgi.core.models import (
     SoftwareBuild,
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
-from corgi.tasks.errata_tool import slow_load_errata
+from corgi.tasks.errata_tool import load_errata
 from corgi.tasks.sca import slow_software_composition_analysis
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True):
 
     # Once we have the full component tree loaded
     softwarebuild.save_component_taxonomy()
-    # We don't call save_product_taxonomy by default to allow async call of slow_load_errata task
+    # We don't call save_product_taxonomy by default to allow async call of load_errata task
     # See CORGI-21
     if save_product:
         softwarebuild.save_product_taxonomy()
@@ -73,10 +73,10 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True):
         logger.info("no errata tags")
     else:
         if isinstance(build_meta["errata_tags"], str):
-            slow_load_errata.delay(build_meta["errata_tags"])
+            load_errata.delay(build_meta["errata_tags"])
         else:
             for e in build_meta["errata_tags"]:
-                slow_load_errata.delay(e)
+                load_errata.delay(e)
 
     if "nested_builds" in build:
         logger.info("Fetching brew builds for %s", build["nested_builds"])

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -65,9 +65,9 @@ def _get_redis():
     return app.broker_connection().default_channel.client
 
 
-def set_task_complete(key: str):
+def set_task_complete(key: str, is_complete: bool = True):
     conn = _get_redis()
-    conn.set(key, int(True))
+    conn.set(key, int(is_complete))
 
 
 def get_task_complete(key: str) -> bool:

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -29,10 +29,11 @@ def load_et_products() -> None:
     autoretry_for=RETRYABLE_ERRORS,
     retry_kwargs=RETRY_KWARGS,
 )
-def slow_load_errata(erratum_name):
-    if get_task_complete(f"slow_load_errata:{erratum_name}"):
-        logger.info("Already completed slow_load_errata for %s", erratum_name)
+def load_errata(erratum_name):
+    if get_task_complete(f"load_errata:{erratum_name}"):
+        logger.info("Already completed load_errata for %s", erratum_name)
         return
+
     et = ErrataTool()
     if not erratum_name.isdigit():
         erratum_id = et.normalize_erratum_id(erratum_name)
@@ -87,7 +88,7 @@ def slow_load_errata(erratum_name):
             # once all build's components are ingested we must save product taxonomy
             sb = SoftwareBuild.objects.get(build_id=b)
             sb.save_product_taxonomy()
-        set_task_complete(f"slow_load_errata:{erratum_name}")
+        set_task_complete(f"load_errata:{erratum_name}")
 
     # Check if we are only part way through loading the errata
     if no_of_processed_builds < len(relation_int_build_ids):

--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -33,8 +33,10 @@ class Command(BaseCommand):
         if options["errata_ids"]:
             errata_ids = options["errata_ids"]
             for erratum_id in errata_ids:
-                self.stdout.write(self.style.SUCCESS(f"Loading Errata {erratum_id}"))
-                load_errata(erratum_id)
+                self.stdout.write(self.style.SUCCESS(f"Force loading Errata {erratum_id}"))
+                # If we are calling this command directly always make sure
+                # we process the errata, even if it's been fully processed before.
+                load_errata(erratum_id, force_process=True)
         elif options["repos"]:
             update_variant_repos()
         else:

--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -2,7 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from corgi.tasks.errata_tool import slow_load_errata, update_variant_repos
+from corgi.tasks.errata_tool import load_errata, update_variant_repos
 
 
 class Command(BaseCommand):
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             errata_ids = options["errata_ids"]
             for erratum_id in errata_ids:
                 self.stdout.write(self.style.SUCCESS(f"Loading Errata {erratum_id}"))
-                slow_load_errata(erratum_id)
+                load_errata(erratum_id)
         elif options["repos"]:
             update_variant_repos()
         else:

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -652,6 +652,6 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_send):
         any_order=True,
     )
 
-    # Verify that slow_load_errata didn't try to fetch the only build in this errata again
+    # Verify that load_errata didn't try to fetch the only build in this errata again
     # TODO: Below should be a method call(), but changing it makes tests fail
     mock_send.assert_not_called

--- a/tests/test_errata_data.py
+++ b/tests/test_errata_data.py
@@ -9,7 +9,7 @@ from corgi.core.models import (
     ProductNode,
     ProductVariant,
 )
-from corgi.tasks.errata_tool import slow_load_errata, update_variant_repos
+from corgi.tasks.errata_tool import load_errata, update_variant_repos
 
 from .factories import ProductVariantFactory
 
@@ -188,8 +188,10 @@ def test_save_product_component_for_errata(
     )
     requests_mock.get(build_list_url, text=build_list)
     mock_get_complete.return_value = False
-    slow_load_errata(erratum_id)
+
+    load_errata(erratum_id)
+
     pcr = ProductComponentRelation.objects.filter(external_system_id=erratum_id)
     assert len(pcr) == no_of_objs
     assert mock_send.call_count == no_of_objs
-    assert mock_get_complete.called_with(f"slow_load_errata:{erratum_id}")
+    assert mock_get_complete.called_with(f"load_errata:{erratum_id}")


### PR DESCRIPTION
Fixes CORGI-152 by setting key in redis slow_load_errata is fully complete. This prevents an errata with many builds having it's save_product_taxonomy called for every build in that errata.