### PR TITLE
CORGI-223:  re-enable get-upstreams on REST API as perf has improved

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -231,8 +231,7 @@ class ComponentSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
-        # return get_component_data_list(instance.get_upstreams())
-        return []
+        return get_component_data_list(instance.get_upstreams())
 
     class Meta:
         model = Component


### PR DESCRIPTION
Verified that get_upstreams() no longer suffers from perf degradation - this is due to indexes being added and [work elsewhere](https://gitlab.corp.redhat.com/product-security/dev/component-registry-ops/-/merge_requests/56) improving django-mptt performance.
