### PR TITLE
CORGI-213: minor optimisation

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -976,7 +976,7 @@ class Component(TimeStampedModel):
         """return all root nodes"""
         return list(
             ComponentNode.objects.get_queryset()  # type: ignore
-            .filter(purl=self.purl)
+            .filter(purl=self.purl, type=ComponentNode.ComponentNodeType.SOURCE)
             .get_ancestors(include_self=True)
             .filter(parent=None)
             .values_list("purl", flat=True)


### PR DESCRIPTION
narrow down ancestors retrieved by get_source() by setting type=ComponentNode.ComponentNodeType.SOURCE