### PR TITLE
CORGI-48 erroneous go arch components

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -130,8 +130,13 @@ class Brew:
                     component_type = "gem"
                 elif component_type in ("npm", "nodejs", "js"):
                     component_type = "npm"
-                elif component_type in ("golang", "crate"):
+                elif component_type == "golang":
+                    # Need to skip arch names, See CORGI-48
+                    if component in ["aarch-64", "ppc-64", "s390-64", "x86-64"]:
+                        continue
                     # golang and crate are both valid component types
+                    pass
+                elif component_type == "crate":
                     pass
                 else:
                     # Account for bundled deps like "bundled(rh-nodejs12-zlib)" where it's not clear

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -464,6 +464,8 @@ def test_parsing_bundled_provides():
     test_provides = [
         # brew rpmID=6809357
         "golang(golang.org/x/crypto/acme)",
+        # brew rpmID=10558907
+        "golang(aarch-64)",
         # brew rpmID=8261950
         "bundled(golang(github.com/git-lfs/go-netrc)",
         "bundled(golang)(github.com/alexbrainman/sspi)",


### PR DESCRIPTION
Exclude components with arch names for golang components discovered via rpm specfile provides.