### PR TITLE
CORGI-114: perf improvements saving product taxonomy I

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -222,7 +222,7 @@ class SoftwareBuild(TimeStampedModel):
         for component in Component.objects.filter(software_build__build_id=self.build_id):
             # This is needed for container image builds which pull in components not
             # built at Red Hat, and therefore not assigned a build_id
-            for d in component.cnodes.all().get_descendants(include_self=True):
+            for d in component.cnodes.get_queryset().get_descendants(include_self=True):
                 if not d.obj:
                     continue
                 components.add(d.obj)
@@ -919,7 +919,7 @@ class Component(TimeStampedModel):
         # this uses the mptt get_root function, not the get_root property defined on Component
         sources = set()
 
-        for cnode in self.cnodes.all():
+        for cnode in self.cnodes.get_queryset():
             if cnode.is_root_node():
                 sources.add(cnode.obj.purl)
             else:

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @app.task(autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
 def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_process: bool = False):
     logger.info("Fetch brew build called with build id: %s", build_id)
-    if not force_process and SoftwareBuild.objects.filter(build_id=build_id).count() > 0:
+    if not force_process and SoftwareBuild.objects.filter(build_id=build_id).exists():
         logger.info("Already processed build_id %s", build_id)
         return
     else:

--- a/corgi/tasks/management/commands/loadbrewdata.py
+++ b/corgi/tasks/management/commands/loadbrewdata.py
@@ -31,6 +31,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Schedule build for ingestion inline (not in celery)",
         )
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            help="force ingestion, even if it exists",
+        )
 
     def handle(self, *args, **options) -> None:
         if options["build_ids"]:
@@ -53,6 +59,10 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR("No build IDs or Product Stream specified..."))
             sys.exit(1)
 
+        force_process = False
+        if options["force"]:
+            force_process = True
+
         self.stdout.write(
             self.style.SUCCESS(
                 f"Fetching component data for builds: {', '.join(map(str, build_ids))}"
@@ -61,6 +71,6 @@ class Command(BaseCommand):
 
         for build_id in build_ids:
             if options["inline"]:
-                slow_fetch_brew_build(build_id)
+                slow_fetch_brew_build(build_id, force_process=force_process)
             else:
-                slow_fetch_brew_build.delay(build_id)
+                slow_fetch_brew_build.delay(build_id, force_process=force_process)


### PR DESCRIPTION
This first PR related to CORGI-114 ensures 

* the list of components save_product_taxonomy works on is distinct
* component get_sources() returns correct information now, as well as avoid multiple objects returned
* added -f (force process) flag to loadbrewdata to force reprocessing of existing softwarebuilds


Note - there will be a couple more PRs related to CORGI-114