### PR TITLE
CORGI-321: Add filter to prevent ingesting community products

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -304,6 +304,9 @@ UMB_BROKER_URL = os.getenv("CORGI_UMB_BROKER_URL")
 # https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
 UMB_BREW_MONITOR_ENABLED = strtobool(os.getenv("CORGI_UMB_BREW_MONITOR_ENABLED", "true"))
 
+# Set to True to turn on loading of community products from product-definitions.
+COMMUNITY_PRODUCTS_ENABLED = strtobool(os.getenv("CORGI_COMMUNITY_PRODUCTS_ENABLED", "false"))
+
 # Brew
 BREW_URL = os.getenv("CORGI_BREW_URL")
 BREW_WEB_URL = os.getenv("CORGI_BREW_WEB_URL")

--- a/corgi/collectors/prod_defs.py
+++ b/corgi/collectors/prod_defs.py
@@ -22,9 +22,11 @@ class ProdDefs:
         data = cls.get_product_definitions()
 
         products = []
-        for ps_product, product_data in data["ps_products"].items():
-            product_data["id"] = ps_product
-            products.append(product_data)
+        for ps_product, product in data["ps_products"].items():
+            if product["business_unit"] == "Community" and not settings.COMMUNITY_PRODUCTS_ENABLED:
+                continue
+            product["id"] = ps_product
+            products.append(product)
 
         for product in products:
             product_versions = []


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This filter was requested by Jason so we don't accidentally load a bunch of community-only components / builds. After checking the data in prod-defs, it looks like only two entries are marked as community. See the Jira ticket for details.