### PR TITLE
Account for unknown build types

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -679,7 +679,8 @@ class Brew:
         # Determine build type
         build_type_info = self.koji_session.getBuildType(build)
         build_type = next(
-            type_ for type_ in build_type_info.keys() if type_ in self.SUPPORTED_BUILD_TYPES
+            (type_ for type_ in build_type_info.keys() if type_ in self.SUPPORTED_BUILD_TYPES),
+            "unknown",
         )
         if not any(type_ in self.SUPPORTED_BUILD_TYPES for type_ in build_type_info.keys()):
             raise BrewBuildTypeNotSupported(


### PR DESCRIPTION
This is a regression from #113. If we encounter a build type that isn't
supported, the next() call ends with StopIteration and an exception is
emitted. Add a default that isn't included in the supported build type list
so we raise the correct exception, `BrewBuildTypeNotSupported`.