### PR TITLE
Fix memory limits and beat-init tasks

### DIFF
--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -48,7 +48,7 @@ def setup_periodic_tasks(sender, **kwargs):
     # task at all: https://github.com/celery/django-celery-beat/issues/221
     upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
     upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
-    upsert_cron_task("rhel_compose", "load_composes", hour=2, minute=0)
+    upsert_cron_task("rhel_compose", "save_composes", hour=2, minute=0)
     upsert_cron_task("monitoring", "email_failed_tasks", hour=10, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
 
   corgi-db:
     container_name: corgi-db
+    deploy:
+      resources:
+        limits:
+          memory: 2G  # Keep in sync with OpenShift mem limits to catch OOM problems
     # Keep this in sync with openshift/playbooks/postgres.yml
     image: registry.redhat.io/rhel8/postgresql-13:1
     hostname: corgi-db
@@ -24,6 +28,10 @@ services:
 
   redis:
     container_name: redis
+    deploy:
+      resources:
+        limits:
+          memory: 256M  # Keep in sync with OpenShift mem limits to catch OOM problems
     hostname: redis
     # Keep this in sync with openshift/playbooks/redis.yml
     image: "registry.redhat.io/rhel8/redis-6:1"


### PR DESCRIPTION
There's one failure in monitoring emails about a task that isn't registered. Quick fix here is just to make the name in beat-init code match the new task name in the Python module where the task is defined.