### PR TITLE
Revert get_source() to use cnodes

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -931,14 +931,13 @@ class Component(TimeStampedModel):
         return list(provides)
 
     def get_source(self) -> list:
-        """return all root nodes"""
-        sources = set()
-        sources.update(
-            ComponentNode.objects.get_queryset()  # type: ignore
-            .filter(purl=self.purl)
+        """return all root components across different component trees"""
+        sources = (
+            self.cnodes.get_queryset()
             .get_ancestors(include_self=True)
-            .filter(level=0)
+            .filter(parent=None)
             .values_list("purl", flat=True)
+            .distinct()
         )
         return list(sources)
 


### PR DESCRIPTION
after discussion with @jasinner reverting back to variation of get_ancestor approach.

Here is a sample listing of process times for get_source() ... before we were getting ~1s per component processing time ... now we have ~.2s which seems reasonable. Note all these processing times will get faster once we are migrate to managed db service.

```
[29/Aug/2022:12:00:02 +0000] [corgi.core.models:936] DEBUG: pkg:container/redhat/ose-azure-disk-csi-driver-container@v4.9.0?arch=x86_64&digest=sha256:02776b9266e75a31c2cc4b3861c115b52c09b686039a841b9b2058402b3fd95b
[29/Aug/2022:12:00:02 +0000] [corgi.core.models:937] DEBUG: # ancestors #1
[29/Aug/2022:12:00:02 +0000] [corgi.core.models:941] DEBUG: #1 - process time:0.002271413803100586
[29/Aug/2022:12:00:02 +0000] [corgi.core.models:936] DEBUG: pkg:rpm/redhat/libselinux@2.9-5.el8?arch=x86_64
[29/Aug/2022:12:00:02 +0000] [corgi.core.models:937] DEBUG: # ancestors #493
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:941] DEBUG: #493 - process time:0.24627280235290527
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:936] DEBUG: pkg:rpm/redhat/glibc-minimal-langpack@2.28-151.el8?arch=x86_64
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:937] DEBUG: # ancestors #381
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:941] DEBUG: #381 - process time:0.17825555801391602
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:936] DEBUG: pkg:rpm/redhat/glibc@2.28-151.el8?arch=x86_64
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:937] DEBUG: # ancestors #381
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:941] DEBUG: #381 - process time:0.2111067771911621
[29/Aug/2022:12:00:03 +0000] [corgi.core.models:936] DEBUG: pkg:rpm/redhat/libsepol@2.9-2.el8?arch=x86_64
[29/Aug/2022:12:00:04 +0000] [corgi.core.models:937] DEBUG: # ancestors #381
[29/Aug/2022:12:00:04 +0000] [corgi.core.models:941] DEBUG: #381 - process time:0.18291783332824707
[29/Aug/2022:12:00:04 +0000] [corgi.core.models:936] DEBUG: pkg:rpm/redhat/libgpg-error@1.31-1.el8?arch=x86_64
[29/Aug/2022:12:00:04 +0000] [corgi.core.models:937] DEBUG: # ancestors #495
[29/Aug/2022:12:00:04 +0000] [corgi.core.models:941] DEBUG: #495 - process time:0.26198601722717285
```



