### PR TITLE
CORGI-308: Fix typo that caused component being manifested's purl to be empty

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -41,7 +41,7 @@
             "externalRefs": [
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
-                    "referenceLocator": "{{node.purl|safe}}",
+                    "referenceLocator": "{{obj.purl|safe}}",
                     "referenceType": "purl"
                 }
             ],


### PR DESCRIPTION
Quick fix for a silly issue I should have caught sooner.