### PR TITLE
Fix wait_for_migrations.sh succeeds if python3 manage.py showmigrations fails

### DIFF
--- a/wait_for_migrations.sh
+++ b/wait_for_migrations.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 while true; do
-    python3 manage.py showmigrations | grep '\[ \]' > /dev/null
-    if [ $? -eq 1 ]; then
+    python3 manage.py showmigrations | grep -v '\[ \]' > /dev/null
+    if [ $? -eq 0 ]; then
         # No unapplied migrations found
         exit 0
     fi


### PR DESCRIPTION
Quick fix for errors seen during a deployment today. "python3 manage.py showmigrations" will fail if the postgres pod hasn't deployed by the time the "wait_for_migrations.sh" script runs, as one example.