### PR TITLE
Revert "Default to main branch reporting now that it's been scanned and exists"

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,6 @@
 sonar.coverage.exclusions=**
 # Don't check tests for security bugs
 sonar.exclusions=tests/**
-# Compare against "main" branch instead of "master"
-sonar.newCode.referenceBranch=main
 # Upload scan results to below project in our team's namespace
 sonar.projectKey=psdevops:component-registry
 # Use coverage.xml for reporting, if we ever fix this


### PR DESCRIPTION
Reverts RedHatProductSecurity/component-registry#202 because this has to be managed in the SonarQube UI only, apparently. Scanning the main branch breaks if we enable this option in code.