### PR TITLE
CORGI-208: Improve purl generator with more correct namespace/type values

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -190,8 +190,7 @@ class ComponentNode(MPTTModel, TimeStampedModel):
         return self.desc.name
 
     def save(self, *args, **kwargs):
-        if not self.purl:
-            self.purl = self.obj.purl
+        self.purl = self.obj.purl
         super().save(*args, **kwargs)
 
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -808,7 +808,7 @@ class Component(TimeStampedModel):
                 type="container",
                 namespace=self.Namespace.REDHAT.lower(),
                 name=self.name,
-                version=f"{self.version}",
+                version=f"{self.version}-{self.release}",
                 qualifiers={
                     "arch": self.arch,
                     "digest": digest,
@@ -818,17 +818,23 @@ class Component(TimeStampedModel):
         elif self.type == Component.Type.UPSTREAM:
             # Upstream components should default to the "generic" purl type and not use any
             # namespaces. In the future, we may extend this to map to upstream-defined purls.
+            version = self.version
+            if self.release:
+                version = f"{version}-{self.release}"
             return PackageURL(
                 type="generic",
                 name=self.name,
-                version=f"{self.version}",
+                version=version,
             )
         else:
-            # unknown
+            # Unknown
+            version = self.version
+            if self.release:
+                version = f"{version}-{self.release}"
             return PackageURL(
                 type=self.type,
                 name=self.name,
-                version=f"{self.version}",
+                version=version,
             )
 
     def save_component_taxonomy(self):

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -766,7 +766,7 @@ class Component(TimeStampedModel):
         """return name"""
         return str(self.name)
 
-    def get_purl(self):
+    def get_purl(self) -> PackageURL:
         if self.type in (Component.Type.RPM, Component.Type.SRPM):
             qualifiers = {
                 "arch": self.arch,
@@ -856,7 +856,7 @@ class Component(TimeStampedModel):
         self.nvr = self.get_nvr()
         self.nevra = self.get_nevra()
         purl = self.get_purl()
-        self.purl = purl.to_string() if purl else ""
+        self.purl = purl.to_string()
         super().save(*args, **kwargs)
 
     @property


### PR DESCRIPTION
We should consider submitting a proposal to include `rpmmod` as a supported purl type. I filed CORGI-224 to further improve the namespace vs type fields.