### PR TITLE
CORGI-229 component api filter for products is too inclusive.

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -1,4 +1,5 @@
 import logging
+from string import Template
 
 from django_filters.rest_framework import CharFilter, Filter, FilterSet
 
@@ -41,17 +42,24 @@ class ComponentFilter(FilterSet):
     description = CharFilter(lookup_expr="icontains")
     tags = TagFilter()
 
-    products = CharFilter(lookup_expr="icontains")
-    product_versions = CharFilter(lookup_expr="icontains")
-    product_streams = CharFilter(lookup_expr="icontains")
-    product_variants = CharFilter(lookup_expr="icontains")
-    channels = CharFilter(lookup_expr="icontains")
+    products = CharFilter(method="filter_arrayfield")
+    product_versions = CharFilter(method="filter_arrayfield")
+    product_streams = CharFilter(method="filter_arrayfield")
+    product_variants = CharFilter(method="filter_arrayfield")
+    channels = CharFilter(method="filter_arrayfield")
     sources = CharFilter(lookup_expr="icontains")
     provides = CharFilter(lookup_expr="icontains")
     upstreams = CharFilter(lookup_expr="icontains")
     re_upstream = CharFilter(lookup_expr="regex", field_name="upstreams")
 
-    ofuri = CharFilter(field_name="product_streams", lookup_expr="icontains")
+    ofuri = CharFilter(method="filter_arrayfield")
+
+    def filter_arrayfield(self, queryset, name, value):
+        array_value = Template("{$value}").substitute(value=value)
+        if name == "ofuri":
+            name = "product_streams"
+        lookup = f"{name}__overlap"
+        return queryset.filter(**{lookup: array_value})
 
 
 class ProductDataFilter(FilterSet):

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Component Registry API
-  version: 0.0.1
+  version: 1.0.0
   description: REST API auto-generated docs for Component Registry
 paths:
   /api/healthy:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,7 +68,6 @@ def test_product_data_detail(model, endpoint_name, client, api_path):
     assert response.json()["count"] == 1
 
 
-@pytest.mark.skip(reason="Disabled until channel data is integrated into core")
 def test_channel_detail(client, api_path):
     p1 = ChannelFactory(name="Repo1")
 
@@ -464,3 +463,57 @@ def test_api_component_404(client, api_path):
 def test_api_component_400(client, api_path):
     response = client.get(f"{api_path}/components?type=NONEXISTANTTYPE")
     assert response.status_code == 400
+
+
+def test_product_components_ofuri(client, api_path):
+    openssl = ComponentFactory(name="openssl")
+    curl = ComponentFactory(name="curl")
+
+    openssl.product_streams = ["o:redhat:rhel:8.6.0"]
+    openssl.save()
+    curl.product_streams = ["o:redhat:rhel:8.6.0.z"]
+    curl.save()
+
+    response = client.get(f"{api_path}/components?ofuri=o:redhat:rhel:8.6.0.z")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    response = client.get(f"{api_path}/components?ofuri=o:redhat:rhel:8.6.0")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+
+def test_product_components_versions(client, api_path):
+    openssl = ComponentFactory(name="openssl")
+    curl = ComponentFactory(name="curl")
+
+    openssl.product_streams = ["o:redhat:rhel:8"]
+    openssl.save()
+    curl.product_streams = ["o:redhat:rhel:7"]
+    curl.save()
+
+    response = client.get(f"{api_path}/components?product_streams=o:redhat:rhel:8")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    response = client.get(f"{api_path}/components?ofuri=o:redhat:rhel:7")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+
+def test_product_components(client, api_path):
+    openssl = ComponentFactory(name="openssl")
+    curl = ComponentFactory(name="curl")
+
+    openssl.products = ["o:redhat:rhel"]
+    openssl.save()
+    curl.products = ["o:redhat:rhel-br"]
+    curl.save()
+
+    response = client.get(f"{api_path}/components?products=o:redhat:rhel")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+    response = client.get(f"{api_path}/components?products=o:redhat:rhel-br")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1


### PR DESCRIPTION
This ensures that when we filter components by products in the api we only get exact matches and not matches for substrings. For example a query for the product_stream rhel-8.6.0 was including results for rhel-8.6.0, and rhel-8.6.0.z.