### PR TITLE
skip sca of kernel

### DIFF
--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -83,6 +83,10 @@ def slow_software_composition_analysis(build_id: int):
             arch="noarch",
         )
 
+    if root_component.name == "kernel":
+        logger.info("skipping scan of the kernel, see CORGI-270")
+        return
+
     root_node = root_component.cnodes.first()
     if not root_node:
         raise ValueError(f"Didn't find root component node for {root_component.purl}")


### PR DESCRIPTION
I'm very confident we don't need to scan the kernel. It's all source code, there are no embedded components I am aware of. It's eating up lots of resources in stage, see CORGI-270.