### PR TITLE
get module version from brew_info instead of modulemd

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -633,18 +633,25 @@ class Brew:
         if not modulemd_yaml:
             raise ValueError("Cannot get module build data, modulemd_yaml is undefined")
         modulemd = yaml.safe_load(modulemd_yaml)
+        meta_attr = {
+            "stream": modulemd["data"]["stream"],
+            "context": modulemd["data"]["context"],
+            "components": modulemd["data"]["components"],
+            "rpms": modulemd["data"]["xmd"]["mbs"]["rpms"],
+        }
         module = {
             "type": "module",
             "namespace": "redhat",
             "meta": {
                 "nvr": build_info["nvr"],
                 "name": build_info["name"],
-                "version": modulemd["data"].get("version", ""),
+                "version": build_info["version"],
                 "license": " OR ".join(modulemd["data"]["license"].get("module", "")),
                 "release": build_info["release"],
                 # "arch": build_info["arch"],
                 "epoch": build_info["epoch"],
-                "components": modulemd["data"]["components"],
+                "description": modulemd["data"]["description"],
+                "meta_attr": meta_attr,
             },
             "analysis_meta": {
                 "source": [],

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -330,7 +330,7 @@ def save_module(softwarebuild, build_data) -> ComponentNode:
             "license": build_data["meta"].get("license", ""),
             "description": build_data["meta"].get("description", ""),
             "software_build": softwarebuild,
-            "meta_attr": build_data["meta"]["components"],
+            "meta_attr": build_data["meta"]["meta_attr"],
         },
     )
     node, _ = obj.cnodes.get_or_create(


### PR DESCRIPTION
This fixes the issue described in CORGI-199.

We still need to link the module RPMs as children of the RHEL_MODULE component. There doesn't seem to be enough information in brew alone to create the link.