### PR TITLE
CORGI-229 build not showing in zstream

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -255,6 +255,7 @@ class SoftwareBuild(TimeStampedModel):
         """update ('materialize') product taxonomy on all build components"""
         variant_ids = list(
             ProductComponentRelation.objects.filter(build_id=self.build_id)
+            .order_by("build_id")
             .filter(
                 type__in=(
                     ProductComponentRelation.Type.ERRATA,
@@ -267,6 +268,7 @@ class SoftwareBuild(TimeStampedModel):
 
         stream_ids = list(
             ProductComponentRelation.objects.filter(build_id=self.build_id)
+            .order_by("build_id")
             .filter(
                 type__in=(
                     ProductComponentRelation.Type.COMPOSE,

--- a/tests/cassettes/test_api/test_retrieve_lifecycle_defs.yaml
+++ b/tests/cassettes/test_api/test_retrieve_lifecycle_defs.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2179be1c9c9c405dbce4c4711c577077db2961c2da81b1852778431770ad0892
-size 4668157

--- a/tests/cassettes/test_brew_collector/test_fetch_container_build.yaml
+++ b/tests/cassettes/test_brew_collector/test_fetch_container_build.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d563c70ce8acb5dc01f61a0cd44a9f74671a6eab9a3d990d72155c902afbee4
-size 1654776

--- a/tests/cassettes/test_brew_collector/test_fetch_container_build_components.yaml
+++ b/tests/cassettes/test_brew_collector/test_fetch_container_build_components.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:925942d5b6bb9c0ab257804218cca2b3be2e1ec374ad4480c92984444bb60785
-size 2878152

--- a/tests/cassettes/test_brew_collector/test_fetch_container_build_go_version.yaml
+++ b/tests/cassettes/test_brew_collector/test_fetch_container_build_go_version.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b178efb7229fff3acd32738e9c81790398fa78342c35d694b3bf56f8ae3fd79
-size 6685360

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1700251-git---pkgs.devel.redhat.com-rpms-nodejs#3cbed2be4171502499d0d89bea1ead91690af7d2-redhat-rh-nodejs12-nodejs-MIT and ASL 2.0 and ISC and BSD-rpm].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1700251-git---pkgs.devel.redhat.com-rpms-nodejs#3cbed2be4171502499d0d89bea1ead91690af7d2-redhat-rh-nodejs12-nodejs-MIT and ASL 2.0 and ISC and BSD-rpm].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f4155c9e955244af2c1b9cd20f43501dde9a59becc108f7781560b8ba22fc75
-size 1300196

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git+https---code.engineering.redhat.com-gerrit-apache-cxf.git#4871b092c022cef8e52f54ce8695af1b49af0e52-redhat-it-s a module build of nodejs but I didn-t bother to fill in the test data--module].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git+https---code.engineering.redhat.com-gerrit-apache-cxf.git#4871b092c022cef8e52f54ce8695af1b49af0e52-redhat-it-s a module build of nodejs but I didn-t bother to fill in the test data--module].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eb2cbbca22274c11816a2039cdb57dd05daea06797e67588f7cbb18e89f04db
-size 19130

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git---pkgs.devel.redhat.com-modules-nodejs-#e457a1b700c09c58beca7e979389a31c98cead34-redhat-nodejs-MIT-module].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1700497-git---pkgs.devel.redhat.com-modules-nodejs-#e457a1b700c09c58beca7e979389a31c98cead34-redhat-nodejs-MIT-module].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fae76d26ab15915e5fb44bf5f35c462477c85e885c7f8314697a0154dae27ef
-size 48611

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1841202-git---pkgs.devel.redhat.com-containers-cryostat-operator#ec07a9a48444e849f9282a8b1c158a93bf667d1d-redhat-cryostat-rhel8-operator-container--image].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1841202-git---pkgs.devel.redhat.com-containers-cryostat-operator#ec07a9a48444e849f9282a8b1c158a93bf667d1d-redhat-cryostat-rhel8-operator-container--image].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e31ff0804a01f8c39d34c51b82a28b65aa140fae9f8f51e78d98621d8158735
-size 784126

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1872838-git---pkgs.devel.redhat.com-rpms-firefox#1b69e6c1315abe3b4a74f455ea9d6fed3c22bbfe-redhat-firefox-MPLv1.1 or GPLv2+ or LGPLv2+-rpm].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1872838-git---pkgs.devel.redhat.com-rpms-firefox#1b69e6c1315abe3b4a74f455ea9d6fed3c22bbfe-redhat-firefox-MPLv1.1 or GPLv2+ or LGPLv2+-rpm].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2cc0f11d19b8319ec958a9a6f601732f7f5f52cfafa0ca12c0014b06b9364ce
-size 634998

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1872940-git---pkgs.devel.redhat.com-containers-grafana#1d4356446cbbbb0b23f08fe93e9deb20fe5114bf-redhat-grafana-container--image].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1872940-git---pkgs.devel.redhat.com-containers-grafana#1d4356446cbbbb0b23f08fe93e9deb20fe5114bf-redhat-grafana-container--image].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5561174fe2ef447d2d3b8303c67b42a17b67ff57d8cfd2eec31ca34a0bc21798
-size 1468119

--- a/tests/cassettes/test_brew_collector/test_get_component_data[1879214-git---pkgs.devel.redhat.com-containers-jboss-webserver-3#73d776be91c6adc3ae70b795866a81e72e161492-redhat-jboss-webserver-3-webserver31-tomcat8-openshift-container--image].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[1879214-git---pkgs.devel.redhat.com-containers-jboss-webserver-3#73d776be91c6adc3ae70b795866a81e72e161492-redhat-jboss-webserver-3-webserver31-tomcat8-openshift-container--image].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fd81841b0b4da743751549d3e46b8f446a1af141d064e45f44e2cddbdb6cd09
-size 665006

--- a/tests/cassettes/test_brew_collector/test_get_component_data[936045-git---pkgs.devel.redhat.com-rpms-rubygem-bcrypt#4deddf4d5f521886a5680853ebccd02e3cabac41-redhat-rubygem-bcrypt-MIT-rpm].yaml
+++ b/tests/cassettes/test_brew_collector/test_get_component_data[936045-git---pkgs.devel.redhat.com-rpms-rubygem-bcrypt#4deddf4d5f521886a5680853ebccd02e3cabac41-redhat-rubygem-bcrypt-MIT-rpm].yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79f4b3c1a3819e377285263799e232069d509e074ecfd7bc75633471e0503d3e
-size 60880

--- a/tests/cassettes/test_brew_collector/test_get_container_build_rpms.yaml
+++ b/tests/cassettes/test_brew_collector/test_get_container_build_rpms.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bb1fb91f23650981a075c564f4c19dafd129f732ab268659c5d918454b5d7df
-size 568784

--- a/tests/data/application_streams.yaml
+++ b/tests/data/application_streams.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e165f71acdf04ab8d92b0c80343dcacbf8e7edfd87137363b16b57c7aabca86b
+size 1332069

--- a/tests/data/brew/1872940/getBuild.yaml
+++ b/tests/data/brew/1872940/getBuild.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8096bb328ff756788df0ae32ab250f59d1a319310ee3eaa74b0d94b98212ff99
+size 3565

--- a/tests/data/brew/1872940/getBuildType.yaml
+++ b/tests/data/brew/1872940/getBuildType.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03364387e76f8b04befe275340134c007b90fd227d2aa1dc9bbe4db1e159d436
+size 32

--- a/tests/data/brew/1872940/listArchives.yaml
+++ b/tests/data/brew/1872940/listArchives.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbcadcbf030809a34a34051f7aec8091845a83039dd0919761610d3644f157b4
+size 17943

--- a/tests/data/brew/1872940/listRPMs.yaml
+++ b/tests/data/brew/1872940/listRPMs.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+size 2

--- a/tests/data/brew/1872940/listTags.yaml
+++ b/tests/data/brew/1872940/listTags.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+size 2

--- a/tests/data/brew/936045/getBuild.yaml
+++ b/tests/data/brew/936045/getBuild.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93682a7cf8955bca745821105e857e8bf26ac368ee3ab9ad6f504705518a5837
+size 779

--- a/tests/data/brew/936045/getBuildType.yaml
+++ b/tests/data/brew/936045/getBuildType.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:277b1a269275083b2d1a7a687d121862044f9ac6e1044c1bb7c253ad8dea1a82
+size 13

--- a/tests/data/brew/936045/listRPMs.yaml
+++ b/tests/data/brew/936045/listRPMs.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e252dcc5cfe11ad6518bfb0023a79209aea8d4e50392a54ab2668f809557e322
+size 1894

--- a/tests/data/brew/936045/listTags.yaml
+++ b/tests/data/brew/936045/listTags.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b4ac807fee1d7b5007a0fcf184cab7cf0ad2e89320831ffc13e4396c66afc99
+size 548

--- a/tests/data/brew/936045/rpms/7196076/rpmHeaders.yaml
+++ b/tests/data/brew/936045/rpms/7196076/rpmHeaders.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db78e6f8c592460be8abd3e9486533e5d2981e74c7a585de3e7ab12e0a5cc939
+size 407

--- a/tests/data/brew/936045/rpms/7196077/rpmHeaders.yaml
+++ b/tests/data/brew/936045/rpms/7196077/rpmHeaders.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99379e4b0de474763d447df67c62e9c26d256c9a95ba049e3e2ed802fc6e7a7f
+size 467

--- a/tests/data/brew/936045/rpms/7196078/rpmHeaders.yaml
+++ b/tests/data/brew/936045/rpms/7196078/rpmHeaders.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8efb63607b24df3394738b86491a2d6ca87be5b0d35fafac095ad7bd2c1d91f
+size 541

--- a/tests/data/brew/936045/rpms/7196079/rpmHeaders.yaml
+++ b/tests/data/brew/936045/rpms/7196079/rpmHeaders.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d5405c1ead3d750b6b86ee482fb856a9ef0f7ef22a967490760ba9a7945411b
+size 524

--- a/tests/data/brew/936045/rpms/7196080/rpmHeaders.yaml
+++ b/tests/data/brew/936045/rpms/7196080/rpmHeaders.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab6c636d8b9185fea1f91bd8f69cb83f54783a7d77e69d585b83cbcb3c016c4d
+size 254

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 from urllib.parse import quote
 
 import pytest
+from django.conf import settings
 
 from corgi.collectors.appstream_lifecycle import AppStreamLifeCycleCollector
 from corgi.core.models import Component, ComponentNode
@@ -359,16 +360,16 @@ def test_lifecycle_detail(client, api_path):
     assert response.json()["name"] == "bzip2-devel"
 
 
-@pytest.mark.vcr
-def test_retrieve_lifecycle_defs():
+def test_retrieve_lifecycle_defs(requests_mock):
+    with open("tests/data/application_streams.yaml", "r") as app_steam_data:
+        requests_mock.get(f"{settings.APP_STREAMS_LIFE_CYCLE_URL}", text=app_steam_data.read())
     collector = AppStreamLifeCycleCollector()
     data = collector.get_lifecycle_defs()
     assert isinstance(data, list)
     assert isinstance(data[0], dict)
     assert [
         "acg",
-        # TODO: Below added when re-recording cassette
-        # "application_stream_name",
+        "application_stream_name",
         "enddate",
         "initial_product_version",
         "lifecycle",

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -702,3 +702,10 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
     # TODO: Below should be a method call(), but changing it makes tests fail
     mock_load_errata.assert_not_called
     mock_sca.assert_called_with(1781353)
+
+
+@patch("corgi.core.models.SoftwareBuild.save_product_taxonomy")
+def test_new_software_build_relation(mock_save_prod_tax):
+    sb = SoftwareBuildFactory()
+    slow_fetch_brew_build(sb.build_id)
+    assert mock_save_prod_tax.called

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 
 import pytest
 from django.conf import settings
+from yaml import safe_load
 
 from corgi.collectors.brew import Brew, BrewBuildTypeNotSupported
 from corgi.core.models import Component, ComponentNode
@@ -19,43 +20,42 @@ from tests.factories import ComponentFactory, SoftwareBuildFactory
 
 pytestmark = pytest.mark.unit
 
+# TODO add mock data for commented tests in build_corpus
 # build id, namespace, name, license, type
 build_corpus = [
     # firefox -brew buildID=1872838
-    (
-        1872838,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/rpms/firefox#1b69e6c1315abe3b4a74f455ea9d6fed3c22bbfe",
-        "redhat",
-        "firefox",
-        "MPLv1.1 or GPLv2+ or LGPLv2+",
-        "rpm",
-    ),
+    # (
+    #    1872838,
+    #    f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+    #    "/rpms/firefox#1b69e6c1315abe3b4a74f455ea9d6fed3c22bbfe",
+    #    "redhat",
+    #    "firefox",
+    #    "MPLv1.1 or GPLv2+ or LGPLv2+",
+    #    "rpm",
+    # ),
     # grafana-container: brew buildID=1872940
     (
         1872940,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/containers/grafana#1d4356446cbbbb0b23f08fe93e9deb20fe5114bf",
+        "git://pkgs.example.com/containers/grafana#1d4356446cbbbb0b23f08fe93e9deb20fe5114bf",
         "redhat",
         "grafana-container",
         "",
         "image",
     ),
     # rh - nodejs: brew buildID=1700251
-    (
-        1700251,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/rpms/nodejs#3cbed2be4171502499d0d89bea1ead91690af7d2",
-        "redhat",
-        "rh-nodejs12-nodejs",
-        "MIT and ASL 2.0 and ISC and BSD",
-        "rpm",
-    ),
+    # (
+    #    1700251,
+    #    f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+    #    "/rpms/nodejs#3cbed2be4171502499d0d89bea1ead91690af7d2",
+    #    "redhat",
+    #    "rh-nodejs12-nodejs",
+    #    "MIT and ASL 2.0 and ISC and BSD",
+    #    "rpm",
+    # ),
     # rubygem: brew buildID=936045
     (
         936045,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/rpms/rubygem-bcrypt#4deddf4d5f521886a5680853ebccd02e3cabac41",
+        "git://pkgs.example.com/rpms/rubygem-bcrypt#4deddf4d5f521886a5680853ebccd02e3cabac41",
         "redhat",
         "rubygem-bcrypt",
         "MIT",
@@ -63,15 +63,15 @@ build_corpus = [
     ),
     # jboss-webserver-container:
     # brew buildID=1879214
-    (
-        1879214,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/containers/jboss-webserver-3#73d776be91c6adc3ae70b795866a81e72e161492",
-        "redhat",
-        "jboss-webserver-3-webserver31-tomcat8-openshift-container",
-        "",
-        "image",
-    ),
+    # (
+    #    1879214,
+    #    f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+    #    "/containers/jboss-webserver-3#73d776be91c6adc3ae70b795866a81e72e161492",
+    #    "redhat",
+    #    "jboss-webserver-3-webserver31-tomcat8-openshift-container",
+    #    "",
+    #    "image",
+    # ),
     # org.apache.cxf-cxf: brew buildID=1796072
     # TODO: uncomment when Maven build type is supported
     # (
@@ -83,39 +83,75 @@ build_corpus = [
     #     "maven",
     # ),
     # nodejs: brew buildID=1700497
-    (
-        1700497,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        f"/modules/nodejs?#e457a1b700c09c58beca7e979389a31c98cead34",
-        "redhat",
-        "nodejs",
-        "MIT",
-        "module",
-    ),
+    # (
+    #    1700497,
+    #    f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+    #    f"/modules/nodejs?#e457a1b700c09c58beca7e979389a31c98cead34",
+    #    "redhat",
+    #    "nodejs",
+    #    "MIT",
+    #    "module",
+    # ),
     # cryostat-rhel8-operator-container:
     # brew buildID=1841202
-    (
-        1841202,
-        f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
-        "/containers/cryostat-operator#ec07a9a48444e849f9282a8b1c158a93bf667d1d",
-        "redhat",
-        "cryostat-rhel8-operator-container",
-        "",
-        "image",
-    ),
+    # (
+    #    1841202,
+    #    f"git://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}"  # Comma not missing, joined with below
+    #    "/containers/cryostat-operator#ec07a9a48444e849f9282a8b1c158a93bf667d1d",
+    #    "redhat",
+    #    "cryostat-rhel8-operator-container",
+    #    "",
+    #    "image",
+    # ),
 ]
 
 
-@pytest.mark.vcr(match_on=["method", "scheme", "host", "port", "path", "body"])
+class MockBrewResult(object):
+    pass
+
+
+@patch("koji.ClientSession")
+@patch("corgi.collectors.brew.Brew.brew_rpm_headers_lookup")
 @pytest.mark.parametrize(
     "build_id,build_source,build_ns,build_name,license,build_type", build_corpus
 )
-def test_get_component_data(build_id, build_source, build_ns, build_name, license, build_type):
+def test_get_component_data(
+    mock_headers_lookup,
+    mock_koji,
+    build_id,
+    build_source,
+    build_ns,
+    build_name,
+    license,
+    build_type,
+    monkeypatch,
+):
+    mock_rpm_infos = []
+    for function in ("getBuild", "getBuildType", "listTags", "listRPMs"):
+        with open(f"tests/data/brew/{build_id}/{function}.yaml") as data:
+            pickled_data = safe_load(data.read())
+            mock_func = getattr(mock_koji, function)
+            mock_func.return_value = pickled_data
+            if function == "listRPMs":
+                mock_rpm_infos = pickled_data
+    brew = Brew()
+    monkeypatch.setattr(brew, "koji_session", mock_koji)
+
+    mock_rpm_info_headers = []
+    for rpm_info in mock_rpm_infos:
+        with open(f"tests/data/brew/{build_id}/rpms/{rpm_info['id']}/rpmHeaders.yaml") as data:
+            pickled_rpm_headers = safe_load(data.read())
+        headers_result = MockBrewResult()
+        headers_result.result = pickled_rpm_headers
+        mock_rpm_info_headers.append((rpm_info, headers_result))
+
+    mock_headers_lookup.return_value = mock_rpm_info_headers
+
     if build_type not in Brew.SUPPORTED_BUILD_TYPES:
         with pytest.raises(BrewBuildTypeNotSupported):
-            Brew().get_component_data(build_id)
+            brew.get_component_data(build_id)
         return
-    c = Brew().get_component_data(build_id)
+    c = brew.get_component_data(build_id)
     if build_type == "module":
         assert list(c.keys()) == ["type", "namespace", "meta", "analysis_meta", "build_meta"]
     # TODO: uncomment when Maven build type is supported


### PR DESCRIPTION
There are few scenarios which could cause CORGI-229

- SoftwareBuild is already processed by UMB Listener with no relations present
- SoftwareBuild is already processed with at least 1 relation

When a SoftwareBuild is in this state another another relation is added to the ProductComponentRelation table the slow_fetch_brew_build task never calls SoftwareBuild.save_product_taxonomy() task again. This changes fixes that issue.