### PR TITLE
fix error with math on max processes we can handle in one day

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -346,7 +346,7 @@ SCA_SCRATCH_DIR = os.getenv("CORGI_SCA_SCATCH_DIR", "/tmp")
 
 # Maximum number of builds to process from the relations table in a single day
 # We don't load them all to avoid overloading Redis, see CORGI-346
-# The default value of 120,000 is based on a throughput of 10 tasks a minute,
-# and therefore 144,000 tasks a day. Allowing 24,000 ah-doc tasks to be scheduled in addition
-# to the 120,000 maximum limit requested from the relations table
-MAX_BUILDS_TO_PROCESS = int(os.getenv("CORGI_MAX_BUILDS_TO_PROCESS", "120000"))
+# The default value of 9,000 is based on a throughput of 8 tasks a minute,
+# and therefore 11,520 tasks a day. Allowing 1,520 ah-doc tasks to be scheduled in addition
+# to the 9,000 maximum limit requested from the relations table
+MAX_BUILDS_TO_PROCESS = int(os.getenv("CORGI_MAX_BUILDS_TO_PROCESS", "9000"))


### PR DESCRIPTION
In the last PR I over-allocated memory in the OpenShift environment which meant builds started failing. When reducing the number of workers to 8 to fix that I noticed that my math was out by a factor of 10, we can only process roughly 10,000 task a day with 8 workers, so fixing that here.