### PR TITLE
CORGI-238 product manifest includes provided relationships

### DIFF
--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -1,3 +1,4 @@
+{# Used as the base of all manifest.json templates #}
 {
     "creationInfo": {
         "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",

--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -1,0 +1,28 @@
+{
+    "creationInfo": {
+        "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",
+        "creators": [
+            "Organization: Red Hat Product Security (secalert@redhat.com)"
+        ],
+        "licenseListVersion": "3.8"
+    },
+    "dataLicense": "CC-BY-4.0",
+    "documentDescribes": [
+        "SPDXRef-{{obj.uuid}}"
+    ],
+    "documentNamespace": "https://access.redhat.com/security/data/manifest/spdx/{{obj.name}}-{{obj.uuid}}",
+    "name": "{{obj.name}}",
+    "packages": [
+      {% block packages %}{% endblock %}
+    ],
+    "relationships": [
+       {% block relationships %}{% endblock %}
+       {
+          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes component being manifested #}
+          "relationshipType": "DESCRIBES",
+          "spdxElementId": "SPDXRef-DOCUMENT"
+       }
+    ],
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "spdxVersion": "SPDX-2.2"
+}

--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -18,7 +18,7 @@
     "relationships": [
        {% block relationships %}{% endblock %}
        {
-          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes component being manifested #}
+          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes stream or component being manifested #}
           "relationshipType": "DESCRIBES",
           "spdxElementId": "SPDXRef-DOCUMENT"
        }

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,64 +1,33 @@
-{
-    "creationInfo": {
-        "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",
-        "creators": [
-            "Organization: Red Hat Product Security (secalert@redhat.com)"
+{% extends "base_manifest.json" %}
+{% block packages %}
+{% for node in obj.get_provides_nodes %}
+        {% include "package_manifest.json" with component=node.obj %}
+    {% endfor %}
+    {
+        "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if obj.channels %}"{{obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
+        "externalRefs": [
+            {
+                "referenceCategory": "PACKAGE_MANAGER",
+                "referenceLocator": "{{obj.purl|safe}}",
+                "referenceType": "purl"
+            }
         ],
-        "licenseListVersion": "3.8"
-    },
-    "dataLicense": "CC-BY-4.0",
-    "documentDescribes": [
-        "SPDXRef-{{obj.uuid}}"
-    ],
-    "documentNamespace": "https://access.redhat.com/security/data/manifest/spdx/{{obj.name}}-{{obj.uuid}}",
-    "name": "{{obj.name}}",
-    "packages": [{% for node in obj.get_provides_nodes %}
-        {
-            "copyrightText": {% if node.obj.copyright_text %}"{{node.obj.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
-            "downloadLocation": {% if node.obj.channels %}"{{node.obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE_MANAGER",
-                    "referenceLocator": "{{node.purl|safe}}",
-                    "referenceType": "purl"
-                }
-            ],
-            "filesAnalyzed": false,
-            "homepage": {% if node.obj.related_url %}"{{node.obj.related_url}}"{% else %}"NOASSERTION"{% endif %},
-            "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-            "licenseConcluded": {% if node.obj.license_concluded %}"{{node.obj.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
-            "licenseDeclared": {% if node.obj.license_declared %}"{{node.obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-            "name": "{{node.obj.name}}",
-            "originator": "NOASSERTION",
-            "packageFileName": {% if node.obj.filename %}"{{node.obj.filename}}"{% else %}"NOASSERTION"{% endif %},
-            "SPDXID": "SPDXRef-{{node.obj.uuid}}",
-            "supplier": "Organization: Red Hat",
-            "versionInfo": "{{node.obj.nevra}}"
-        },{% endfor %}
-        {
-            "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
-            "downloadLocation": {% if obj.channels %}"{{obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE_MANAGER",
-                    "referenceLocator": "{{obj.purl|safe}}",
-                    "referenceType": "purl"
-                }
-            ],
-            "filesAnalyzed": false,
-            "homepage": {% if obj.related_url %}"{{obj.related_url}}"{% else %}"NOASSERTION"{% endif %},
-            "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-            "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
-            "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-            "name": "{{obj.name}}",
-            "originator": "NOASSERTION",
-            "packageFileName": {% if obj.filename %}"{{obj.filename}}"{% else %}"NOASSERTION"{% endif %},
-            "SPDXID": "SPDXRef-{{obj.uuid}}",
-            "supplier": "Organization: Red Hat",
-            "versionInfo": "{{obj.version}}"
-        }
-    ],
-    "relationships": [{% for node in obj.get_provides_nodes %}
+        "filesAnalyzed": false,
+        "homepage": {% if obj.related_url %}"{{obj.related_url}}"{% else %}"NOASSERTION"{% endif %},
+        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+        "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
+        "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+        "name": "{{obj.name}}",
+        "originator": "NOASSERTION",
+        "packageFileName": {% if obj.filename %}"{{obj.filename}}"{% else %}"NOASSERTION"{% endif %},
+        "SPDXID": "SPDXRef-{{obj.uuid}}",
+        "supplier": "Organization: Red Hat",
+        "versionInfo": "{{obj.version}}"
+    }
+{% endblock %}
+{% block relationships %}
+    {% for node in obj.get_provides_nodes %}
         {
           "relatedSpdxElement": "SPDXRef-{{node.obj.uuid}}",{# subcomponent is built from, or contained in, component #}
           "relationshipType": {% if node.type == "PROVIDES_DEV" %}"BUILD_DEPENDENCY_OF"{% else %}"CONTAINS"{% endif %},
@@ -69,12 +38,4 @@
           "relationshipType": "CONTAINS",
           "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
         },{% endfor %}
-        {
-          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes component being manifested #}
-          "relationshipType": "DESCRIBES",
-          "spdxElementId": "SPDXRef-DOCUMENT"
-        }
-    ],
-    "SPDXID": "SPDXRef-DOCUMENT",
-    "spdxVersion": "SPDX-2.2"
-}
+{% endblock %}

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -18,7 +18,7 @@
             "downloadLocation": {% if node.obj.channels %}"{{node.obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
             "externalRefs": [
                 {
-                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceCategory": "PACKAGE_MANAGER",
                     "referenceLocator": "{{node.purl|safe}}",
                     "referenceType": "purl"
                 }
@@ -40,7 +40,7 @@
             "downloadLocation": {% if obj.channels %}"{{obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
             "externalRefs": [
                 {
-                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceCategory": "PACKAGE_MANAGER",
                     "referenceLocator": "{{obj.purl|safe}}",
                     "referenceType": "purl"
                 }

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,3 +1,4 @@
+{# Component manifest #}
 {% extends "base_manifest.json" %}
 {% block packages %}
 {% for node in obj.get_provides_nodes %}

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -27,15 +27,5 @@
     }
 {% endblock %}
 {% block relationships %}
-    {% for node in obj.get_provides_nodes %}
-        {
-          "relatedSpdxElement": "SPDXRef-{{node.obj.uuid}}",{# subcomponent is built from, or contained in, component #}
-          "relationshipType": {% if node.type == "PROVIDES_DEV" %}"BUILD_DEPENDENCY_OF"{% else %}"CONTAINS"{% endif %},
-          "spdxElementId": "SPDXRef-{{obj.uuid}}"
-        },
-        {
-          "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
-          "relationshipType": "CONTAINS",
-          "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
-        },{% endfor %}
+    {% include "provided_relationships_manifest.json" with obj=obj %}
 {% endblock %}

--- a/corgi/web/templates/package_manifest.json
+++ b/corgi/web/templates/package_manifest.json
@@ -1,0 +1,22 @@
+{
+    "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
+    "downloadLocation": {% if component.channels %}"{{component.channels.0}}"{% else %}"NOASSERTION"{% endif %},
+    "externalRefs": [
+        {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "{{component.purl|safe}}",
+            "referenceType": "purl"
+        }
+    ],
+    "filesAnalyzed": false,
+    "homepage": {% if component.related_url %}"{{component.related_url}}"{% else %}"NOASSERTION"{% endif %},
+    "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+    "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
+    "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+    "name": "{{component.name}}",
+    "originator": "NOASSERTION",
+    "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
+    "SPDXID": "SPDXRef-{{component.uuid}}",
+    "supplier": "Organization: Red Hat",
+    "versionInfo": "{{component.nevra}}"
+}

--- a/corgi/web/templates/package_manifest.json
+++ b/corgi/web/templates/package_manifest.json
@@ -19,4 +19,4 @@
     "SPDXID": "SPDXRef-{{component.uuid}}",
     "supplier": "Organization: Red Hat",
     "versionInfo": "{{component.nevra}}"
-}
+},

--- a/corgi/web/templates/package_manifest.json
+++ b/corgi/web/templates/package_manifest.json
@@ -1,3 +1,4 @@
+{# Template for the SPDX package object #}
 {
     "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
     "downloadLocation": {% if component.channels %}"{{component.channels.0}}"{% else %}"NOASSERTION"{% endif %},

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,68 +1,40 @@
-{
-    "creationInfo": {
-        "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",
-        "creators": [
-            "Organization: Red Hat Product Security (secalert@redhat.com)"
+{% extends "base_manifest.json" %}
+{% block packages %}
+{% for component in obj.get_latest_components %}{# Below will eventually become component.manifest #}
+        {% include "package_manifest.json" with component=component %}
+        {% for provided in component.get_provides_nodes %}
+            {% include "package_manifest.json" with component=provided %}
+        {% endfor %}
+    {% endfor %}
+    {
+        "copyrightText": "NOASSERTION",
+        "downloadLocation": {% if obj.channels %}"{{obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
+        "externalRefs": [{% for cpe in obj.cpes %}
+            {
+                "referenceCategory": "SECURITY",
+                "referenceLocator": "{{cpe}}",
+                "referenceType": "cpe22Type"
+            },{% endfor %}
+            {{# We report ofuri since it can be used to link and compare two manifests for the same product, like CPE #}
+                "referenceCategory": "SECURITY",
+                "referenceLocator": "cpe:/{{obj.ofuri}}",
+                "referenceType": "cpe22Type"
+            }
         ],
-        "licenseListVersion": "3.8"
-    },
-    "dataLicense": "CC-BY-4.0",
-    "documentDescribes": [
-        "SPDXRef-{{obj.uuid}}"
-    ],
-    "documentNamespace": "https://access.redhat.com/security/data/manifest/spdx/{{obj.name}}-{{obj.uuid}}",
-    "name": "{{obj.name}}",
-    "packages": [{% for component in obj.get_latest_components %}{# Below will eventually become component.manifest #}
-        {
-            "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
-            "downloadLocation": {% if component.channels %}"{{component.channels.0}}"{% else %}"NOASSERTION"{% endif %},
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE_MANAGER",
-                    "referenceLocator": "{{component.purl|safe}}",
-                    "referenceType": "purl"
-                }
-            ],
-            "filesAnalyzed": false,
-            "homepage": {% if component.related_url %}"{{component.related_url}}"{% else %}"NOASSERTION"{% endif %},
-            "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-            "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
-            "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-            "name": "{{component.name}}",
-            "originator": "NOASSERTION",
-            "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
-            "SPDXID": "SPDXRef-{{component.uuid}}",
-            "supplier": "Organization: Red Hat",
-            "versionInfo": "{{component.nevra}}"
-        },{% endfor %}
-        {
-            "copyrightText": "NOASSERTION",
-            "downloadLocation": {% if obj.channels %}"{{obj.channels.0}}"{% else %}"NOASSERTION"{% endif %},
-            "externalRefs": [{% for cpe in obj.cpes %}
-                {
-                    "referenceCategory": "SECURITY",
-                    "referenceLocator": "{{cpe}}",
-                    "referenceType": "cpe22Type"
-                },{% endfor %}
-                {{# We report ofuri since it can be used to link and compare two manifests for the same product, like CPE #}
-                    "referenceCategory": "SECURITY",
-                    "referenceLocator": "cpe:/{{obj.ofuri}}",
-                    "referenceType": "cpe22Type"
-                }
-            ],
-            "filesAnalyzed": false,
-            "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
-            "licenseComments": "Red Hat cannot providing licensing information for products in our manifests at this time.",
-            "licenseConcluded": "NOASSERTION",
-            "licenseDeclared": "NOASSERTION",
-            "name": "{{obj.name}}",
-            "packageFileName": "NOASSERTION",
-            "SPDXID": "SPDXRef-{{obj.uuid}}",
-            "supplier": "Organization: Red Hat",
-            "versionInfo": "{{obj.version}}"
-        }
-    ],
-    "relationships": [{% for component in obj.get_latest_components %}
+        "filesAnalyzed": false,
+        "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
+        "licenseComments": "Red Hat cannot providing licensing information for products in our manifests at this time.",
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "name": "{{obj.name}}",
+        "packageFileName": "NOASSERTION",
+        "SPDXID": "SPDXRef-{{obj.uuid}}",
+        "supplier": "Organization: Red Hat",
+        "versionInfo": "{{obj.version}}"
+    }
+{% endblock %}
+{% block relationships %}
+    {% for component in obj.get_latest_components %}
         {
           "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
           "relationshipType": "PACKAGE_OF",
@@ -73,12 +45,4 @@
           "relationshipType": "CONTAINS",
           "spdxElementId": "SPDXRef-{{component.uuid}}"
         },{% endfor %}
-        {
-          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
-          "relationshipType": "DESCRIBES",
-          "spdxElementId": "SPDXRef-DOCUMENT"
-        }
-    ],
-    "SPDXID": "SPDXRef-DOCUMENT",
-    "spdxVersion": "SPDX-2.2"
-}
+{% endblock %}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -35,14 +35,11 @@
 {% endblock %}
 {% block relationships %}
     {% for component in obj.get_latest_components %}
+        {% include "provided_relationships_manifest.json" with obj=component %}
         {
           "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
           "relationshipType": "PACKAGE_OF",
           "spdxElementId": "SPDXRef-{{component.uuid}}"
         },
-        {
-          "relatedSpdxElement": "NONE",
-          "relationshipType": "CONTAINS",
-          "spdxElementId": "SPDXRef-{{component.uuid}}"
-        },{% endfor %}
+    {% endfor %}
 {% endblock %}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,3 +1,4 @@
+{# ProductModel manifest #}
 {% extends "base_manifest.json" %}
 {% block packages %}
 {% for component in obj.get_latest_components %}{# Below will eventually become component.manifest #}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -18,7 +18,7 @@
             "downloadLocation": {% if component.channels %}"{{component.channels.0}}"{% else %}"NOASSERTION"{% endif %},
             "externalRefs": [
                 {
-                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceCategory": "PACKAGE_MANAGER",
                     "referenceLocator": "{{component.purl|safe}}",
                     "referenceType": "purl"
                 }

--- a/corgi/web/templates/provided_relationships_manifest.json
+++ b/corgi/web/templates/provided_relationships_manifest.json
@@ -1,0 +1,11 @@
+{% for node in obj.get_provides_nodes %}
+    {
+      "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# subcomponent is built from, or contained in, component #}
+      "relationshipType": {% if node.type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
+      "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
+    },
+    {
+      "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
+    },{% endfor %}

--- a/tests/data/spdx-22-spec.json
+++ b/tests/data/spdx-22-spec.json
@@ -1,0 +1,722 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$id" : "http://spdx.org/rdf/terms",
+  "title" : "SPDX 2.2",
+  "type" : "object",
+  "properties" : {
+    "SPDXID" : {
+      "type" : "string",
+      "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+    },
+    "annotations" : {
+      "description" : "Provide additional information about an SpdxElement.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "annotationDate" : {
+            "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+            "type" : "string"
+          },
+          "annotationType" : {
+            "description" : "Type of the annotation.",
+            "type" : "string",
+            "enum" : [ "OTHER", "REVIEW" ]
+          },
+          "annotator" : {
+            "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+            "type" : "string"
+          },
+          "comment" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+        "additionalProperties" : false,
+        "description" : "An Annotation is a comment on an SpdxItem by an agent."
+      }
+    },
+    "comment" : {
+      "type" : "string"
+    },
+    "creationInfo" : {
+      "type" : "object",
+      "properties" : {
+        "comment" : {
+          "type" : "string"
+        },
+        "created" : {
+          "description" : "Identify when the SPDX file was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard. This field is distinct from the fields in section 8, which involves the addition of information during a subsequent review.",
+          "type" : "string"
+        },
+        "creators" : {
+          "description" : "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+          "minItems" : 1,
+          "type" : "array",
+          "items" : {
+            "description" : "Identify who (or what, in the case of a tool) created the SPDX file. If the SPDX file was created by an individual, indicate the person's name. If the SPDX file was created on behalf of a company or organization, indicate the entity name. If the SPDX file was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate.",
+            "type" : "string"
+          }
+        },
+        "licenseListVersion" : {
+          "description" : "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created.",
+          "type" : "string"
+        }
+      },
+      "required" : [ "created", "creators" ],
+      "additionalProperties" : false,
+      "description" : "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."
+    },
+    "dataLicense" : {
+      "description" : "License expression for dataLicense.  Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.",
+      "type" : "string"
+    },
+    "externalDocumentRefs" : {
+      "description" : "Identify any external SPDX documents referenced within this SPDX document.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "checksum" : {
+            "type" : "object",
+            "properties" : {
+              "algorithm" : {
+                "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                "type" : "string",
+                "enum" : [ "SHA256", "SHA1", "SHA384", "MD2", "MD4", "SHA512", "MD6", "MD5", "SHA224" ]
+              },
+              "checksumValue" : {
+                "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "algorithm", "checksumValue" ],
+            "additionalProperties" : false,
+            "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+          },
+          "externalDocumentId" : {
+            "description" : "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document.",
+            "type" : "string"
+          },
+          "spdxDocument" : {
+            "description" : "SPDX ID for SpdxDocument.  A property containing an SPDX document.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "checksum", "externalDocumentId", "spdxDocument" ],
+        "additionalProperties" : false,
+        "description" : "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."
+      }
+    },
+    "hasExtractedLicensingInfos" : {
+      "description" : "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument.",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "crossRefs" : {
+            "description" : "Cross Reference Detail for a license SeeAlso URL",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "isLive" : {
+                  "description" : "Indicate a URL is still a live accessible location on the public internet",
+                  "type" : "boolean"
+                },
+                "isValid" : {
+                  "description" : "True if the URL is a valid well formed URL",
+                  "type" : "boolean"
+                },
+                "isWayBackLink" : {
+                  "description" : "True if the License SeeAlso URL points to a Wayback archive",
+                  "type" : "boolean"
+                },
+                "match" : {
+                  "description" : "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text.",
+                  "type" : "string"
+                },
+                "order" : {
+                  "description" : "The ordinal order of this element within a list",
+                  "type" : "integer"
+                },
+                "timestamp" : {
+                  "description" : "Timestamp",
+                  "type" : "string"
+                },
+                "url" : {
+                  "description" : "URL Reference",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "url" ],
+              "additionalProperties" : false,
+              "description" : "Cross reference details for the a URL reference"
+            }
+          },
+          "extractedText" : {
+            "description" : "Verbatim license or licensing notice text that was discovered.",
+            "type" : "string"
+          },
+          "licenseId" : {
+            "description" : "A human readable short form license identifier for a license. The license ID is either on the standard license list or the form \"LicenseRef-\"[idString] where [idString] is a unique string containing letters, numbers, \".\", \"-\" or \"+\".",
+            "type" : "string"
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "seeAlsos" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "extractedText", "licenseId" ],
+        "additionalProperties" : false,
+        "description" : "An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."
+      }
+    },
+    "name" : {
+      "description" : "Identify name of this SpdxElement.",
+      "type" : "string"
+    },
+    "revieweds" : {
+      "description" : "Reviewed",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "comment" : {
+            "type" : "string"
+          },
+          "reviewDate" : {
+            "description" : "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator.",
+            "type" : "string"
+          },
+          "reviewer" : {
+            "description" : "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "reviewDate" ],
+        "additionalProperties" : false
+      }
+    },
+    "spdxVersion" : {
+      "description" : "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made.",
+      "type" : "string"
+    },
+    "documentNamespace" : {
+      "type" : "string",
+      "description" : "The URI provides an unambiguous mechanism for other SPDX documents to reference SPDX elements within this SPDX document."
+    },
+    "documentDescribes" : {
+      "description" : "Packages, files and/or Snippets described by this SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "description" : "SPDX ID for each Package, File, or Snippet."
+      }
+    },
+    "packages" : {
+      "description" : "Packages referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "checksums" : {
+            "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "algorithm" : {
+                  "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                  "type" : "string",
+                  "enum" : [ "SHA256", "SHA1", "SHA384", "MD2", "MD4", "SHA512", "MD6", "MD5", "SHA224" ]
+                },
+                "checksumValue" : {
+                  "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "algorithm", "checksumValue" ],
+              "additionalProperties" : false,
+              "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the Package or File.",
+            "type" : "string"
+          },
+          "description" : {
+            "description" : "Provides a detailed description of the package.",
+            "type" : "string"
+          },
+          "downloadLocation" : {
+            "description" : "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively.",
+            "type" : "string"
+          },
+          "externalRefs" : {
+            "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "comment" : {
+                  "type" : "string"
+                },
+                "referenceCategory" : {
+                  "description" : "Category for the external reference",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "PERSISTENT_ID", "SECURITY", "PACKAGE_MANAGER" ]
+                },
+                "referenceLocator" : {
+                  "description" : "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>.",
+                  "type" : "string"
+                },
+                "referenceType" : {
+                  "description" : "Type of the external reference. These are definined in an appendix in the SPDX specification.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "referenceCategory", "referenceLocator", "referenceType" ],
+              "additionalProperties" : false,
+              "description" : "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."
+            }
+          },
+          "filesAnalyzed" : {
+            "description" : "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files.",
+            "type" : "boolean"
+          },
+          "hasFiles" : {
+            "description" : "Indicates that a particular file belongs to a package.",
+            "type" : "array",
+            "items" : {
+              "description" : "SPDX ID for File.  Indicates that a particular file belongs to a package.",
+              "type" : "string"
+            }
+          },
+          "homepage" : {
+            "type" : "string"
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+            "type" : "string"
+          },
+          "licenseDeclared" : {
+            "description" : "License expression for licenseDeclared.  The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist.",
+            "type" : "string"
+          },
+          "licenseInfoFromFiles" : {
+            "description" : "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoFromFiles.  The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.",
+              "type" : "string"
+            }
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "originator" : {
+            "description" : "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          },
+          "packageFileName" : {
+            "description" : "The base name of the package file name. For example, zlib-1.2.5.tar.gz.",
+            "type" : "string"
+          },
+          "packageVerificationCode" : {
+            "type" : "object",
+            "properties" : {
+              "packageVerificationCodeExcludedFiles" : {
+                "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                "type" : "array",
+                "items" : {
+                  "description" : "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files.",
+                  "type" : "string"
+                }
+              },
+              "packageVerificationCodeValue" : {
+                "description" : "The actual package verification code as a hex encoded value.",
+                "type" : "string"
+              }
+            },
+            "required" : [ "packageVerificationCodeValue" ],
+            "additionalProperties" : false,
+            "description" : "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."
+          },
+          "sourceInfo" : {
+            "description" : "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source.",
+            "type" : "string"
+          },
+          "summary" : {
+            "description" : "Provides a short description of the package.",
+            "type" : "string"
+          },
+          "supplier" : {
+            "description" : "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax.",
+            "type" : "string"
+          },
+          "versionInfo" : {
+            "description" : "Provides an indication of the version of the package that is described by this SpdxDocument.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "copyrightText", "downloadLocation", "licenseConcluded", "licenseDeclared", "name" ],
+        "additionalProperties" : false
+      }
+    },
+    "files" : {
+      "description" : "Files referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "artifactOfs" : {
+            "description" : "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats.",
+            "type" : "array",
+            "items" : {
+              "type" : "object"
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "checksums" : {
+            "description" : "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed.",
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "algorithm" : {
+                  "description" : "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time.",
+                  "type" : "string",
+                  "enum" : [ "SHA256", "SHA1", "SHA384", "MD2", "MD4", "SHA512", "MD6", "MD5", "SHA224" ]
+                },
+                "checksumValue" : {
+                  "description" : "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm.",
+                  "type" : "string"
+                }
+              },
+              "required" : [ "algorithm", "checksumValue" ],
+              "additionalProperties" : false,
+              "description" : "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the Package or File.",
+            "type" : "string"
+          },
+          "fileContributors" : {
+            "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content.",
+              "type" : "string"
+            }
+          },
+          "fileDependencies" : {
+            "type" : "array",
+            "items" : {
+              "description" : "SPDX ID for File",
+              "type" : "string"
+            }
+          },
+          "fileName" : {
+            "description" : "The name of the file relative to the root of the package.",
+            "type" : "string"
+          },
+          "fileTypes" : {
+            "description" : "The type of the file.",
+            "type" : "array",
+            "items" : {
+              "description" : "The type of the file.",
+              "type" : "string",
+              "enum" : [ "OTHER", "DOCUMENTATION", "IMAGE", "VIDEO", "ARCHIVE", "SPDX", "APPLICATION", "SOURCE", "BINARY", "TEXT", "AUDIO" ]
+            }
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+            "type" : "string"
+          },
+          "licenseInfoInFiles" : {
+            "description" : "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoInFile.  Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.",
+              "type" : "string"
+            }
+          },
+          "noticeText" : {
+            "description" : "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "checksums", "copyrightText", "fileName", "licenseConcluded", "licenseInfoInFiles" ],
+        "additionalProperties" : false
+      }
+    },
+    "snippets" : {
+      "description" : "Snippets referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "SPDXID" : {
+            "type" : "string",
+            "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."
+          },
+          "annotations" : {
+            "description" : "Provide additional information about an SpdxElement.",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "annotationDate" : {
+                  "description" : "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard.",
+                  "type" : "string"
+                },
+                "annotationType" : {
+                  "description" : "Type of the annotation.",
+                  "type" : "string",
+                  "enum" : [ "OTHER", "REVIEW" ]
+                },
+                "annotator" : {
+                  "description" : "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document.",
+                  "type" : "string"
+                },
+                "comment" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "annotationDate", "annotationType", "annotator", "comment" ],
+              "additionalProperties" : false,
+              "description" : "An Annotation is a comment on an SpdxItem by an agent."
+            }
+          },
+          "attributionTexts" : {
+            "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+            "type" : "array",
+            "items" : {
+              "description" : "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce.",
+              "type" : "string"
+            }
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "copyrightText" : {
+            "description" : "The text of copyright declarations recited in the Package or File.",
+            "type" : "string"
+          },
+          "licenseComments" : {
+            "description" : "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen.",
+            "type" : "string"
+          },
+          "licenseConcluded" : {
+            "description" : "License expression for licenseConcluded.  The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the package.",
+            "type" : "string"
+          },
+          "licenseInfoInSnippets" : {
+            "description" : "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+            "type" : "array",
+            "items" : {
+              "description" : "License expression for licenseInfoInSnippet.  Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.",
+              "type" : "string"
+            }
+          },
+          "name" : {
+            "description" : "Identify name of this SpdxElement.",
+            "type" : "string"
+          },
+          "ranges" : {
+            "description" : "This field defines the byte range in the original host file (in X.2) that the snippet information applies to",
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "endPointer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "reference" : {
+                      "description" : "SPDX ID for File",
+                      "type" : "string"
+                    },
+                    "offset" : {
+                      "type" : "integer",
+                      "description" : "Byte offset in the file"
+                    },
+                    "lineNumber" : {
+                      "type" : "integer",
+                      "description" : "line number offset in the file"
+                    }
+                  },
+                  "required" : [ "reference" ],
+                  "additionalProperties" : false
+                },
+                "startPointer" : {
+                  "type" : "object",
+                  "properties" : {
+                    "reference" : {
+                      "description" : "SPDX ID for File",
+                      "type" : "string"
+                    },
+                    "offset" : {
+                      "type" : "integer",
+                      "description" : "Byte offset in the file"
+                    },
+                    "lineNumber" : {
+                      "type" : "integer",
+                      "description" : "line number offset in the file"
+                    }
+                  },
+                  "required" : [ "reference" ],
+                  "additionalProperties" : false
+                }
+              },
+              "required" : [ "endPointer", "startPointer" ],
+              "additionalProperties" : false
+            }
+          },
+          "snippetFromFile" : {
+            "description" : "SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).",
+            "type" : "string"
+          }
+        },
+        "required" : [ "SPDXID", "copyrightText", "licenseConcluded", "name", "ranges", "snippetFromFile" ],
+        "additionalProperties" : false
+      }
+    },
+    "relationships" : {
+      "description" : "Relationships referenced in the SPDX document",
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "spdxElementId" : {
+            "type" : "string",
+            "description" : "Id to which the SPDX element is related"
+          },
+          "comment" : {
+            "type" : "string"
+          },
+          "relatedSpdxElement" : {
+            "description" : "SPDX ID for SpdxElement.  A related SpdxElement.",
+            "type" : "string"
+          },
+          "relationshipType" : {
+            "description" : "Describes the type of relationship between two SPDX elements.",
+            "type" : "string",
+            "enum" : [ "VARIANT_OF", "COPY_OF", "PATCH_FOR", "TEST_DEPENDENCY_OF", "CONTAINED_BY", "DATA_FILE_OF", "OPTIONAL_COMPONENT_OF", "ANCESTOR_OF", "GENERATES", "CONTAINS", "OPTIONAL_DEPENDENCY_OF", "FILE_ADDED", "DEV_DEPENDENCY_OF", "DEPENDENCY_OF", "BUILD_DEPENDENCY_OF", "DESCRIBES", "PREREQUISITE_FOR", "HAS_PREREQUISITE", "PROVIDED_DEPENDENCY_OF", "DYNAMIC_LINK", "DESCRIBED_BY", "METAFILE_OF", "DEPENDENCY_MANIFEST_OF", "PATCH_APPLIED", "RUNTIME_DEPENDENCY_OF", "TEST_OF", "TEST_TOOL_OF", "DEPENDS_ON", "FILE_MODIFIED", "DISTRIBUTION_ARTIFACT", "AMENDS", "DOCUMENTATION_OF", "GENERATED_FROM", "STATIC_LINK", "OTHER", "BUILD_TOOL_OF", "TEST_CASE_OF", "PACKAGE_OF", "DESCENDANT_OF", "FILE_DELETED", "EXPANDED_FROM_ARCHIVE", "DEV_TOOL_OF", "EXAMPLE_OF" ]
+          }
+        },
+        "required" : [ "spdxElementId", "relatedSpdxElement", "relationshipType" ],
+        "additionalProperties" : false
+      }
+    }
+  },
+  "required" : [ "SPDXID", "creationInfo", "dataLicense", "name", "spdxVersion" ],
+  "additionalProperties" : false
+}

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -188,7 +188,7 @@ def setup_products_and_components():
         build_id=1,
         completion_time=datetime.strptime("2017-03-29 12:13:29 GMT+0000", "%Y-%m-%d %H:%M:%S %Z%z"),
     )
-    provided = ComponentFactory(type=Component.Type.RPM)
+    provided = ComponentFactory(type=Component.Type.RPM, arch="x86_64")
     dev_provided = ComponentFactory(type=Component.Type.NPM)
     component = SrpmComponentFactory(
         software_build=build,

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -38,13 +38,7 @@ def test_product_manifest_properties():
     # v2.2.2/schemas/spdx-schema.json
     with open("tests/data/spdx-22-spec.json", "r") as spec_file:
         schema = json.load(spec_file)
-    try:
-        jsonschema.validate(manifest, schema)
-    except jsonschema.exceptions.ValidationError as e:
-        print(e)
-        assert False
-
-    # Test will fail with JSONDecodeError if above isn't valid
+    jsonschema.validate(manifest, schema)
 
     # One component linked to this product
     num_components = len(stream.get_latest_components())
@@ -124,7 +118,7 @@ def test_product_manifest_properties():
 
 
 def test_component_manifest_properties():
-    """Test that all models inheriting from ProductModel have a .manifest property
+    """Test that all Components have a .manifest property
     And that it generates valid JSON."""
     component, _, provided, dev_provided = setup_products_and_components()
 
@@ -134,11 +128,7 @@ def test_component_manifest_properties():
     # v2.2.2/schemas/spdx-schema.json
     with open("tests/data/spdx-22-spec.json", "r") as spec_file:
         schema = json.load(spec_file)
-    try:
-        jsonschema.validate(manifest, schema)
-    except jsonschema.exceptions.ValidationError as e:
-        print(e)
-        assert False
+    jsonschema.validate(manifest, schema)
 
     num_provided = component.get_provides_nodes().count()
 


### PR DESCRIPTION
Include all the provided relationships for each root level component in the product manifests.

- Validates product and component manifest against [SPDX 2.2.2 schema](https://raw.githubusercontent.com/spdx/spdx-spec/development/v2.2.2/schemas/spdx-schema.json)
- Utilized django templates blocks and includes to avoid repeating ourselves (DRY)

@RedHatProductSecurity/corgi-devs 