### PR TITLE
Speculative: Coverage command task

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -187,15 +187,15 @@ class ComponentSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_provides(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.provides)
+        return get_component_data_list(instance.get_provides())
 
     @staticmethod
     def get_sources(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.sources)
+        return get_component_data_list(instance.get_source())
 
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.upstreams)
+        return get_component_data_list(instance.get_upstreams())
 
     class Meta:
         model = Component
@@ -271,15 +271,15 @@ class ComponentDetailSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_provides(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.provides)
+        return get_component_data_list(instance.get_provides())
 
     @staticmethod
     def get_sources(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.sources)
+        return get_component_data_list(instance.get_source())
 
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
-        return get_component_data_list(instance.upstreams)
+        return get_component_data_list(instance.get_upstreams())
 
     class Meta:
         model = Component

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -235,7 +235,9 @@ class SoftwareBuild(TimeStampedModel):
         return None
 
     def save_component_taxonomy(self):
-        """it is only possible to update ('materialize') component taxonomy when all
+        """Note: this function is no longer invoked and may be removed in the future.
+
+        it is only possible to update ('materialize') component taxonomy when all
         components (from a build) have loaded"""
         for component in Component.objects.filter(software_build__build_id=self.build_id):
             for cnode in component.cnodes.get_queryset():

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -61,8 +61,6 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
     for c in build.get("components", []):
         save_component(c, root_node, softwarebuild)
 
-    # Once we have the full component tree loaded
-    softwarebuild.save_component_taxonomy()
     # We don't call save_product_taxonomy by default to allow async call of slow_load_errata task
     # See CORGI-21
     if save_product:

--- a/corgi/tasks/management/commands/coveragereport.py
+++ b/corgi/tasks/management/commands/coveragereport.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from corgi.core.models import Component, ProductStream
+
+
+class Command(BaseCommand):
+
+    help = "Generate coverage report."
+
+    def handle(self, *args, **options):
+        self.stdout.write("ofuri, #builds, #components")
+        self.stdout.write("---------------------------------------")
+        for ps in ProductStream.objects.all():
+            if ps.builds.count() > 0:
+                component_count = Component.objects.filter(
+                    product_streams__icontains=ps.ofuri
+                ).count()
+                self.stdout.write(f"{ps.ofuri}, {ps.builds.count()}, {component_count}")

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -90,7 +90,6 @@ def slow_software_composition_analysis(build_id: int):
 
     no_of_new_components = _scan_files(root_node, distgit_sources)
     if no_of_new_components > 0:
-        software_build.save_component_taxonomy()
         software_build.save_product_taxonomy()
 
     # clean up source code so that we don't have to deal with reuse and an ever growing disk

--- a/scripts/reconciliation.py
+++ b/scripts/reconciliation.py
@@ -70,6 +70,7 @@ for stream_ofuri, deptopia_id in stream_corpus:
     success = []
     failure = []
     different = []
+    cnt = 0
 
     for deptopia_build in reversed(deptopia_builds["builds"]):
         component_type = None
@@ -105,7 +106,11 @@ for stream_ofuri, deptopia_id in stream_corpus:
                     "FAILURE: %s", deptopia_build["nvr"] + "," + deptopia_build["build_type"]
                 )
                 failure.append(deptopia_build["nvr"])
+        cnt += 1
 
-    logger.info(f"failures:{failure}")
-    logger.info(f"different:{different}")
+    logger.info(f"# success:{len(success)}")
+    logger.info(f"# failures:{len(failure)}")
+    logger.info(f"# different:{len(different)}")
+    logger.info(f"# total:{cnt}")
+    logger.info(f"# coverage:{len(success)/cnt}")
     logger.info(f"reconciliation: done product_stream: {stream_ofuri}.")

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -281,5 +281,5 @@ def test_slow_software_composition_analysis(
         )
     else:
         root_component = Component.objects.get(type=Component.Type.SRPM, software_build=sb)
-    assert expected_purl in root_component.provides
+    assert expected_purl in root_component.get_provides()
     mock_save_prod_tax.assert_called_once()


### PR DESCRIPTION
As part of simplifying REST API we can move coverage report into a command task.

This is the simplest version presented for discussion.

Outputs the following:

```
> ./manage.py coveragereport                                 

ofuri, #builds, #components
---------------------------------------
o:redhat:ansible_automation_platform:1.2, 11, 591
o:redhat:ansible_automation_platform:2.0, 155, 879
o:redhat:ansible_automation_platform:2.1, 160, 1441
o:redhat:ansible_automation_platform:2.2, 379, 2152
o:redhat:ceph-2-default:, 51, 783
o:redhat:ceph:3, 7, 668
o:redhat:cfme:5.11, 57, 314
o:redhat:cnv:2.4, 3, 11
o:redhat:fdp-el:7, 13, 239
o:redhat:fdp-el8-ovs:, 1, 36
o:redhat:jws:3.1, 9, 544
o:redhat:ocp-tools:4.8, 1, 6
o:redhat:openstack:13, 969, 4511
o:redhat:openstack:16.1, 927, 5948
o:redhat:openstack:16.2, 543, 3653
o:redhat:rhel:7.3.z, 100, 0
o:redhat:rhel:7.4.z, 100, 0
o:redhat:rhel:7.6.z, 54, 0
o:redhat:rhel:7.7.z, 43, 0
o:redhat:rhel:8.2.0.z, 1, 57
o:redhat:rhel:8.4.0.z, 21, 4
o:redhat:rhel:8.5.0.z, 4, 0
o:redhat:rhel:8.6.0.z, 23, 5
o:redhat:rhel-br:8.4.0.z, 6, 2932
o:redhat:rhel-br:8.5.0.z, 2, 2520
o:redhat:rhel-br:8.6.0.z, 8, 2650
o:redhat:rhev-m:4.3.z, 224, 3307
o:redhat:rhev-m:4.4.z, 206, 4573
o:redhat:rhn_satellite:6.7, 1245, 11827
o:redhat:rhn_satellite:6.9, 1, 10364
o:redhat:rhui:3.0, 2, 24
o:redhat:stf:1.2, 18, 144
o:redhat:stf:1.3, 15, 69
```
