### PR TITLE
CORGI-256: Add sonarqube integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,9 @@ include:
   - project: 'product-security/dev/component-registry-ops'
     ref: "$CORGI_OPS_BRANCH"
     file: '/templates/gitlab/ansible-run.yml'
+  - project: 'product-security/dev/component-registry-ops'
+    ref: "$CORGI_OPS_BRANCH"
+    file: '/templates/gitlab/sonarqube.yml'
 
 .common_ci_setup: &common_ci_setup
   - export LANG=en_US.UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.exclusions=tests/**
+sonar.projectKey=component-registry
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3
+sonar.qualitygate.wait=true
+sonar.sources=.


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review this MR to add SonarQube scanning to the CI pipeline. #158 must be merged first to fix the outstanding issues, and once that's done we can merge this MR to turn on the scanning.

The internal SonarQube server has the results, under the URL "dashboard?id=component-registry&branch=add-sonarqube-integration", but doesn't report the coverage correctly even though this works locally. Fixing this would require running the sonarqube job after the test job that generates the coverage.xml file (either in a new stage or as a dependent job in the same stage).

This slows down the pipeline quite a bit and we don't really use the coverage report anyway, so going to ignore this for now.