### PR TITLE
Improve analysis meta

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -325,7 +325,7 @@
         "filename": "tests/test_sca.py",
         "hashed_secret": "75272b8978226ca0852fd26fb75ed8c2bd4f4680",
         "is_verified": true,
-        "line_number": 150,
+        "line_number": 155,
         "is_secret": false
       },
       {
@@ -333,10 +333,10 @@
         "filename": "tests/test_sca.py",
         "hashed_secret": "b6bed62bf61a2710e03218decfb836a10a7bce0a",
         "is_verified": true,
-        "line_number": 159,
+        "line_number": 164,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-11-17T17:34:53Z"
+  "generated_at": "2022-11-25T00:11:36Z"
 }

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -320,6 +320,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
             "provides",
             "upstreams",
             "manifest",
+            "filename",
         ]
 
 

--- a/corgi/collectors/go_list.py
+++ b/corgi/collectors/go_list.py
@@ -82,8 +82,8 @@ class GoList:
                 "meta": {
                     "name": artifact["ImportPath"],
                     "go_component_type": "go-package",
+                    "source": ["go-list"],
                 },
-                "analysis_meta": {"source": "go-list"},
             }
             # `go list` returns packages which are part of modules, as well as those which are part
             # of the standard library. Packages which are part of the standard library don't have a

--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -74,8 +74,8 @@ class Syft:
                         "name": artifact["name"],
                         "version": artifact["version"],
                         "purl": artifact["purl"],
+                        "source": [f"syft-{syft_version}"],
                     },
-                    "analysis_meta": {"source": f"syft-{syft_version}"},
                 }
 
                 if pkg_type == Component.Type.MAVEN:

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -174,7 +174,7 @@ def find_package_file_name(sources: list[str]) -> str:
     """Find a packageFileName for a manifest using a list of source filenames from a build system"""
     for source in sources:
         # Use first matching source value that looks like a package
-        match = re.match(r"\.(?:rpm|tar|tgz|zip)", source)
+        match = re.search(r"\.(?:rpm|tar|tgz|zip)", source)
         if match:
             return source
     return ""  # If sources was an empty list, or none of the filenames matched

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -136,15 +136,15 @@ def slow_fetch_modular_build(build_id: str, force_process: bool = False) -> None
     #  We don't currently handle reprocessing a modular build
     # Note: module builds don't include arch information, only the individual RPMs that make up a
     # module are built for specific architectures.
+    meta = rhel_module_data["meta"]
     obj, created = Component.objects.get_or_create(
-        name=rhel_module_data["meta"]["name"],
+        name=meta.pop("name"),
         type=rhel_module_data["type"],
-        version=rhel_module_data["meta"]["version"],
-        release=rhel_module_data["meta"]["release"],
+        version=meta.pop("version"),
+        release=meta.pop("release"),
         defaults={
-            # This gives us an indication as to which task (this or slow_fetch_brew_build)
-            # last processed the module
-            "meta_attr": rhel_module_data["analysis_meta"],
+            # Any remaining meta keys are recorded in meta_attr
+            "meta_attr": meta,
         },
     )
     # This should result in a lookup if slow_fetch_brew_build has already processed this module.
@@ -221,7 +221,7 @@ def save_component(
         arch=meta.pop("arch", ""),
         defaults={
             "description": meta.pop("description", ""),
-            "filename": find_package_file_name(meta.pop("source", [])),
+            "filename": find_package_file_name(meta.pop("source_files", [])),
             "license_declared_raw": meta.pop("license", ""),
             "namespace": component.get("namespace", ""),
             "related_url": related_url,
@@ -283,7 +283,7 @@ def save_srpm(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentNode:
             # set only when initially created
             defaults={
                 "description": build_data["meta"].get("description", ""),
-                "filename": find_package_file_name(build_data["meta"].get("source", [])),
+                "filename": find_package_file_name(build_data["meta"].get("source_files", [])),
                 "license_declared_raw": build_data["meta"].get("license", ""),
                 "related_url": related_url,
             },
@@ -427,7 +427,6 @@ def save_module(softwarebuild, build_data) -> ComponentNode:
     the relationships. We create the relationships using data from RHEL_COMPOSE, or RPM repository
     See CORGI-200, and CORGI-163"""
     meta_attr = build_data["meta"]["meta_attr"]
-    meta_attr.update(build_data["analysis_meta"])
     obj, created = Component.objects.update_or_create(
         name=build_data["meta"]["name"],
         type=build_data["type"],

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -33,17 +33,7 @@ def save_component(component: dict[str, Any], parent: ComponentNode):
     meta = component.get("meta", {})
     if component["type"] not in Component.Type:
         logger.warning("Tried to save component with unknown type: %s", component["type"])
-        # TODO: Missing return here?
-
-    meta_attr = component["analysis_meta"]
-
-    if component["type"] == Component.Type.MAVEN:
-        group_id = meta.get("group_id")
-        if group_id:
-            meta_attr["group_id"] = group_id
-
-    if "go_component_type" in meta:
-        meta_attr["go_component_type"] = meta["go_component_type"]
+        return False
 
     # Use all fields from Component index and uniqueness constraint
     obj, created = Component.objects.get_or_create(
@@ -52,7 +42,7 @@ def save_component(component: dict[str, Any], parent: ComponentNode):
         version=meta.pop("version", ""),
         release="",
         arch="",
-        defaults={"meta_attr": meta_attr},
+        defaults={"meta_attr": meta},
     )
 
     if "purl" in meta and obj.purl != meta["purl"]:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1222,6 +1222,8 @@ components:
         manifest:
           type: string
           readOnly: true
+        filename:
+          type: string
       required:
       - channels
       - description

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -164,7 +164,8 @@ def test_get_component_data(
         return
     c = brew.get_component_data(build_id)
     if build_type == "module":
-        assert list(c.keys()) == ["type", "namespace", "meta", "analysis_meta", "build_meta"]
+        assert list(c.keys()) == ["type", "namespace", "meta", "build_meta"]
+        assert set(c["meta"].keys()) == {"source"}
     # TODO: uncomment when Maven build type is supported
     # elif build_type == "maven":
     #     assert list(c.keys()) == ["type", "namespace", "meta", "build_meta"]
@@ -178,16 +179,35 @@ def test_get_component_data(
             "components",
             "build_meta",
         ]
+        assert set(c["meta"].keys()) == {
+            "parent",
+            "build_parent_nvrs",
+            "release",
+            "version",
+            "arch",
+            "epoch",
+            "name",
+            "digests",
+            "source",
+        }
     else:
         assert list(c.keys()) == [
             "type",
             "namespace",
-            "id",
             "meta",
-            "analysis_meta",
             "components",
             "build_meta",
         ]
+        set(c["meta"].keys()) == {
+            "nvr",
+            "name",
+            "version",
+            "release",
+            "epoch",
+            "arch",
+            "source",
+            "rpm_id",
+        }
     assert c["build_meta"]["build_info"]["source"] == build_source
     assert c["build_meta"]["build_info"]["build_id"] == build_id
     assert c["build_meta"]["build_info"]["name"] == build_name

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -9,7 +9,11 @@ from yaml import safe_load
 
 from corgi.collectors.brew import Brew, BrewBuildTypeNotSupported
 from corgi.core.models import Component, ComponentNode
-from corgi.tasks.brew import save_component, slow_fetch_brew_build
+from corgi.tasks.brew import (
+    find_package_file_name,
+    save_component,
+    slow_fetch_brew_build,
+)
 from tests.data.image_archive_data import (
     NO_RPMS_IN_SUBCTL_CONTAINER,
     NOARCH_RPM_IDS,
@@ -363,6 +367,19 @@ def test_get_container_build_data_remote_sources_in_archives(
             f"{settings.BREW_DOWNLOAD_ROOT_URL}/{download_path}/remote-source-{path}.tar.gz"
             for path in remote_sources_names
         ]
+
+
+def test_find_package_file_name():
+    filename = find_package_file_name(
+        [
+            "gvisor-tap-vsock-fdc231ae7b8fe1aec4cf0b8777274fa21b70d789.tar.gz",
+            "podman-machine-cni-0749884.tar.gz",
+            "dnsname-18822f9.tar.gz",
+            "v0.1.7.tar.gz",
+            "podman-4.3.1-814b7b0.tar.gz",
+        ]
+    )
+    assert filename == "gvisor-tap-vsock-fdc231ae7b8fe1aec4cf0b8777274fa21b70d789.tar.gz"
 
 
 def test_extract_remote_sources(requests_mock):

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -62,11 +62,18 @@ def test_parse_golist_components():
     assert "crypto/tls" in names
 
 
-def test_golist_scan_files():
+go_sources = [
+    ("tests/data/go/runc-1.1.3.tar.gz"),
+    ("tests/data/go/podman-4.3.1-814b7b0.tar.gz"),
+]
+
+
+@pytest.mark.parametrize("go_source", go_sources)
+def test_golist_scan_files(go_source):
     scan_file = Path("Dockerfile")
     assert not scan_file.is_dir()
     assert not GoList.scan_files([scan_file])
-    archive = Path("tests/data/go/runc-1.1.3.tar.gz")
+    archive = Path(go_source)
     assert GoList.scan_files([archive])
 
 

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -39,7 +39,7 @@ def test_parse_components():
     # directives in nested go.mod files
     assert "../" not in names
     assert "github.com/Microsoft/go-winio" in names
-    assert results[0]["analysis_meta"] == {"source": "syft-0.60.1"}
+    assert results[0]["meta"]["source"] == ["syft-0.60.1"]
 
 
 def test_parse_maven_components():
@@ -73,7 +73,7 @@ def test_golist_scan_files():
 @patch("corgi.collectors.go_list.GoList.scan_files")
 def test_add_go_stdlib_version(go_list_scan_files):
     go_list_scan_files.return_value = [
-        {"type": Component.Type.GOLANG, "meta": {"name": "go-package"}, "analysis_meta": {}}
+        {"type": Component.Type.GOLANG, "meta": {"name": "go-package"}}
     ]
     root_component = ContainerImageComponentFactory(
         meta_attr={"go_stdlib_version": GO_STDLIB_VERSION}
@@ -107,7 +107,6 @@ def test_go_package_with_version(go_list_scan_files):
         {
             "type": Component.Type.GOLANG,
             "meta": {"name": "go-package", "version": GO_PACKAGE_VERSION},
-            "analysis_meta": {},
         }
     ]
     root_component = ContainerImageComponentFactory()
@@ -130,7 +129,6 @@ def test_go_package_type(go_list_scan_files):
                 "version": GO_PACKAGE_VERSION,
                 "go_component_type": "go-package",
             },
-            "analysis_meta": {},
         }
     ]
     root_component = ContainerImageComponentFactory()
@@ -400,5 +398,5 @@ def test_slow_software_composition_analysis(
         )
     else:
         root_component = Component.objects.srpms().get(software_build=sb)
-    assert expected_component.meta_attr["source"] == "syft-0.60.1"
+    assert expected_component.meta_attr["source"] == ["syft-0.60.1"]
     mock_save_prod_tax.assert_called_once()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -43,9 +43,10 @@ def test_viewset_ordering(api_path):
             "SoftwareBuildViewSet",
             "ComponentViewSet",
             "AppStreamLifeCycleViewSet",
+            "ChannelViewSet",
         ):
             # Skip imported names and special cases which have no queryset
-            # last three pass or fail depending on whether query planner
+            # last four pass or fail depending on whether query planner
             # uses an index scan or a sorted table scan
             continue
 


### PR DESCRIPTION
Supports CORGI-313

I actually set out to do CORGI-343, and while searching the stage data I found that I couldn't find the analysis_meta / source data on any components except for those found via SCA analysis. That lead me to fix that issue by writing the old analysis_meta field, which tells us how a component for first discovered, so that it now directly writes to the collector 'meta.source' field. From there, its a little easier to persist it into Component.meta_attr. We save everything that wasn't popped off and put in Component fields into meta_attr.

I was trying to test getting bundled deps from a specfile on the podman package when I discovered some errors parsing the 'go list' output. I also found these errors in the stage TaskResult data, so I put some checks around the 'go list' output parsing to skip those results with errors. 

Finally there was some code already using 'meta.source' attribute of collector data and I discovered it had a bug which meant that it wasn't actually returning any results. I fix that, and now added the 'filename' attribute to the ComponentSerializer. I think this attribute is only being set on some components of type 'upstream' but we can probably also use the field for other types too, particularly the 'rpm' type.