### PR TITLE
CORGI-311 - set pg table specific autovacuum_vacuum_scale_factor

### DIFF
--- a/corgi/core/migrations/0042_autovacuum.py
+++ b/corgi/core/migrations/0042_autovacuum.py
@@ -1,0 +1,19 @@
+# set table specific pg autovacuum settings
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0041_alter_component_options"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "ALTER TABLE public.core_componentnode SET (autovacuum_vacuum_scale_factor=0.001);"
+        ),
+        migrations.RunSQL(
+            "ALTER TABLE public.core_component SET (autovacuum_vacuum_scale_factor=0.001);"
+        ),
+    ]


### PR DESCRIPTION
The component and componentnode tables undergo mutation activity during build ingestion and have a larger row count than any of the other tables ... so we treat them differently. 

The autovacuum_vacuum_scale_factor setting to a smaller factor ensures autovacuum runs more frequently ensuring queries (for COUNT) are efficient.

Note - once we move to Aurora it is expected that these settings may be adjusted.