### PR TITLE
Default to main branch reporting now that it's been scanned and exists

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.coverage.exclusions=**
 # Don't check tests for security bugs
 sonar.exclusions=tests/**
 # Compare against "main" branch instead of "master"
-# sonar.newCode.referenceBranch=main
+sonar.newCode.referenceBranch=main
 # Upload scan results to below project in our team's namespace
 sonar.projectKey=psdevops:component-registry
 # Use coverage.xml for reporting, if we ever fix this


### PR DESCRIPTION
Follow-up to previous PR that had to be done separately, due to some known SonarQube issues: https://github.com/RedHatProductSecurity/component-registry/pull/201