### PR TITLE
Splunk logging improvements

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -2,6 +2,10 @@ import logging
 
 from celery import Celery  # type: ignore[attr-defined]
 from celery.app import trace
+from celery.app.log import TaskFormatter
+from celery.signals import after_setup_logger, after_setup_task_logger
+
+from config.settings.base import LOG_DATE_FORMAT, LOG_FORMAT_END, LOG_FORMAT_START
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +18,35 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # And no config changes are needed when a new submodule is added
 app.autodiscover_tasks()
 
-LOG_FORMAT = """\
-%(return_value)s\", task_name=%(name)s, task_id=%(id)s, task_runtime=%(runtime)ss\
-"""
 
-trace.LOG_SUCCESS = LOG_FORMAT
-trace.LOG_FAILURE = LOG_FORMAT
+CELERY_TASK_LOG_FORMAT = (
+    f"{LOG_FORMAT_START}, process_name=%(processName)s, task_name=%(task_name)s, "
+    f"task_id=%(task_id)s, {LOG_FORMAT_END}"
+)
+
+
+@after_setup_logger.connect
+def after_setup_logger_handler(logger, *args, **kwargs):
+    """Override the celery logger to include splunk friendly timestamp"""
+    formatter = TaskFormatter(f"{LOG_FORMAT_START}, {LOG_FORMAT_END}")
+    formatter.datefmt = LOG_DATE_FORMAT
+    for handler in logger.handlers:
+        handler.setFormatter(formatter)
+
+
+@after_setup_task_logger.connect
+def after_setup_task_logger_handler(logger, *args, **kwargs):
+    """Override the celery task logging to include key/value pairs"""
+    formatter = TaskFormatter(f"{CELERY_TASK_LOG_FORMAT}")
+    formatter.datefmt = LOG_DATE_FORMAT
+    for handler in logger.handlers:
+        handler.setFormatter(formatter)
+
+
+log_common = 'task_name=%(name)s, task_id=%(id)s, task_args="%(args)s", task_kwargs="%(kwargs)s"'
+
+# Closes the message log attribute early and adds key value pairs
+# Avoids a trailing " by adding an extra 'x' key
+trace.LOG_SUCCESS = f"""\
+" status=SUCCESS, result=%(return_value)s, {log_common} task_runtime=%(runtime)ss x="\
+"""

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -164,8 +164,13 @@ TEMPLATES: list[dict] = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
-LOG_FORMAT_START = "%(asctime)s +0000: thread=%(thread)d"
+# Splunk friendly key/value pairs
+LOG_FORMAT_START = (
+    "%(asctime)s.%(msecs)03d+00:00 thread=%(thread)d, name=%(name)s, lineno=%(lineno)d"
+)
 LOG_FORMAT_END = f'level=%(levelname)s, app=corgi, env={get_env()}, msg="%(message)s"'
+# Splunk friendly timestamp
+LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 LOGGING = {
     "version": 1,
@@ -173,6 +178,7 @@ LOGGING = {
     "formatters": {
         "default": {
             "format": f"{LOG_FORMAT_START}, {LOG_FORMAT_END}",
+            "datefmt": f"{LOG_DATE_FORMAT}",
         },
     },
     "filters": {
@@ -281,11 +287,6 @@ CELERY_TASK_ROUTES = (
         ("corgi.tasks.*.slow_*", {"queue": "slow"}),  # Any module's slow_* tasks go to 'slow' queue
         ("*", {"queue": "fast"}),  # default other tasks go to 'fast'
     ],
-)
-
-CELERY_WORKER_LOG_FORMAT = f"{LOG_FORMAT_START}, {LOG_FORMAT_END}"
-CELERY_WORKER_TASK_LOG_FORMAT = (
-    f"{LOG_FORMAT_START}, task_name=%(task_name)s, task_id=%(task_id)s, {LOG_FORMAT_END}"
 )
 
 

--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -5,7 +5,6 @@ from functools import reduce
 
 import requests
 from django.conf import settings
-from requests import HTTPError
 from requests_gssapi import HTTPSPNEGOAuth
 
 from corgi.collectors.models import (
@@ -200,15 +199,8 @@ class ErrataTool:
     def normalize_erratum_id(self, name: str) -> int:
         if name.isdigit():
             return int(name)
-        try:
-            erratum_details = self.get(f"api/v1/erratum/{name}")
-        except HTTPError as e:
-            logger.error(e)
-            return 0
-
+        erratum_details = self.get(f"api/v1/erratum/{name}")
         erratum_id = self.get_from_dict(erratum_details, ["content", "content", "errata_id"])
-        if not erratum_id:
-            return 0
         return int(erratum_id)
 
     # https://stackoverflow.com/questions/28225552/

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -39,9 +39,6 @@ def slow_load_errata(erratum_name):
     et = ErrataTool()
     if not erratum_name.isdigit():
         erratum_id = et.normalize_erratum_id(erratum_name)
-        if not erratum_id:
-            logger.warning("Couldn't normalize erratum: %s", erratum_name)
-            return
     else:
         erratum_id = int(erratum_name)
     relation_build_ids = _get_relation_build_ids(erratum_id)


### PR DESCRIPTION
I noticed some of the keys where not being picked up correctly by splunk. It could be because we used spaces in the datetime stamp. Also fixing a trailing " in celery worker task logs.