### PR TITLE
CORGI-156: Handle sourceless builds

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -47,12 +47,12 @@ class Brew:
     MAVEN_BUILD_TYPE = "maven"
     WIN_BUILD_TYPE = "win"
     MODULE_BUILD_TYPE = "module"
+
+    # A subset of build types that we are able to analyze right now, others from the listing
+    # above will be added once support for them is added.
     SUPPORTED_BUILD_TYPES = (
         CONTAINER_BUILD_TYPE,
         RPM_BUILD_TYPE,
-        # These builds fail because we don't support Maven (yet?)
-        # MAVEN_BUILD_TYPE,
-        WIN_BUILD_TYPE,
         MODULE_BUILD_TYPE,
     )
 
@@ -701,14 +701,10 @@ class Brew:
             component = self.get_container_build_data(build_id, build)
         elif build_type == self.RPM_BUILD_TYPE:
             component = self.get_rpm_build_data(build_id)
-        elif build_type == self.MAVEN_BUILD_TYPE:
-            component = self.get_maven_build_data(build, build_type_info)
         elif build_type == self.MODULE_BUILD_TYPE:
             component = self.get_module_build_data(build)
-        elif build_type == self.WIN_BUILD_TYPE:
-            component = {}
         else:
-            component = {}
+            return {}
 
         component["build_meta"] = {"build_info": build, "type_info": build_type_info}
         return component

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -687,7 +687,8 @@ class Brew:
             if build["cg_name"] != "atomic-reactor":
                 # Container images are built in OSBS, which uses atomic-reactor to build them.
                 raise BrewBuildTypeNotSupported(
-                    f"Image build {build_id} is not supported: {build['cg_name']} content generator used"
+                    f"Image build {build_id} is not supported: "
+                    f"{build['cg_name']} content generator used"
                 )
         build["type"] = build_type
 
@@ -702,6 +703,10 @@ class Brew:
                 # Some older builds do not specify source URLs; the below date was chosen based
                 # on some initial analysis of source-less builds in Brew.
                 if datetime.fromtimestamp(build["completion_ts"]) < datetime(2015, 1, 1):
+                    logger.error(
+                        f"Build {build_id} has no associated source URL but is too old "
+                        f"to process; returning an empty component."
+                    )
                     return {}
                 else:
                     raise exc
@@ -724,7 +729,9 @@ class Brew:
         elif build_type == self.MODULE_BUILD_TYPE:
             component = self.get_module_build_data(build)
         else:
-            return {}
+            raise BrewBuildTypeNotSupported(
+                f"Build {build_id} of type {build_type} is not supported"
+            )
 
         component["build_meta"] = {"build_info": build, "type_info": build_type_info}
         return component

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -32,6 +32,10 @@ class BrewBuildSourceNotFound(Exception):
     pass
 
 
+class BrewBuildNotFound(Exception):
+    pass
+
+
 class Brew:
     """Interface to the Brew API for build data collection.
 
@@ -657,7 +661,7 @@ class Brew:
         logger.info("Retrieving Brew build: %s", build_id)
         build = self.koji_session.getBuild(build_id)
         if not build:
-            raise BrewBuildSourceNotFound(f"Build {build_id} was not found")
+            raise BrewBuildNotFound(f"Build {build_id} was not found")
 
         # Determine build state
         state = build.get("state")

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1796072-git+https---code.engineering.redhat.com-gerrit-apache-cxf.git#4871b092c022cef8e52f54ce8695af1b49af0e52-redhat-org.apache.cxf-cxf--maven].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1796072-git+https---code.engineering.redhat.com-gerrit-apache-cxf.git#4871b092c022cef8e52f54ce8695af1b49af0e52-redhat-org.apache.cxf-cxf--maven].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fec4bd4209515159027717c74ba86f2eb8690cf474903a93f47fcd6cbf14517
-size 14688

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -72,14 +72,15 @@ build_corpus = [
         "image",
     ),
     # org.apache.cxf-cxf: brew buildID=1796072
-    (
-        1796072,
-        os.getenv("CORGI_TEST_CODE_URL"),
-        "redhat",
-        "org.apache.cxf-cxf",
-        "",
-        "maven",
-    ),
+    # TODO: uncomment when Maven build type is supported
+    # (
+    #     1796072,
+    #     os.getenv("CORGI_TEST_CODE_URL"),
+    #     "redhat",
+    #     "org.apache.cxf-cxf",
+    #     "",
+    #     "maven",
+    # ),
     # nodejs: brew buildID=1700497
     (
         1700497,
@@ -116,8 +117,9 @@ def test_get_component_data(build_id, build_source, build_ns, build_name, licens
     c = Brew().get_component_data(build_id)
     if build_type == "module":
         assert list(c.keys()) == ["type", "namespace", "meta", "analysis_meta", "build_meta"]
-    elif build_type == "maven":
-        assert list(c.keys()) == ["type", "namespace", "meta", "build_meta"]
+    # TODO: uncomment when Maven build type is supported
+    # elif build_type == "maven":
+    #     assert list(c.keys()) == ["type", "namespace", "meta", "build_meta"]
     elif build_type == "image":
         assert list(c.keys()) == [
             "type",


### PR DESCRIPTION
This puts in some safeguards around processing builds that may be missing source URLs. It also removes processing of build types that we can't analyzed (yet), e.g. "maven".