### PR TITLE
CORGI-168: lower pg shared_buffer setting

### DIFF
--- a/etc/pg/custom_pg.conf
+++ b/etc/pg/custom_pg.conf
@@ -2,7 +2,7 @@
 # ssl_ca_file = '/root.crt'
 # ssl_cert_file = '/pg/local-server.crt'
 # ssl_key_file = '/pg/local-server.key'
-shared_buffers = 64MB			# min 128kB
+shared_buffers = 1MB			# min 128kB
 					# (change requires restart)
 synchronous_commit = off		# synchronization level;
 					# off, local, remote_write, remote_apply, or on


### PR DESCRIPTION
Addresses clash with defaults in stage/prod env ... no need to adjust there as we will eventually migrate away from our own pg pod.

Note - have changed live env settings via psql as well and communicated to @jasinner this change needs to surface in his ops PR