### PR TITLE
Draft: Fix eventlet workers

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -274,6 +274,10 @@ CELERY_RESULT_EXPIRES = None
 CELERY_TASK_ROUTES = (
     [
         ("corgi.tasks.*.slow_*", {"queue": "slow"}),  # Any module's slow_* tasks go to 'slow' queue
+        (
+            "corgi.tasks.*.eventlet_*",
+            {"queue": "eventlet"},
+        ),  # Any module's eventlet_* tasks go to 'eventlet' queue
         ("*", {"queue": "fast"}),  # default other tasks go to 'fast'
     ],
 )

--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -7,7 +7,7 @@ from proton import Event, SSLDomain
 from proton.handlers import MessagingHandler
 from proton.reactor import Container, Selector
 
-from corgi.tasks.brew import fetch_brew_build
+from corgi.tasks.brew import eventlet_fetch_brew_build
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +62,10 @@ class UMBReceiverHandler(MessagingHandler):
         build_id = message["info"]["build_id"]
 
         try:
-            fetch_brew_build.apply_async(args=(build_id,))
+            eventlet_fetch_brew_build.apply_async(args=(build_id,))
         except Exception as exc:
             logger.error(
-                "Failed to schedule fetch_brew_build task for build ID %s: %s",
+                "Failed to schedule eventlet_fetch_brew_build task for build ID %s: %s",
                 build_id,
                 str(exc),
             )

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -18,14 +18,16 @@ from corgi.core.models import (
     SoftwareBuild,
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
-from corgi.tasks.errata_tool import load_errata
+from corgi.tasks.errata_tool import slow_load_errata
 from corgi.tasks.sca import slow_software_composition_analysis
 
 logger = logging.getLogger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def fetch_brew_build(build_id: int, save_product: bool = True, force_process: bool = False):
+def eventlet_fetch_brew_build(
+    build_id: int, save_product: bool = True, force_process: bool = False
+):
     logger.info("Fetch brew build called with build id: %s", build_id)
     try:
         softwarebuild = SoftwareBuild.objects.get(build_id=build_id)
@@ -95,7 +97,7 @@ def fetch_brew_build(build_id: int, save_product: bool = True, force_process: bo
     for c in component.get("components", []):
         save_component(c, root_node, softwarebuild)
 
-    # We don't call save_product_taxonomy by default to allow async call of load_errata task
+    # We don't call save_product_taxonomy by default to allow async call of slow_load_errata task
     # See CORGI-21
     if save_product:
         softwarebuild.save_product_taxonomy()
@@ -106,16 +108,16 @@ def fetch_brew_build(build_id: int, save_product: bool = True, force_process: bo
         logger.info("no errata tags")
     else:
         if isinstance(build_meta["errata_tags"], str):
-            load_errata.delay(build_meta["errata_tags"])
+            slow_load_errata.delay(build_meta["errata_tags"])
         else:
             for e in build_meta["errata_tags"]:
-                load_errata.delay(e)
+                slow_load_errata.delay(e)
 
     build_ids = component.get("nested_builds", ())
     logger.info("Fetching brew builds for %s", build_ids)
     for b_id in build_ids:
         logger.info("Requesting fetch of nested build: %s", b_id)
-        fetch_brew_build.delay(b_id)
+        eventlet_fetch_brew_build.delay(b_id)
 
     logger.info("Requesting software composition analysis for %s", build_id)
     slow_software_composition_analysis.delay(build_id)
@@ -124,13 +126,13 @@ def fetch_brew_build(build_id: int, save_product: bool = True, force_process: bo
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def fetch_modular_build(build_id: str, force_process: bool = False) -> None:
+def slow_fetch_modular_build(build_id: str, force_process: bool = False) -> None:
     logger.info("Fetch modular build called with build id: %s", build_id)
     rhel_module_data = Brew.fetch_rhel_module(build_id)
     # Some compose build_ids in the relations table will be for SRPMs, skip those here
     if not rhel_module_data:
         logger.info("No module data fetched for build %s from Brew, exiting...", build_id)
-        fetch_brew_build.delay(int(build_id), force_process=force_process)
+        eventlet_fetch_brew_build.delay(int(build_id), force_process=force_process)
         return
     # TODO: Should we use update_or_create here?
     #  We don't currently handle reprocessing a modular build
@@ -142,13 +144,13 @@ def fetch_modular_build(build_id: str, force_process: bool = False) -> None:
         version=rhel_module_data["meta"]["version"],
         release=rhel_module_data["meta"]["release"],
         defaults={
-            # This gives us an indication as to which task (this or fetch_brew_build)
+            # This gives us an indication as to which task (this or eventlet_fetch_brew_build)
             # last processed the module
             "meta_attr": rhel_module_data["analysis_meta"],
         },
     )
-    # This should result in a lookup if fetch_brew_build has already processed this module.
-    # Likewise if fetch_brew_build processes the module subsequently we should not create
+    # This should result in a lookup if eventlet_fetch_brew_build has already processed this module.
+    # Likewise if eventlet_fetch_brew_build processes the module subsequently we should not create
     # a new ComponentNode, instead the same one will be looked up and used as the root node
     node, _ = obj.cnodes.get_or_create(
         type=ComponentNode.ComponentNodeType.SOURCE,
@@ -164,9 +166,9 @@ def fetch_modular_build(build_id: str, force_process: bool = False) -> None:
         # to the RPM components. We don't link the SRPM into the tree because some of it's RPMs
         # might not be included in the module
         if "brew_build_id" in c:
-            fetch_brew_build.delay(c["brew_build_id"])
+            eventlet_fetch_brew_build.delay(c["brew_build_id"])
         save_component(c, node)
-    fetch_brew_build.delay(int(build_id), force_process=force_process)
+    eventlet_fetch_brew_build.delay(int(build_id), force_process=force_process)
     logger.info("Finished fetching modular build: %s", build_id)
 
 
@@ -478,7 +480,7 @@ def load_brew_tags() -> None:
 
 def fetch_modular_builds(relations_query: QuerySet, force_process: bool = False) -> None:
     for build_id in relations_query:
-        fetch_modular_build.delay(build_id, force_process=force_process)
+        slow_fetch_modular_build.delay(build_id, force_process=force_process)
 
 
 def fetch_unprocessed_relations(
@@ -498,7 +500,7 @@ def fetch_unprocessed_relations(
             continue
         if not SoftwareBuild.objects.filter(build_id=int(build_id)).exists():
             logger.info("Processing CDN relation build with id: %s", build_id)
-            fetch_modular_build.delay(build_id, force_process=force_process)
+            slow_fetch_modular_build.delay(build_id, force_process=force_process)
             processed_builds += 1
     return processed_builds
 

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -28,8 +28,8 @@ def load_et_products() -> None:
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def save_errata_product_taxonomy(erratum_id: int):
-    logger.info(f"save_errata_product_taxonomy called for {erratum_id}")
+def slow_save_errata_product_taxonomy(erratum_id: int):
+    logger.info(f"slow_save_errata_product_taxonomy called for {erratum_id}")
     relation_build_ids = _get_relation_build_ids(erratum_id)
     for b in relation_build_ids:
         logger.info("Saving product taxonomy for build %s", b)
@@ -39,7 +39,7 @@ def save_errata_product_taxonomy(erratum_id: int):
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def load_errata(erratum_name):
+def slow_load_errata(erratum_name):
     et = ErrataTool()
     if not erratum_name.isdigit():
         erratum_id = et.normalize_erratum_id(erratum_name)
@@ -76,8 +76,8 @@ def load_errata(erratum_name):
     # If the number of relations was more than 0 check if we've processed all the builds
     # in the errata
     elif len(relation_build_ids) == no_of_processed_builds:
-        logger.info(f"Calling save_errata_product_taxonomy for {erratum_id}")
-        save_errata_product_taxonomy.delay(erratum_id)
+        logger.info(f"Calling slow_save_errata_product_taxonomy for {erratum_id}")
+        slow_save_errata_product_taxonomy.delay(erratum_id)
 
     # Check if we are only part way through loading the errata
     if no_of_processed_builds < len(relation_build_ids):
@@ -89,10 +89,10 @@ def load_errata(erratum_name):
             # We set save_product argument to False because it reads from the
             # ProductComponentRelations table which this function writes to. We've seen contention
             # on this database table causes by recursive looping of this task, and the
-            # fetch_brew_build task, eg CORGI-21. We call save_product_taxonomy from
+            # eventlet_fetch_brew_build task, eg CORGI-21. We call save_product_taxonomy from
             # this task only after all the builds in the errata have been loaded instead.
-            logger.info("Calling fetch_brew_build for %s", build_id)
-            app.send_task("corgi.tasks.brew.fetch_brew_build", args=[build_id, False])
+            logger.info("Calling eventlet_fetch_brew_build for %s", build_id)
+            app.send_task("corgi.tasks.brew.eventlet_fetch_brew_build", args=[build_id, False])
     else:
         logger.info("Finished processing %s", erratum_id)
 

--- a/corgi/tasks/management/commands/loadbrewdata.py
+++ b/corgi/tasks/management/commands/loadbrewdata.py
@@ -5,7 +5,10 @@ from koji import GenericError
 
 from corgi.collectors.brew import Brew
 from corgi.core.models import ProductStream
-from corgi.tasks.brew import fetch_brew_build, fetch_unprocessed_brew_tag_relations
+from corgi.tasks.brew import (
+    eventlet_fetch_brew_build,
+    fetch_unprocessed_brew_tag_relations,
+)
 
 
 class Command(BaseCommand):
@@ -83,6 +86,6 @@ class Command(BaseCommand):
 
         for build_id in build_ids:
             if options["inline"]:
-                fetch_brew_build(build_id, force_process=options["force"])
+                eventlet_fetch_brew_build(build_id, force_process=options["force"])
             else:
-                fetch_brew_build.delay(build_id, force_process=options["force"])
+                eventlet_fetch_brew_build.delay(build_id, force_process=options["force"])

--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -2,7 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand, CommandParser
 
-from corgi.tasks.errata_tool import load_errata
+from corgi.tasks.errata_tool import slow_load_errata
 from corgi.tasks.pulp import update_cdn_repo_channels
 
 
@@ -36,9 +36,9 @@ class Command(BaseCommand):
             for erratum_id in errata_ids:
                 self.stdout.write(self.style.SUCCESS(f"Loading Errata {erratum_id}"))
                 if options["inline"]:
-                    load_errata(erratum_id)
+                    slow_load_errata(erratum_id)
                 else:
-                    load_errata.delay(erratum_id)
+                    slow_load_errata.delay(erratum_id)
         elif options["repos"]:
             self.stdout.write(self.style.SUCCESS("Loading channels"))
             if options["inline"]:

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -31,12 +31,12 @@ def setup_pulp_relations() -> None:
     for channel in Channel.objects.filter(type=Channel.Type.CDN_REPO):
         for pv_ofuri in channel.product_variants:
             pv = ProductVariant.objects.get(ofuri=pv_ofuri)
-            setup_pulp_rpm_relations.delay(channel.name, pv.name)
-            setup_pulp_module_relations.delay(channel.name, pv.name)
+            slow_setup_pulp_rpm_relations.delay(channel.name, pv.name)
+            slow_setup_pulp_module_relations.delay(channel.name, pv.name)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def setup_pulp_rpm_relations(channel, variant):
+def slow_setup_pulp_rpm_relations(channel, variant):
     srpm_build_ids = Pulp().get_rpm_data(channel)
     no_of_relations = _create_relations(
         srpm_build_ids, channel, variant, ProductComponentRelation.Type.CDN_REPO
@@ -46,7 +46,7 @@ def setup_pulp_rpm_relations(channel, variant):
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def setup_pulp_module_relations(channel, variant):
+def slow_setup_pulp_module_relations(channel, variant):
     module_build_ids = Pulp().get_module_data(channel)
     no_of_relations = _create_relations(
         module_build_ids, channel, variant, ProductComponentRelation.Type.CDN_REPO

--- a/corgi/tasks/rhel_compose.py
+++ b/corgi/tasks/rhel_compose.py
@@ -5,7 +5,7 @@ from celery_singleton import Singleton
 from config.celery import app
 from corgi.collectors.rhel_compose import RhelCompose
 from corgi.core.models import ProductComponentRelation, ProductStream, SoftwareBuild
-from corgi.tasks.brew import fetch_modular_build
+from corgi.tasks.brew import slow_fetch_modular_build
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, _create_relations
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,6 @@ def get_builds(
             continue
         if not SoftwareBuild.objects.filter(build_id=int(build_id)).exists():
             logger.info("Processing Compose relation build with id: %s", build_id)
-            fetch_modular_build.delay(build_id, force_process=force_process)
+            slow_fetch_modular_build.delay(build_id, force_process=force_process)
             processed_builds += 1
     return processed_builds

--- a/corgi/tasks/tasks.py
+++ b/corgi/tasks/tasks.py
@@ -1,6 +1,6 @@
 """
 Helper code to move all Celery task names in all sibling modules into a common namespace
-Eg. corgi.tasks.brew.fetch_brew_build is also corgi.tasks.tasks.fetch_brew_build
+Eg. corgi.tasks.brew.eventlet_fetch_brew_build is also corgi.tasks.tasks.eventlet_fetch_brew_build
 Needed in order to discover new tasks without config changes whenever a new submodule is added
 Note that either name above will work to import and run it in a Python shell
 But Celery uses the name of the module where the app.task decorator was applied, i.e. 1st form

--- a/corgi/tasks/yum.py
+++ b/corgi/tasks/yum.py
@@ -34,11 +34,11 @@ def load_yum_repositories() -> None:
     ):
         for repo in repos:  # type: ignore
             # mypy thinks yum_repositories can be None, even though it defaults to []
-            load_yum_repositories_for_stream.delay(stream, repo)
+            slow_load_yum_repositories_for_stream.delay(stream, repo)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def load_yum_repositories_for_stream(stream: str, repo: str) -> None:
+def slow_load_yum_repositories_for_stream(stream: str, repo: str) -> None:
     """Use dnf repoquery commands to inspect and load all content in a particular Yum repo"""
     logger.info(f"Loading Yum repository {repo} for ProductStream {stream}")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,9 +90,28 @@ services:
     volumes:
       - .:/opt/app-root/src:z
 
+  corgi-celery-eventlet:
+    deploy:
+      replicas: 3
+      resources:
+        limits:
+          memory: 256M  # Keep in sync with OpenShift mem limits to catch OOM problems
+    container_name: corgi-celery-eventlet
+    image: corgi
+    env_file:
+      - .env
+    environment:
+      DJANGO_SETTINGS_MODULE: "config.settings.dev"
+      CORGI_DB_HOST: corgi-db
+    depends_on: ["corgi-celery-beat"]
+    command: ./run_celery_eventlet.sh
+    # TODO: add healthcheck
+    volumes:
+      - .:/opt/app-root/src:z
+
   corgi-celery-fast:
     deploy:
-      replicas: 2
+      replicas: 3
       resources:
         limits:
           memory: 256M  # Keep in sync with OpenShift mem limits to catch OOM problems
@@ -111,7 +130,7 @@ services:
 
   corgi-celery-slow:
     deploy:
-      replicas: 8
+      replicas: 6
       resources:
         limits:
           memory: 640M  # Keep in sync with OpenShift mem limits to catch OOM problems

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,6 @@ django-celery-beat
 django-celery-results
 django-csp
 django-filter
-dnspython
 eventlet
 # The latest main-branch commit on our fork of django-mptt
 # This includes a fix for concurrent writes causing tree corruption

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,9 +113,7 @@ djangorestframework==3.13.1 \
 dnspython==2.2.1 \
     --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
     --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
-    # via
-    #   -r requirements/base.in
-    #   eventlet
+    # via eventlet
 drf-spectacular==0.21.2 \
     --hash=sha256:4ad3a72609640c57a4ff297d498cb0b810a70aca5555c0760b2da9e2f74a45b2 \
     --hash=sha256:aa7a78c8595b63e1ba14906049c770210c8fa34d84b6d1c7dce5c9e334aa2775

--- a/run_celery_eventlet.sh
+++ b/run_celery_eventlet.sh
@@ -3,7 +3,7 @@
 # custom run script for starting corgi celery service in corgi-stage and corgi-prod environments.
 
 # Remove any left-over PID files in case the container is being restarted to prevent errors such as:
-# ERROR: Pidfile (/tmp/slow.pid) already exists.
-rm -f /tmp/slow.pid
+# ERROR: Pidfile (/tmp/eventlet.pid) already exists.
+rm -f /tmp/eventlet.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -Q eventlet,slow,fast -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/eventlet.pid -Q eventlet -P eventlet -c 16 -n celery@%h

--- a/run_celery_fast.sh
+++ b/run_celery_fast.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/fast.pid) already exists.
 rm -f /tmp/fast.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -Q fast -P eventlet -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -Q fast -n celery@%h

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -9,7 +9,7 @@ from yaml import safe_load
 
 from corgi.collectors.brew import Brew, BrewBuildTypeNotSupported
 from corgi.core.models import Component, ComponentNode
-from corgi.tasks.brew import fetch_brew_build, save_component
+from corgi.tasks.brew import eventlet_fetch_brew_build, save_component
 from tests.data.image_archive_data import (
     NO_RPMS_IN_SUBCTL_CONTAINER,
     NOARCH_RPM_IDS,
@@ -653,7 +653,7 @@ def test_extract_image_components():
 @pytest.mark.vcr(match_on=["method", "scheme", "host", "port", "path", "body"])
 @patch("corgi.tasks.sca.slow_software_composition_analysis.delay")
 def test_fetch_rpm_build(mock_sca):
-    fetch_brew_build(1705913)
+    eventlet_fetch_brew_build(1705913)
     srpm = Component.objects.srpms().get(name="cockpit")
     assert srpm.description
     assert srpm.license_declared_raw
@@ -696,13 +696,13 @@ def test_fetch_rpm_build(mock_sca):
 
 @patch("corgi.tasks.brew.Brew")
 @patch("corgi.tasks.brew.slow_software_composition_analysis.delay")
-@patch("corgi.tasks.brew.load_errata.delay")
-@patch("corgi.tasks.brew.fetch_brew_build.delay")
+@patch("corgi.tasks.brew.slow_load_errata.delay")
+@patch("corgi.tasks.brew.eventlet_fetch_brew_build.delay")
 def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, mock_sca, mock_brew):
     with open("tests/data/brew/1781353/component_data.json", "r") as component_data_file:
         mock_brew.return_value.get_component_data.return_value = json.load(component_data_file)
 
-    fetch_brew_build(1781353)
+    eventlet_fetch_brew_build(1781353)
     image_index = Component.objects.get(
         name="subctl-container", type=Component.Type.CONTAINER_IMAGE, arch="noarch"
     )
@@ -727,7 +727,7 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
                 assert len(arch_specific_rpms) == NO_RPMS_IN_SUBCTL_CONTAINER - len(NOARCH_RPM_IDS)
     assert len(child_containers) == 3
 
-    # Verify calls were made to fetch_brew_build.delay for rpm builds
+    # Verify calls were made to eventlet_fetch_brew_build.delay for rpm builds
     assert len(mock_fetch_brew_build.call_args_list) == len(RPM_BUILD_IDS)
     mock_fetch_brew_build.assert_has_calls(
         [call(build_id) for build_id in RPM_BUILD_IDS],
@@ -740,5 +740,5 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
 @patch("corgi.core.models.SoftwareBuild.save_product_taxonomy")
 def test_new_software_build_relation(mock_save_prod_tax):
     sb = SoftwareBuildFactory()
-    fetch_brew_build(sb.build_id)
+    eventlet_fetch_brew_build(sb.build_id)
     assert mock_save_prod_tax.called

--- a/tests/test_errata_data.py
+++ b/tests/test_errata_data.py
@@ -16,7 +16,7 @@ from corgi.core.models import (
     ProductNode,
     ProductVariant,
 )
-from corgi.tasks.errata_tool import load_errata, update_variant_repos
+from corgi.tasks.errata_tool import slow_load_errata, update_variant_repos
 
 from .factories import ProductStreamFactory, ProductVariantFactory
 
@@ -206,7 +206,7 @@ def test_save_product_component_for_errata(
 ):
     build_list_url = f"{settings.ERRATA_TOOL_URL}/api/v1/erratum/{erratum_id}/builds_list.json"
     requests_mock.get(build_list_url, text=build_list)
-    load_errata(erratum_id)
+    slow_load_errata(erratum_id)
     pcr = ProductComponentRelation.objects.filter(external_system_id=erratum_id)
     assert len(pcr) == no_of_objs
     assert mock_send.call_count == no_of_objs

--- a/tests/test_rhel_compose.py
+++ b/tests/test_rhel_compose.py
@@ -7,7 +7,7 @@ from corgi.collectors.brew import Brew
 from corgi.collectors.models import CollectorRhelModule, CollectorRPM, CollectorSRPM
 from corgi.collectors.rhel_compose import RhelCompose
 from corgi.core.models import Component, ProductComponentRelation, ProductStream
-from corgi.tasks.brew import fetch_modular_build
+from corgi.tasks.brew import slow_fetch_modular_build
 from corgi.tasks.rhel_compose import get_builds, save_compose
 
 pytestmark = pytest.mark.unit
@@ -57,7 +57,7 @@ def test_fetch_module_data(mock_brew_rpm_lookup, mock_brew_srpm_lookup, requests
 
 
 @patch("corgi.collectors.brew.Brew.fetch_rhel_module", return_value={})
-@patch("corgi.tasks.brew.fetch_brew_build.delay")
+@patch("corgi.tasks.brew.eventlet_fetch_brew_build.delay")
 def test_get_builds(mock_fetch_rhel_module, mock_slow_fetch_brew_build):
     get_builds()
     assert mock_fetch_rhel_module.call_count == 0
@@ -66,8 +66,8 @@ def test_get_builds(mock_fetch_rhel_module, mock_slow_fetch_brew_build):
         type=ProductComponentRelation.Type.COMPOSE, build_id=module_build_id
     )
     with patch(
-        "corgi.tasks.brew.fetch_modular_build.delay",
-        return_value=fetch_modular_build(module_build_id),
+        "corgi.tasks.brew.slow_fetch_modular_build.delay",
+        return_value=slow_fetch_modular_build(module_build_id),
     ) as mock_fetch_compose:
         get_builds()
         assert mock_fetch_compose.call_count == 1
@@ -75,10 +75,10 @@ def test_get_builds(mock_fetch_rhel_module, mock_slow_fetch_brew_build):
     assert mock_slow_fetch_brew_build.call_count == 1
 
 
-@patch("corgi.tasks.brew.fetch_brew_build.delay")
+@patch("corgi.tasks.brew.eventlet_fetch_brew_build.delay")
 def test_fetch_compose_build(mock_fetch_brew):
     modular_rpm = _set_up_rhel_compose()
-    fetch_modular_build(module_build_id)
+    slow_fetch_modular_build(module_build_id)
     module_obj = Component.objects.get(type=Component.Type.RPMMOD)
     assert module_obj
     assert module_obj.nvr == modular_rpm.rhel_module.first().nvr


### PR DESCRIPTION
@jasinner This is the draft change I mentioned in my email. Summarizing:

The fast queue shouldn't have tasks like fetch_brew_build or fetch_modular_build, since those spawn many copies. If the queue fills up with many instances of those tasks, the daily load tasks and our daily monitoring task will be delayed and not run on time.

Adding a separate eventlet_* queue and eventlet workers lets us move I/O-bound tasks into this queue. These I/O-bound tasks can be processed quickly by eventlet. They get their own dedicated queue so that the fast tasks aren't delayed and so that these asynchronous / greenthread-based workers don't get blocked by some CPU-bound task.

More detailed info is on each commit message.