### PR TITLE
Only log django.request errors to emails, not all errors at root

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -190,11 +190,13 @@ LOGGING = {
         },
     },
     "root": {
-        "handlers": ["console", "mail_admins"],
+        "handlers": ["console"],
         "level": "WARNING",
     },
     "loggers": {
         "django": {"handlers": ["console"], "level": "WARNING"},
+        # Mail errors only, but set level=WARNING here to pass warnings up to parent loggers
+        "django.request": {"handlers": ["mail_admins"], "level": "WARNING"},
         "corgi": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }


### PR DESCRIPTION
@mprpic Would you mind giving this a quick sanity check? Or please let me know if you think we should just turn off email logging. I was trying to copy SDEngine's behavior, where we get emails for 500-level errors (which happen only rarely). But the spam is a little frustrating.

CORGI-354 is the specific bug that made me want a traceback, and made me realize we weren't getting these emails.