### PR TITLE
CORGI-256: Disable SonarQube coverage report - fixing will slow down pipeline

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
+# Don't report on coverage - it's currently broken
+# Fixing it would require running the SonarQube job after the test job
+# Which would slow down the pipeline quite a bit
+sonar.coverage.exclusions=**
 sonar.exclusions=tests/**
 sonar.projectKey=component-registry
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Quick fix to disable a check in a GUI since it's causing problems. We already ignore the results, as discussed in previous MR.