### PR TITLE
Fix broken ci after maven purl changes

### DIFF
--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -39,7 +39,7 @@ class Syft:
             # We might consider more adding more sanitization if we accept ad-hoc source for scans
             scan_result = subprocess.check_output(  # nosec B603
                 [
-                    "/usr/local/bin/syft",
+                    "/usr/bin/syft",
                     "packages",
                     "-q",
                     "-o=syft-json",

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -297,7 +297,8 @@ def test_slow_software_composition_analysis(
     assert mock_syft.call_args_list == expected_syft_call_arg_list
     expected_component = Component.objects.get(purl=expected_purl)
     if is_container:
-        root_component = Component.objects.get(type=Component.Type.CONTAINER_IMAGE, arch="noarch", software_build=sb
+        root_component = Component.objects.get(
+            type=Component.Type.CONTAINER_IMAGE, arch="noarch", software_build=sb
         )
     else:
         root_component = Component.objects.srpms().get(software_build=sb)

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -270,7 +270,7 @@ def test_slow_software_composition_analysis(
     expected_syft_call_arg_list = [
         call(
             [
-                "/usr/local/bin/syft",
+                "/usr/bin/syft",
                 "packages",
                 "-q",
                 "-o=syft-json",
@@ -284,7 +284,7 @@ def test_slow_software_composition_analysis(
         expected_syft_call_arg_list.append(
             call(
                 [
-                    "/usr/local/bin/syft",
+                    "/usr/bin/syft",
                     "packages",
                     "-q",
                     "-o=syft-json",


### PR DESCRIPTION
Fixing failing black test on main branch.

I didn't realize earlier that the syft install location changed when I upgraded that library as well. Updating the syft command path now.