### PR TITLE
expose productstream active param on api schema

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -4,7 +4,8 @@ import logging
 import django_filters.rest_framework
 from django.db import connection
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from mptt.templatetags.mptt_tags import cache_tree_children
 from packageurl import PackageURL
 from rest_framework import filters, status
@@ -296,6 +297,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
     queryset = ProductStream.objects.filter(active=True).order_by(ProductDataViewSet.ordering_field)
     serializer_class = ProductStreamSerializer
 
+    @extend_schema(parameters=[OpenApiParameter("active", OpenApiTypes.STR, OpenApiParameter.QUERY)])
     def list(self, request, *args, **kwargs):
         req = self.request
         active = request.query_params.get("active")

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -5,7 +5,7 @@ import django_filters.rest_framework
 from django.db import connection
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from mptt.templatetags.mptt_tags import cache_tree_children
 from packageurl import PackageURL
 from rest_framework import filters, status
@@ -297,7 +297,9 @@ class ProductStreamViewSetSet(ProductDataViewSet):
     queryset = ProductStream.objects.filter(active=True).order_by(ProductDataViewSet.ordering_field)
     serializer_class = ProductStreamSerializer
 
-    @extend_schema(parameters=[OpenApiParameter("active", OpenApiTypes.STR, OpenApiParameter.QUERY)])
+    @extend_schema(
+        parameters=[OpenApiParameter("active", OpenApiTypes.STR, OpenApiParameter.QUERY)]
+    )
     def list(self, request, *args, **kwargs):
         req = self.request
         active = request.query_params.get("active")
@@ -405,6 +407,13 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
             # No matching model instance found, or invalid ofuri
             return self.queryset
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("ofuri", OpenApiTypes.STR, OpenApiParameter.QUERY),
+            OpenApiParameter("view", OpenApiTypes.STR, OpenApiParameter.QUERY),
+            OpenApiParameter("purl", OpenApiTypes.STR, OpenApiParameter.QUERY),
+        ]
+    )
     def list(self, request, *args, **kwargs):
         # purl are stored with each segment url encoded as per the specification. The purl query
         # param here is url decoded, to ensure special characters such as '@' and '?'

--- a/openapi.yml
+++ b/openapi.yml
@@ -196,6 +196,10 @@ paths:
         schema:
           type: integer
       - in: query
+        name: ofuri
+        schema:
+          type: string
+      - in: query
         name: product_streams
         schema:
           type: string
@@ -213,6 +217,10 @@ paths:
           type: string
       - in: query
         name: provides
+        schema:
+          type: string
+      - in: query
+        name: purl
         schema:
           type: string
       - in: query
@@ -267,6 +275,10 @@ paths:
           type: string
       - in: query
         name: version
+        schema:
+          type: string
+      - in: query
+        name: view
         schema:
           type: string
       tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -402,6 +402,10 @@ paths:
       description: View for api/v1/product_streams
       parameters:
       - in: query
+        name: active
+        schema:
+          type: string
+      - in: query
         name: channels
         schema:
           type: string


### PR DESCRIPTION
I discovered this while testing the ops repo deptopia-reconcilication scripts. The bindings generated against the 1.1.0 schema failed with an error about the productstreams list endpoint not having an active parameter.