### PR TITLE
Add Celery debug pages

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "django.contrib.postgres",
     "django_celery_results",
     "django_celery_beat",

--- a/corgi/web/templates/app_status.html
+++ b/corgi/web/templates/app_status.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{# Only task-related view are Celery-dependent; modify below title if this is used anywhere else. #}
+{% block title %}Tasks{% endblock %}
+
+{% block body %}
+<h2 style="margin-left: 1em;">{{ msg }}</h2>
+{% endblock %}

--- a/corgi/web/templates/data.html
+++ b/corgi/web/templates/data.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}{% load humanize %}
+
+{% block title %}Home{% endblock %}
+
+{% block body %}
+<div class="container-fluid container-cards-pf">
+  <div class="row row-cards-pf">
+    <div class="col-xs-6 col-sm-4 col-md-4">
+      <div class="card-pf">
+        <div class="card-pf-body">
+          <h1 class="card-pf-title">
+            Cached Data
+          </h1>
+          <table class="table">
+            <caption>List of model names and total count of model objects</caption>
+            <thead>
+              <tr>
+                <th>Resource</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for resource, count in counts %}
+              <tr>
+                <td>{{ resource }}</td>
+                <td>{{ count|intcomma }}</td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td>No data cached...</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div><!-- /row -->
+  </div><!-- /container -->
+</div>
+{% endblock %}

--- a/corgi/web/templates/index.html
+++ b/corgi/web/templates/index.html
@@ -3,6 +3,7 @@
 <div class="container-fluid">
   <hr/>
   <p>Corgi: <a href='/api/v1/'>API</a> | <a href='api/healthy'>Health</a> | <a href='/api/v1/status'>Status</a></p>
+  <p>Utils: <a href='/data'>Data</a> | <a href='tasks'>Available Tasks</a> | <a href='/tasks/running'>Running Tasks</a></p>
   <hr/>
   <p>Docs:  <a href='/api/v1/schema/docs'>API</a></p>
   <p>Schema: <a href='/api/v1/schema?format=json'>JSON</a>| <a href='api/v1/schema?format=yaml'>YAML</a></p>

--- a/corgi/web/templates/task_list.html
+++ b/corgi/web/templates/task_list.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+
+{% block title %}Tasks{% endblock %}
+
+{% block body %}
+<div class="container-fluid container-cards-pf">
+  <div class="row row-cards-pf">
+    <div class="col-md-12">
+      <div class="card-pf">
+        <div class="card-pf-body">
+          <h1 class="card-pf-title">
+            <span style="padding-right: 0.5em">Tasks</span>
+            {% if running %}
+            <span class="label label-info">Queued (fast): {{ fast_queue_len }}</span>
+            <span class="label label-info">Queued (slow): {{ slow_queue_len }}</span>
+            {% endif %}
+          </h1>
+          <table class="table">
+            <caption>List of running / scheduled tasks</caption>
+            <thead>
+              <tr>
+                 <th>Name</th>
+                {% if running %}
+                  <th>Args</th>
+                  <th>Kwargs</th>
+                  <th>Status</th>
+                  <th>Queue</th>
+                  <th>Started</th>
+                {% else %}
+                  <th>Description</th>
+                {% endif %}
+              </tr>
+            </thead>
+            <tbody>
+            {% for task in tasks %}
+              <tr>
+                <td>{{ task.name }}</td>
+                {% if running %}
+                  <td>{{ task.args }}</td>
+                  <td>{{ task.kwargs }}</td>
+                  <td>{{ task.status }}</td>
+                  <td>{{ task.delivery_info.routing_key }}</td>
+                  <td>{{ task.time_start }}</td>
+                {% else %}
+                  <td>{{ task.description }}</td>
+                {% endif %}
+              </tr>
+            {% empty %}
+              <tr><td>No Tasks found...</td></tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/corgi/web/urls.py
+++ b/corgi/web/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
 
-from .views import home
+from .views import data_list, home, running_tasks, tasks_list
 
 urlpatterns = [
     # v1 API
-    path("", home)
+    path("", home),
+    path("data", data_list),
+    path("tasks", tasks_list),
+    path("tasks/running", running_tasks),
 ]

--- a/corgi/web/views.py
+++ b/corgi/web/views.py
@@ -1,6 +1,162 @@
+from functools import wraps
+
+import redis
+from django.apps import apps
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.http import require_safe
+
+from config.celery import app as celery_app
+
+CELERY_WORKERS: list = []
+CELERY_WORKERS_LAST_REFRESH = timezone.now().timestamp()
+CELERY_WORKERS_REFRESH_PERIOD = 900  # Once every 15 minutes refresh list of workers
+
+
+def inspect_celery():
+    """Return the Celery inspect object."""
+    return celery_app.control.inspect(CELERY_WORKERS)
+
+
+def check_app_status(func):
+    """Check if Redis is up; if it is, check if Celery workers are up."""
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        r = redis.Redis.from_url(settings.CELERY_BROKER_URL)
+        try:
+            r.ping()
+        except redis.ConnectionError:
+            return render(
+                args[0],  # Response object
+                "app_status.html",
+                {"msg": "Redis message broker is not running..."},
+            )
+
+        global CELERY_WORKERS
+        global CELERY_WORKERS_LAST_REFRESH
+
+        # If we are due to refresh - wipe the list of workers to force full refresh
+        if timezone.now().timestamp() - CELERY_WORKERS_LAST_REFRESH > CELERY_WORKERS_REFRESH_PERIOD:
+            CELERY_WORKERS = []
+            CELERY_WORKERS_LAST_REFRESH = timezone.now().timestamp()
+
+        i = inspect_celery()
+        # This is much faster if CELERY_WORKERS is set to current set of worker names
+        ping_replies = i.ping()
+        if (
+            not ping_replies
+            or len(ping_replies) < len(CELERY_WORKERS)
+            or not all([r["ok"] == "pong" for r in ping_replies.values()])
+        ):
+            # Reset worker list - maybe they were redeployed?
+            CELERY_WORKERS = []
+            CELERY_WORKERS_LAST_REFRESH = timezone.now().timestamp()
+            return render(
+                args[0],  # Response object
+                "app_status.html",
+                {"msg": "Celery workers are not running..."},
+            )
+
+        # Update list of current workers
+        CELERY_WORKERS = list(ping_replies.keys())
+        return func(*args, **kwargs)
+
+    return wrapped
+
+
+@require_safe
+def data_list(request: HttpRequest) -> HttpResponse:
+    """Renders a count of all cached resources in the DB."""
+    models = sorted(
+        apps.get_app_config("core").get_models(),
+        key=lambda model: model._meta.verbose_name,  # type: ignore
+    )
+    return render(
+        request,
+        "data.html",
+        {
+            "counts": [
+                (model._meta.verbose_name_plural, model.objects.count()) for model in models
+            ],
+            "nbar": "data",  # Navbar identifier
+        },
+    )
+
+
+@check_app_status
+@require_safe
+def tasks_list(request):
+    inspect = inspect_celery()
+    tasks = []
+    for task in inspect.registered("__doc__")[CELERY_WORKERS[0]]:
+        task_name, _, desc = task.partition(" ")
+        desc = (
+            desc.replace("[__doc__=", "").rstrip("]").replace("\n", "").strip() if desc else "N/A"
+        )
+        tasks.append({"name": task_name, "description": desc})
+
+    return render(
+        request,
+        "task_list.html",
+        {
+            "tasks": sorted(tasks, key=lambda x: x["name"]),
+            "running": False,
+            "nbar": "scheduleable_tasks",
+        },
+    )
+
+
+@check_app_status
+@require_safe
+def running_tasks(request):
+    def add_tasks(ret, task_dict, status, scheduled=False):
+        for worker in task_dict:
+            for task in task_dict[worker]:
+                if scheduled:
+                    # There's another level of nesting for scheduled tasks.
+                    task = task["request"]
+
+                task["status"] = status
+                if task.get("time_start"):
+                    task["time_start"] = timezone.datetime.utcfromtimestamp(task["time_start"])
+                ret.append(task)
+        # Return None to implicitly indicate ret (list of tasks) was mutated
+
+    inspect = inspect_celery()
+    tasks = []  # A list of task dicts
+    add_tasks(tasks, inspect.active(), "running")
+    add_tasks(tasks, inspect.reserved(), "pending")
+    add_tasks(tasks, inspect.scheduled(), "scheduled", scheduled=True)
+    # Sort the list of tasks so they don't jump around each time the display view is refreshed
+    # Based on status (to match existing behavior) and name
+    # Then start time for running tasks with same name
+    # And args / kwargs for pending tasks with same name but no start time
+    unstarted_task_datetime = timezone.datetime.utcfromtimestamp(0)
+    tasks = sorted(
+        tasks,
+        key=lambda x: (
+            x["status"],
+            x["name"],
+            x.get("time_start", unstarted_task_datetime),
+            x["args"],
+            x["kwargs"],
+        ),
+    )
+    r = redis.Redis.from_url(settings.CELERY_BROKER_URL)
+    return render(
+        request,
+        "task_list.html",
+        {
+            "fast_queue_len": r.llen("fast"),
+            "slow_queue_len": r.llen("slow"),
+            "tasks": tasks,
+            "running": True,
+            "nbar": "running_tasks",
+        },
+    )
 
 
 @require_safe


### PR DESCRIPTION
@jasinner @mprpic  I remembered we added this Celery rate limit setting about 5 minutes before I was supposed to go to sleep. Oh well :smile: 

Jason mentioned "about 8 tasks per minute" is how fast things ran while he was testing...which is exactly what this Celery task rate limit was set to. The comment that "both Brew and SCA tasks take about the same amount of time to finish" also made me suspicious, which eventually jogged my memory about this setting. So thanks for that!

Feel free to click the merge button here, push new commits, or just close if we don't want to do this. I won't touch this branch again. We could merge this as-is, or deploy to stage without merging and see if it actually makes a difference. Although I'd be very suprised if it didn't help. We could also keep the setting instead of completely removing it, and just set it to some higher value.

You can also set or override the rate limit on individual tasks using the task decorator, like we do in other tools:
```
# AKA 36/m across all 6 slow workers
# AKA 3/5s
@app.task(rate_limit="6/m")
```

EDIT: Jason's other MR has the rate limit fix, so I tweaked this one to be just the debug pages. They're useful for me when loading data locally and don't hurt anything, so I might merge this if there's no strong opinions. Will let sit for another day or so.