### PR TITLE
Refresh schema to include 1.0.0 version string

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Component Registry API
-  version: 0.0.1
+  version: 1.0.0
   description: REST API auto-generated docs for Component Registry
 paths:
   /api/healthy:


### PR DESCRIPTION
Forgot to include this for 4e1c759623b0ed2a17a2c42a1fa0f3d8567c0a2c :disappointed: Will wait for CI to actually run this time before merging.