### PR TITLE
Fix sonarqube integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,9 +9,8 @@ include:
   - project: 'product-security/dev/component-registry-ops'
     ref: "$CORGI_OPS_BRANCH"
     file: '/templates/gitlab/ansible-run.yml'
-  - project: 'product-security/dev/component-registry-ops'
-    ref: "$CORGI_OPS_BRANCH"
-    file: '/templates/gitlab/sonarqube.yml'
+  - project: 'enterprise-pipelines/gitlab-ci/includes'
+    file: 'SAST/sonarqube.yml'
 
 .common_ci_setup: &common_ci_setup
   - export LANG=en_US.UTF-8
@@ -67,6 +66,10 @@ deploy-prod:
   except:
     refs:
       - schedules
+
+sonarqube:
+  # https://source.redhat.com/groups/public/sonarqubecorp/user_documentation/sonarqube_gitlab_ci_job_include
+  stage: test
 
 test:
   stage: test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,9 +2,19 @@
 # Fixing it would require running the SonarQube job after the test job
 # Which would slow down the pipeline quite a bit
 sonar.coverage.exclusions=**
+# Don't check tests for security bugs
 sonar.exclusions=tests/**
-sonar.projectKey=component-registry
-sonar.python.coverage.reportPaths=coverage.xml
+# Compare against "main" branch instead of "master"
+# sonar.newCode.referenceBranch=main
+# Upload scan results to below project in our team's namespace
+sonar.projectKey=psdevops:component-registry
+# Use coverage.xml for reporting, if we ever fix this
+# sonar.python.coverage.reportPaths=coverage.xml
+# Force Python3 compatibility to check for Python3-specific issues
 sonar.python.version=3
+# Wait for results and fail CI pipeline if scan finds new issues
 sonar.qualitygate.wait=true
+# Scan all files in repo, including scripts and config
 sonar.sources=.
+# Report how many unit tests we have
+sonar.tests=tests/


### PR DESCRIPTION
Update SonarQube settings after IT fixed an incorrect namespace for our project. Before, we couldn't assign issues to developers or mark them resolved. The new namespace fixes this issue by giving permissions to our team for all projects beginning with "psdevops:", but requires this update to our settings to actually use the new namespace for the component-registry SonarQube project.