### PR TITLE
CORGI-222 allow null value for cg_name field image build

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -683,10 +683,18 @@ class Brew:
         #  identified in a separate attribute on the build itself.
         if build_type == self.CONTAINER_BUILD_TYPE:
             # If this is an "image" type build, it may be building a container image, ISO image,
-            # or other types of images. Check the content generator name to determine where this
-            # image was built, which indicates what type of image it is.
-            if build["cg_name"] != "atomic-reactor":
+            # or other types of images.
+            build_extra = build.get("extra")
+            if build["cg_name"] == "atomic-reactor":
+                # Check the content generator name to determine where this
+                # image was built, which indicates what type of image it is.
                 # Container images are built in OSBS, which uses atomic-reactor to build them.
+                pass
+            elif build_extra and build_extra.get("submitter") == "osbs":
+                # Some builds such as 903565 have the cg_name field set to None
+                # In that case check the extra/submitter field for osbs value
+                pass
+            else:
                 raise BrewBuildTypeNotSupported(
                     f"Image build {build_id} is not supported: "
                     f"{build['cg_name']} content generator used"

--- a/tests/data/brew/903617/getBuild.yaml
+++ b/tests/data/brew/903617/getBuild.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d35e27deaef765a320ebd73dd81241b0d012fde1847d420f5632a7477cac295
+size 1857

--- a/tests/data/brew/903617/getBuildType.yaml
+++ b/tests/data/brew/903617/getBuildType.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81a9e59c2ec9acf8f7b80100232fee05effa63e5fd876c4f882619b896a1cb03
+size 31

--- a/tests/data/brew/903617/listArchives.yaml
+++ b/tests/data/brew/903617/listArchives.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4e1ce9a1aa064a41bfc6ef3e73aecd171724063947c83d12f787d9d45c51d23
+size 6047

--- a/tests/data/brew/903617/listRPMs.yaml
+++ b/tests/data/brew/903617/listRPMs.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+size 2

--- a/tests/data/brew/903617/listTags.yaml
+++ b/tests/data/brew/903617/listTags.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945
+size 2

--- a/tests/data/brew/936045/getBuild.yaml
+++ b/tests/data/brew/936045/getBuild.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93682a7cf8955bca745821105e857e8bf26ac368ee3ab9ad6f504705518a5837
+oid sha256:f5037b219e56ec1a80c4c581d98043052a212d6ec1cad345ac674be2aa049807
 size 779

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -37,7 +37,6 @@ build_corpus = [
     (
         1872940,
         "git://pkgs.example.com/containers/grafana#1d4356446cbbbb0b23f08fe93e9deb20fe5114bf",
-        "redhat",
         "grafana-container",
         "",
         "image",
@@ -56,7 +55,6 @@ build_corpus = [
     (
         936045,
         "git://pkgs.example.com/rpms/rubygem-bcrypt#4deddf4d5f521886a5680853ebccd02e3cabac41",
-        "redhat",
         "rubygem-bcrypt",
         "MIT",
         "rpm",
@@ -103,6 +101,16 @@ build_corpus = [
     #    "",
     #    "image",
     # ),
+    # ansible-tower-messaging-container
+    # brew buildID=903617
+    (
+        903617,
+        "git://pkgs.example.com/containers/"
+        "ansible-tower-messaging#bef542c8527bf77fe9b02d6c2d2c60455fe7e510",
+        "ansible-tower-messaging-container",
+        "",
+        "image",
+    ),
 ]
 
 
@@ -113,14 +121,13 @@ class MockBrewResult(object):
 @patch("koji.ClientSession")
 @patch("corgi.collectors.brew.Brew.brew_rpm_headers_lookup")
 @pytest.mark.parametrize(
-    "build_id,build_source,build_ns,build_name,license_declared_raw,build_type", build_corpus
+    "build_id,build_source,build_name,license_declared_raw,build_type", build_corpus
 )
 def test_get_component_data(
     mock_headers_lookup,
     mock_koji,
     build_id,
     build_source,
-    build_ns,
     build_name,
     license_declared_raw,
     build_type,
@@ -184,7 +191,6 @@ def test_get_component_data(
     # The "license_declared_raw" field on the Component model defaults to ""
     # But the Brew collector (via get_rpm_build_data) / Koji (via getRPMHeaders) may return None
     assert c["meta"].get("license", "") == license_declared_raw
-    assert c["namespace"] == build_ns
     assert c["type"] == build_type
 
 


### PR DESCRIPTION
This fixes CORGI-222 where 3 image builds from ansible_automation_platform-1.2 where not being fetched from brew.