### PR TITLE
CORGI-289: Load composes periodically

### DIFF
--- a/corgi/tasks/management/commands/loadcomposedata.py
+++ b/corgi/tasks/management/commands/loadcomposedata.py
@@ -1,10 +1,6 @@
 from django.core.management.base import BaseCommand, CommandParser
 
-from corgi.tasks.rhel_compose import (
-    get_all_builds,
-    get_builds_by_compose,
-    get_builds_by_stream,
-)
+from corgi.tasks.rhel_compose import get_builds
 
 
 class Command(BaseCommand):
@@ -41,11 +37,11 @@ class Command(BaseCommand):
         if options["compose_names"]:
             compose_names = options["compose_names"]
             self.stderr.write(self.style.NOTICE(f"Fetching builds for composes: {compose_names}"))
-            get_builds_by_compose(compose_names)
+            get_builds(compose_names=compose_names)
         elif options["stream"]:
             stream = options["stream"]
             self.stderr.write(self.style.NOTICE(f"Fetching builds for stream {stream}"))
-            get_builds_by_stream(stream)
+            get_builds(stream_name=stream)
         else:
             self.stderr.write(self.style.NOTICE("Fetching builds for all composes"))
-            get_all_builds()
+            get_builds()

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -57,8 +57,9 @@ def setup_periodic_tasks(sender, **kwargs):
     # task at all: https://github.com/celery/django-celery-beat/issues/221
     upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
     upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
-    upsert_cron_task("pulp", "update_cdn_repo_channels", hour=1, minute=30)
+    upsert_cron_task("pulp", "update_cdn_repo_channels", hour=2, minute=0)
     upsert_cron_task("rhel_compose", "save_composes", hour=3, minute=0)
+    upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)
     upsert_cron_task("monitoring", "email_failed_tasks", hour=10, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -12,7 +12,7 @@ from corgi.core.models import (
     ProductVariant,
     SoftwareBuild,
 )
-from corgi.tasks.brew import fetch_modular_build, slow_fetch_brew_build
+from corgi.tasks.brew import fetch_modular_build
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, _create_relations
 from corgi.tasks.errata_tool import update_variant_repos
 
@@ -40,8 +40,7 @@ def fetch_unprocessed_cdn_relations(force_process=False, created_in_last_week=Tr
         ]:
             if not SoftwareBuild.objects.filter(build_id=int(build_id)).exists():
                 logger.info("Processing CDN relation build with id: %s", build_id)
-                fetch_modular_build.delay(build_id)
-                slow_fetch_brew_build.delay(int(build_id), force_process=force_process)
+                fetch_modular_build.delay(build_id, force_process=force_process)
         offset = offset + limit
 
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This change should cause us to automatically load all compose builds every day, if they don't already exist. I don't know how much processing this involves, after the existing data is loaded and we only have to ingest new builds.

Maybe it's better to only check for / load new builds once a week? Or maybe we'd prefer to keep our data more current (no more than 24 hours delay / staleness) and it's better to run the task daily.