### PR TITLE
CORGI-334: Fix returning a datetime when a timedelta is expected

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -484,13 +484,12 @@ def fetch_modular_builds(relations_query: QuerySet, force_process: bool = False)
 
 def fetch_unprocessed_relations(
     relation_type: ProductComponentRelation.Type,
-    created_since: timedelta,
+    created_since: timezone.datetime,
     force_process: bool = False,
 ) -> int:
     relations_query = ProductComponentRelation.objects.filter(type=relation_type)
     if created_since:
-        created_during = timezone.now() - created_since
-        relations_query = relations_query.filter(created_at__gte=created_during)
+        relations_query = relations_query.filter(created_at__gte=created_since)
     # batch process to avoid exhausting the memory limit for the pod
     distinct_ids = relations_query.values_list("build_id", flat=True).distinct()
     relation_count = distinct_ids.count()
@@ -521,8 +520,9 @@ def fetch_unprocessed_relations(
 def fetch_unprocessed_brew_tag_relations(
     force_process: bool = False, created_since: int = 2
 ) -> int:
+    created_dt = timezone.now() - timedelta(days=created_since)
     return fetch_unprocessed_relations(
         ProductComponentRelation.Type.BREW_TAG,
         force_process=force_process,
-        created_since=timedelta(days=created_since),
+        created_since=created_dt,
     )

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -44,7 +44,7 @@ def fatal_code(e):
         return 400 <= e.response.status_code < 500 and e.response.status_code != 408
 
 
-def get_last_success_for_task(task_name):
+def get_last_success_for_task(task_name: str) -> timezone.datetime:
     """Return the timestamp of the last successful task so we can fetch updates since that time.
 
     For extra measure, the last success timestamp is offset by 30 minutes to overlap. If no record

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from celery_singleton import Singleton
 from django.conf import settings
+from django.utils import timezone
 
 from config.celery import app
 from corgi.collectors.pulp import Pulp
@@ -21,10 +22,11 @@ logger = logging.getLogger(__name__)
     soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
 def fetch_unprocessed_cdn_relations(force_process: bool = False, created_since: int = 8) -> int:
+    created_dt = timezone.now() - timedelta(days=created_since)
     return fetch_unprocessed_relations(
         ProductComponentRelation.Type.CDN_REPO,
         force_process=force_process,
-        created_since=timedelta(days=created_since),
+        created_since=created_dt,
     )
 
 

--- a/corgi/tasks/yum.py
+++ b/corgi/tasks/yum.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 from celery_singleton import Singleton
 from django.conf import settings
+from django.utils import timezone
 
 from config.celery import app
 from corgi.collectors.yum import Yum
@@ -27,13 +28,13 @@ logger = logging.getLogger(__name__)
 )
 def fetch_unprocessed_yum_relations(force_process: bool = False, created_since: int = 0) -> int:
     if created_since:
-        created_delta = timedelta(days=created_since)
+        created_dt = timezone.now() - timedelta(days=created_since)
     else:
-        created_delta = get_last_success_for_task("corgi.tasks.yum.fetch_unprocessed_yum_relations")
+        created_dt = get_last_success_for_task("corgi.tasks.yum.fetch_unprocessed_yum_relations")
     return fetch_unprocessed_relations(
         ProductComponentRelation.Type.YUM_REPO,
         force_process=force_process,
-        created_since=created_delta,
+        created_since=created_dt,
     )
 
 


### PR DESCRIPTION
@mprpic Quick review please. I made all the related code pass a datetime (instead of a timedelta) to fetch_unprocessed_relations, since other code that uses get_last_success_for_task expects it to return a timezone.

I didn't want to change get_last_success_for_task from what's implemented in SDEngine. But I could tweak get_last_success_for_task and its callers instead, if you think returning a timedelta there would be less invasive or more sensible.