### PR TITLE
Manifest should use .get_latest_components now

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -230,14 +230,6 @@ class ProductViewSet(ProductDataViewSet):
         return response
 
     @action(methods=["get"], detail=True)
-    def manifest(self, request, uuid=None):
-        obj = self.queryset.filter(uuid=uuid).first()
-        if not obj:
-            return Response(status=404)
-        manifest = json.loads(obj.manifest)
-        return Response(manifest)
-
-    @action(methods=["get"], detail=True)
     def taxonomy(self, request, uuid=None):
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
@@ -266,14 +258,6 @@ class ProductVersionViewSet(ProductDataViewSet):
         response = Response(status=302)
         response["Location"] = f"/api/{CORGI_API_VERSION}/product_versions/{pv.uuid}"
         return response
-
-    @action(methods=["get"], detail=True)
-    def manifest(self, request, uuid=None):
-        obj = self.queryset.filter(uuid=uuid).first()
-        if not obj:
-            return Response(status=404)
-        manifest = json.loads(obj.manifest)
-        return Response(manifest)
 
     @action(methods=["get"], detail=True)
     def taxonomy(self, request, uuid=None):
@@ -345,14 +329,6 @@ class ProductVariantViewSetSet(ProductDataViewSet):
         response = Response(status=302)
         response["Location"] = f"/api/{CORGI_API_VERSION}/product_variants/{pv.uuid}"
         return response
-
-    @action(methods=["get"], detail=True)
-    def manifest(self, request, uuid=None):
-        obj = self.queryset.filter(uuid=uuid).first()
-        if not obj:
-            return Response(status=404)
-        manifest = json.loads(obj.manifest)
-        return Response(manifest)
 
     @action(methods=["get"], detail=True)
     def taxonomy(self, request, uuid=None):

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -379,11 +379,6 @@ class ProductModel(models.Model):
         return self.get_related_components(self.builds, "purl")
 
     @property
-    def manifest(self) -> str:
-        """Return an SPDX-style manifest in JSON format."""
-        return ProductManifestFile(self).render_content()
-
-    @property
     def coverage(self) -> int:
         if not self.pnodes.exists():
             return 0
@@ -514,6 +509,11 @@ class ProductStream(ProductModel, TimeStampedModel):
         """
         stream_name = re.sub(r"(-|_|)" + self.version + "$", "", self.name)
         return f"o:redhat:{stream_name}:{self.version}"
+
+    @property
+    def manifest(self) -> str:
+        """Return an SPDX-style manifest in JSON format."""
+        return ProductManifestFile(self).render_content()
 
     def get_latest_components(self):
         """Return root components from latest builds."""

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -12,7 +12,7 @@
     ],
     "documentNamespace": "https://access.redhat.com/security/data/manifest/spdx/{{product.name}}-{{product.uuid}}",
     "name": "{{product.name}}",
-    "packages": [{% for component in product.components %}{# Below will eventually become component.manifest #}
+    "packages": [{% for component in product.get_latest_components %}{# Below will eventually become component.manifest #}
         {
             "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
             "downloadLocation": {% if component.channels %}"{{component.channels.0}}"{% else %}"NOASSERTION"{% endif %},
@@ -62,7 +62,7 @@
             "versionInfo": "{{product.version}}"
         }
     ],
-    "relationships": [{% for component in product.components %}
+    "relationships": [{% for component in product.get_latest_components %}
         {
           "relatedSpdxElement": "SPDXRef-{{product.uuid}}",
           "relationshipType": "PACKAGE_OF",

--- a/openapi.yml
+++ b/openapi.yml
@@ -588,27 +588,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductVariant'
           description: ''
-  /api/v1/product_variants/{uuid}/manifest:
-    get:
-      operationId: v1_product_variants_manifest_retrieve
-      description: View for api/v1/product_variants
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product variant.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductVariant'
-          description: ''
   /api/v1/product_variants/{uuid}/taxonomy:
     get:
       operationId: v1_product_variants_taxonomy_retrieve
@@ -719,27 +698,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductVersion'
           description: ''
-  /api/v1/product_versions/{uuid}/manifest:
-    get:
-      operationId: v1_product_versions_manifest_retrieve
-      description: View for api/v1/product_versions
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product version.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductVersion'
-          description: ''
   /api/v1/product_versions/{uuid}/taxonomy:
     get:
       operationId: v1_product_versions_taxonomy_retrieve
@@ -832,27 +790,6 @@ paths:
   /api/v1/products/{uuid}:
     get:
       operationId: v1_products_retrieve
-      description: View for api/v1/products
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
-  /api/v1/products/{uuid}/manifest:
-    get:
-      operationId: v1_products_manifest_retrieve
       description: View for api/v1/products
       parameters:
       - in: path

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from random import choice, randint
 
 import factory
+from django.utils import timezone
 
 from corgi.core import models
 
@@ -26,6 +27,7 @@ class SoftwareBuildFactory(factory.django.DjangoModelFactory):
     build_id = factory.sequence(lambda n: n + 100)
     name = factory.Faker("word")
     tag = factory.RelatedFactory(SoftwareBuildTagFactory, factory_related_name="software_build")
+    completion_time = timezone.now()
 
 
 class ProductTagFactory(TagFactory):


### PR DESCRIPTION
Now that we have a 'latest' filter which returns the latest built top level components (SRPM, noarch CONTAINER_IMAGE and RHEL_MODULE) ... we should employ this when generating product stream manifest.

Tagging @juspence specifically ... there is a failing test which we need to figure out ... though running out of time this week to diagnose ... raising this PR for discussion.

Note - we also may consider removing from REST API manifest links from product, product_version and product_variants 