### PR TITLE
Stop sending emails for app-level errors, only alert for Django ones

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -195,7 +195,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {"handlers": ["console"], "level": "WARNING"},
-        "corgi": {"handlers": ["console", "mail_admins"], "level": "INFO", "propagate": False},
+        "corgi": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }
 


### PR DESCRIPTION
Quick fix for email spam overnight - if this doesn't actually fix it I'll just remove the logging.