### PR TITLE
CORGI-183: Disable saving comp tax

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -182,7 +182,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {"handlers": ["console"], "level": "WARNING"},
-        "corgi": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
+        "corgi": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }
 

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -187,15 +187,15 @@ class ComponentSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_provides(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.provides)
+        return get_component_data_list(instance.get_provides())
 
     @staticmethod
     def get_sources(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.sources)
+        return get_component_data_list(instance.get_source())
 
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.upstreams)
+        return get_component_data_list(instance.get_upstreams())
 
     class Meta:
         model = Component
@@ -271,15 +271,15 @@ class ComponentDetailSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_provides(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.provides)
+        return get_component_data_list(instance.get_provides())
 
     @staticmethod
     def get_sources(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.sources)
+        return get_component_data_list(instance.get_source())
 
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.upstreams)
+        return get_component_data_list(instance.get_upstreams())
 
     class Meta:
         model = Component

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -235,7 +235,9 @@ class SoftwareBuild(TimeStampedModel):
         return None
 
     def save_component_taxonomy(self):
-        """it is only possible to update ('materialize') component taxonomy when all
+        """Note: this function is no longer invoked and may be removed in the future.
+
+        it is only possible to update ('materialize') component taxonomy when all
         components (from a build) have loaded"""
         for component in Component.objects.filter(software_build__build_id=self.build_id):
             for cnode in component.cnodes.get_queryset():

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -61,8 +61,6 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
     for c in build.get("components", []):
         save_component(c, root_node, softwarebuild)
 
-    # Once we have the full component tree loaded
-    softwarebuild.save_component_taxonomy()
     # We don't call save_product_taxonomy by default to allow async call of slow_load_errata task
     # See CORGI-21
     if save_product:
@@ -80,8 +78,8 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
                 slow_load_errata.delay(e)
 
     build_ids = build.get("nested_builds", ())
-    logger.info("Fetching brew builds for %s", build_ids)
     for b_id in build_ids:
+        logger.info("Requesting fetch of nested build: %s", b_id)
         slow_fetch_brew_build.delay(b_id)
 
     logger.info("Requesting software composition analysis for %s", build_id)

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -90,7 +90,6 @@ def slow_software_composition_analysis(build_id: int):
 
     no_of_new_components = _scan_files(root_node, distgit_sources)
     if no_of_new_components > 0:
-        software_build.save_component_taxonomy()
         software_build.save_product_taxonomy()
 
     # clean up source code so that we don't have to deal with reuse and an ever growing disk

--- a/scripts/reconciliation.py
+++ b/scripts/reconciliation.py
@@ -70,6 +70,7 @@ for stream_ofuri, deptopia_id in stream_corpus:
     success = []
     failure = []
     different = []
+    cnt = 0
 
     for deptopia_build in reversed(deptopia_builds["builds"]):
         component_type = None
@@ -105,7 +106,11 @@ for stream_ofuri, deptopia_id in stream_corpus:
                     "FAILURE: %s", deptopia_build["nvr"] + "," + deptopia_build["build_type"]
                 )
                 failure.append(deptopia_build["nvr"])
+        cnt += 1
 
-    logger.info(f"failures:{failure}")
-    logger.info(f"different:{different}")
+    logger.info(f"# success:{len(success)}")
+    logger.info(f"# failures:{len(failure)}")
+    logger.info(f"# different:{len(different)}")
+    logger.info(f"# total:{cnt}")
+    logger.info(f"# coverage:{len(success)/cnt}")
     logger.info(f"reconciliation: done product_stream: {stream_ofuri}.")

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -281,5 +281,5 @@ def test_slow_software_composition_analysis(
         )
     else:
         root_component = Component.objects.get(type=Component.Type.SRPM, software_build=sb)
-    assert expected_purl in root_component.provides
+    assert expected_purl in root_component.get_provides()
     mock_save_prod_tax.assert_called_once()


### PR DESCRIPTION
We decided to disable persisting component taxonomy information at ingestion time and dynamically generate when the REST API is called for any specific component. This has a positive impact on ingestion performance though I have taken a minimal approach (eg. we can consider ripping out deprecated function and removing from model related attributes at some future point).

Also tweaked reconciliation script (used to compare components against deptopia).
