### PR TITLE
CORGI-340 expose redis and celery metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     depends_on: ["redis", "corgi-db"]
     command: ./run_celery_flower.sh
     ports:
-      - "5555:5555"
+      - "5555:9455"
     volumes:
       - .:/opt/app-root/src:z
 

--- a/run_celery_flower.sh
+++ b/run_celery_flower.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-exec celery -A config flower
+exec celery -A config flower --port=9455


### PR DESCRIPTION
Adjusts the celery-flower port to allow it's built-in prometheus metrics to be collected by SignalFX.