### PR TITLE
CORGI-215 - return array of components when using /api/v1/components?ofuri={}

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -45,7 +45,7 @@ def get_component_purl_link(purl: str) -> str:
 
 def get_model_ofuri_link(model_name: str, ofuri: str, related_type=None) -> str:
     """Generic method to get an ofuri link for an arbitrary Model subclass."""
-    link = f"{CORGI_API_URL}/{model_name}?ofuri={ofuri}"
+    link = f"{CORGI_API_URL}/{model_name}?ofuri={ofuri}&type=SRPM&limit=3000"
     return link if not related_type else f"{link}&type={related_type}"
 
 

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -37,6 +37,7 @@ from .filters import (
 from .serializers import (
     AppStreamLifeCycleSerializer,
     ChannelSerializer,
+    ComponentListSerializer,
     ComponentSerializer,
     ProductSerializer,
     ProductStreamSerializer,
@@ -383,6 +384,10 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         # purl are stored with each segment url encoded as per the specification. The purl query
         # param here is url decoded, to ensure special characters such as '@' and '?'
         # are not interpreted as part of the request.
+        ofuri = request.query_params.get("ofuri")
+        if ofuri:
+            self.serializer_class = ComponentListSerializer
+            return super().list(request)
         purl = request.query_params.get("purl")
         if not purl:
             return super().list(request)


### PR DESCRIPTION
Invoking

` /api/v1/components?ofuri={}`

should return an array of {link,purl} objects.

**NOTE**- The only other open question is if we can do boolean || with django rest api params (eg. type=SRPM&type=CONTAINER_IMAGE or type=SRPM||CONTAINER_IMAGE)