### PR TITLE
fix celery worker name so that shared liveness probes work in k8s

### DIFF
--- a/run_celery_fast.sh
+++ b/run_celery_fast.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/fast.pid) already exists.
 rm -f /tmp/fast.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -Q fast -P eventlet -n celery-fast@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -Q fast -P eventlet -n celery@%h

--- a/run_celery_slow.sh
+++ b/run_celery_slow.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/slow.pid) already exists.
 rm -f /tmp/slow.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -Q slow,fast -n celery-slow@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -Q slow,fast -n celery@%h


### PR DESCRIPTION
liveness probes a failing consistently on stage. I think it's because I changed the destination names.