### PR TITLE
CORGI-332 improve logging for splunk

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -1,6 +1,7 @@
 import logging
 
 from celery import Celery  # type: ignore[attr-defined]
+from celery.app import trace
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +13,7 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # So all tasks in any corgi.tasks submodule are automatically discovered
 # And no config changes are needed when a new submodule is added
 app.autodiscover_tasks()
+
+trace.LOG_SUCCESS = """\
+%(return_value)s\" task_name=%(name)s, task_id=%(id)s, task_runtime=%(runtime)ss\
+"""

--- a/config/celery.py
+++ b/config/celery.py
@@ -14,6 +14,9 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # And no config changes are needed when a new submodule is added
 app.autodiscover_tasks()
 
-trace.LOG_SUCCESS = """\
-%(return_value)s\" task_name=%(name)s, task_id=%(id)s, task_runtime=%(runtime)ss\
+LOG_FORMAT = """\
+%(return_value)s\", task_name=%(name)s, task_id=%(id)s, task_runtime=%(runtime)ss\
 """
+
+trace.LOG_SUCCESS = LOG_FORMAT
+trace.LOG_FAILURE = LOG_FORMAT

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,7 @@ from distutils.util import strtobool
 from pathlib import Path
 
 # noinspection PyPep8Naming
+from config.utils import get_env
 from corgi import __version__ as CORGI_VERSION
 
 # Build paths inside the project like this: BASE_DIR / "subdir".
@@ -163,13 +164,15 @@ TEMPLATES: list[dict] = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
+LOG_FORMAT_START = "%(asctime)s +0000: thread=%(thread)d"
+LOG_FORMAT_END = f'level=%(levelname)s, app=corgi, env={get_env()}, msg="%(message)s"'
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
         "default": {
-            "format": "[%(asctime)s] [%(name)s:%(lineno)d] %(levelname)s: %(message)s",
-            "datefmt": "%d/%b/%Y:%H:%M:%S %z",  # Matches the one used by gunicorn
+            "format": f"{LOG_FORMAT_START}, {LOG_FORMAT_END}",
         },
     },
     "filters": {
@@ -278,6 +281,11 @@ CELERY_TASK_ROUTES = (
         ("corgi.tasks.*.slow_*", {"queue": "slow"}),  # Any module's slow_* tasks go to 'slow' queue
         ("*", {"queue": "fast"}),  # default other tasks go to 'fast'
     ],
+)
+
+CELERY_WORKER_LOG_FORMAT = f"{LOG_FORMAT_START}, {LOG_FORMAT_END}"
+CELERY_WORKER_TASK_LOG_FORMAT = (
+    f"{LOG_FORMAT_START}, task_name=%(task_name)s, task_id=%(task_id)s, {LOG_FORMAT_END}"
 )
 
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,30 +1,5 @@
 from .base import *  # noqa: F401, F403
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "default": {
-            "format": "[%(asctime)s] [%(name)s:%(lineno)d] %(levelname)s: %(message)s",
-            "datefmt": "%d/%b/%Y:%H:%M:%S %z",  # Matches the one used by gunicorn
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "default",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-    "loggers": {
-        "django": {"handlers": ["console"], "level": "WARNING"},
-        "corgi": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
-    },
-}
-
 DEBUG = True
 
 SECRET_KEY = "helloworld"

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -1,7 +1,7 @@
-import logging
 import re
 from typing import Optional
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
 from django.db.models import QuerySet
@@ -21,7 +21,7 @@ from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 from corgi.tasks.errata_tool import slow_load_errata
 from corgi.tasks.sca import slow_software_composition_analysis
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -1,5 +1,4 @@
-import logging
-
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.db import transaction
 
@@ -14,7 +13,7 @@ from corgi.core.models import (
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/corgi/tasks/lifecycle.py
+++ b/corgi/tasks/lifecycle.py
@@ -1,6 +1,6 @@
-import logging
 from datetime import datetime
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.db import transaction
 
@@ -9,7 +9,7 @@ from corgi.collectors.appstream_lifecycle import AppStreamLifeCycleCollector
 from corgi.core.models import AppStreamLifeCycle
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -1,7 +1,7 @@
-import logging
 from datetime import timedelta
 
 from celery.signals import beat_init
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton, clear_locks
 from django.conf import settings
 from django.core.mail import EmailMessage
@@ -14,7 +14,7 @@ from config.utils import running_dev
 
 from .common import get_last_success_for_task
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @beat_init.connect

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -1,6 +1,6 @@
-import logging
 import re
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.db import transaction
 
@@ -16,7 +16,7 @@ from corgi.core.models import (
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 # Find a substring that looks like a version (e.g. "3", "3.5", "3-5", "1.2.z") at the end of a
 # searched string.
 RE_VERSION_LIKE_STRING = re.compile(r"\d[\dz.-]*$|$")

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -1,5 +1,4 @@
-import logging
-
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
 
@@ -10,7 +9,7 @@ from corgi.tasks.brew import fetch_unprocessed_relations
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, _create_relations
 from corgi.tasks.errata_tool import update_variant_repos
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(

--- a/corgi/tasks/rhel_compose.py
+++ b/corgi/tasks/rhel_compose.py
@@ -1,6 +1,6 @@
-import logging
 from typing import Iterable
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 
 from config.celery import app
@@ -9,7 +9,7 @@ from corgi.core.models import ProductComponentRelation, ProductStream, SoftwareB
 from corgi.tasks.brew import slow_fetch_modular_build
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, _create_relations
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import shutil
 import subprocess  # nosec B404
@@ -8,6 +7,7 @@ from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
 from requests import Response
@@ -26,7 +26,7 @@ LOOKASIDE_REGEX_SOURCE_PATTERNS = [
     r"^(?P<alg>[A-Z0-9]*) \((?P<file>[a-zA-Z0-9.-]*)\) = (?P<hash>[a-f0-9]*)",
 ]
 lookaside_source_regexes = tuple(re.compile(p) for p in LOOKASIDE_REGEX_SOURCE_PATTERNS)
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 def save_component(component: dict[str, Any], parent: ComponentNode):

--- a/corgi/tasks/yum.py
+++ b/corgi/tasks/yum.py
@@ -1,6 +1,6 @@
-import logging
 from urllib.parse import urlparse
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
 
@@ -10,7 +10,7 @@ from corgi.core.models import Channel, ProductComponentRelation, ProductStream
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, _create_relations
 from corgi.tasks.pulp import fetch_unprocessed_relations
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs 

This uses key=value pairs separated by commas for logging as per the [splunk best-practices guide](https://dev.splunk.com/enterprise/docs/developapps/addsupport/logging/loggingbestpractices/#Use-clear-key-value-pairs). In order to group log messages together more easily I've switched all tasks to use the celery task logger which includes the task name, and id in log messages. I've also added a thread attribute to help tie logs from collector and other classes together to the task which called it. Finally I override the task_success message to include a task_runtime key which we can use to gather metrics on task runtimes.