### PR TITLE
CORGI-154 fix builds property of productmodel

### DIFF
--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -22,14 +22,16 @@ pytestmark = pytest.mark.unit
 def test_product_manifest_properties():
     """Test that all models inheriting from ProductModel have a .manifest property
     And that it generates valid JSON. TODO: Use a library to generate + validate the SPDX data"""
-    product = ProductFactory(product_variants=["1"])
-    version = ProductVersionFactory(product_variants=["1"])
-    stream = ProductStreamFactory(product_variants=["1"])
+    product = ProductFactory()
+    version = ProductVersionFactory()
+    stream = ProductStreamFactory()
     variant = ProductVariantFactory(name="1")
     pnode = ProductNode.objects.create(parent=None, obj=product, object_id=product.pk)
     pvnode = ProductNode.objects.create(parent=pnode, obj=version, object_id=version.pk)
     psnode = ProductNode.objects.create(parent=pvnode, obj=stream, object_id=stream.pk)
     _ = ProductNode.objects.create(parent=psnode, obj=variant, object_id=variant.pk)
+    # This generates and saves the product_variants, and product_streams property of `variant`
+    variant.save_product_taxonomy()
 
     build = SoftwareBuildFactory(build_id=1)
     component = ComponentFactory(software_build=build)


### PR DESCRIPTION
I removed both the `errata`, and `upstream` properties of ProductModel which were using `get_product_component_relations` function but where not being called by anything. That allowed me to consolidate the `get_product_component_relations` function into the `builds` function, and therefore simplify it.

While I was simplifying functions I also fixed the `errata` function of the Component model so that it didn't check the meta_attr components field unnecessarily. I removed both `get_product_variants`, and `get_product_streams` functions from Component which were a legacy of when we had a `save_product_taxonomy` function directly on the Component Model. Today component product taxonomies are updated by calling SoftwareBuild's `save_product_taxonomy` function.

Also added 2 new tests, and refactored some tests to make them work after the changes to ProductModel `builds` , and easier to understand.

@RedHatProductSecurity/corgi-devs please review.


