### PR TITLE
CORGI-201: Use password authentication even if a valid Kerb ticket exists

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -195,6 +195,9 @@ DATABASES = {
         "PASSWORD": os.getenv("CORGI_DB_PASSWORD", "test"),
         "HOST": os.getenv("CORGI_DB_HOST", "localhost"),
         "PORT": os.getenv("CORGI_DB_PORT", "5432"),
+        # Prefer password authentication even if a valid Kerberos ticket exists on the system.
+        # See: https://www.postgresql.org/docs/devel/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
+        "OPTIONS": {"gssencmode": "disable"},
     }
 }
 


### PR DESCRIPTION
This saves us an extra request to the KDC to validate the ticket against
the DB, which inevitably fails because the DB server is not registered as a
valid principal in the KDC.