### PR TITLE
CORGI-308: Add one missing line to component manifests

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -51,6 +51,7 @@
             "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
             "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
             "name": "{{obj.name}}",
+            "originator": "NOASSERTION",
             "packageFileName": {% if obj.filename %}"{{obj.filename}}"{% else %}"NOASSERTION"{% endif %},
             "SPDXID": "SPDXRef-{{obj.uuid}}",
             "supplier": "Organization: Red Hat",


### PR DESCRIPTION
Quick fix to add data that's needed for components (where we don't necessarily know the originator). This line isn't present in the product manifest template I copied, since we know the originator of a Red Hat product is always Red Hat :)