### PR TITLE
dont expire singleton locks, clear then on startup

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -3,7 +3,8 @@ import logging
 from celery import Celery  # type: ignore[attr-defined]
 from celery.app import trace
 from celery.app.log import TaskFormatter
-from celery.signals import after_setup_logger, after_setup_task_logger
+from celery.signals import after_setup_logger, after_setup_task_logger, worker_ready
+from celery_singleton import clear_locks
 
 from config.settings.base import LOG_DATE_FORMAT, LOG_FORMAT_END, LOG_FORMAT_START
 
@@ -23,6 +24,11 @@ CELERY_TASK_LOG_FORMAT = (
     f"{LOG_FORMAT_START}, process_name=%(processName)s, task_name=%(task_name)s, "
     f"task_id=%(task_id)s, {LOG_FORMAT_END}"
 )
+
+
+@worker_ready.connect
+def unlock_all(**kwargs):
+    clear_locks(app)
 
 
 @after_setup_logger.connect

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -256,11 +256,8 @@ CELERY_RESULT_BACKEND_MAX_RETRIES = 2
 CELERY_TASK_SOFT_TIME_LIMIT = 900
 # CELERY_SINGLETON_LOCK_EXPIRY and redis visibility timeout must never be less than the below value
 CELERY_LONGEST_SOFT_TIME_LIMIT = 2400
-# Expire locks after 40 minutes, which is the longest task time limit.
-# https://github.com/steinitzu/celery-singleton#app-configuration
-CELERY_SINGLETON_LOCK_EXPIRY = CELERY_LONGEST_SOFT_TIME_LIMIT
 
-CELERY_WORKER_CONCURRENCY = 15  # defaults to CPU core count, which breaks in OpenShift
+CELERY_WORKER_CONCURRENCY = 5  # defaults to CPU core count, which breaks in OpenShift
 
 # Disable task prefetching, which caused connection timeouts and other odd task failures in SDEngine
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
@@ -285,6 +282,7 @@ CELERY_RESULT_EXPIRES = None
 CELERY_TASK_ROUTES = (
     [
         ("corgi.tasks.*.slow_*", {"queue": "slow"}),  # Any module's slow_* tasks go to 'slow' queue
+        ("corgi.tasks.*.cpu_*", {"queue": "cpu"}),  # Any module's cpu* tasks go to 'cpu' queue
         ("*", {"queue": "fast"}),  # default other tasks go to 'fast'
     ],
 )

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -19,7 +19,7 @@ from corgi.core.models import (
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 from corgi.tasks.errata_tool import slow_load_errata
-from corgi.tasks.sca import slow_software_composition_analysis
+from corgi.tasks.sca import cpu_software_composition_analysis
 
 logger = get_task_logger(__name__)
 
@@ -118,7 +118,7 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
         slow_fetch_brew_build.delay(b_id)
 
     logger.info("Requesting software composition analysis for %s", build_id)
-    slow_software_composition_analysis.delay(build_id)
+    cpu_software_composition_analysis.delay(build_id)
 
     logger.info("Finished fetching brew build: %s", build_id)
 

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -79,7 +79,7 @@ def save_component(component: dict[str, Any], parent: ComponentNode):
     retry_kwargs=RETRY_KWARGS,
     soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
-def slow_software_composition_analysis(build_id: int):
+def cpu_software_composition_analysis(build_id: int):
     logger.info("Started software composition analysis for %s", build_id)
     software_build = SoftwareBuild.objects.get(build_id=build_id)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,10 +124,10 @@ services:
 
   corgi-celery-slow:
     deploy:
-      replicas: 5
+      replicas: 2
       resources:
         limits:
-          memory: 640M  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 1G  # Keep in sync with OpenShift mem limits to catch OOM problems
     container_name: corgi-celery-slow
     image: corgi
     env_file:
@@ -137,6 +137,25 @@ services:
       CORGI_DB_HOST: corgi-db
     depends_on: ["corgi-celery-beat"]
     command: ./run_celery_slow.sh
+    # TODO: add healthcheck
+    volumes:
+      - .:/opt/app-root/src:z
+
+  corgi-celery-cpu:
+    deploy:
+      replicas: 8
+      resources:
+        limits:
+          memory: 256M  # Keep in sync with OpenShift mem limits to catch OOM problems
+    container_name: corgi-celery-cpu
+    image: corgi
+    env_file:
+      - .env
+    environment:
+      DJANGO_SETTINGS_MODULE: "config.settings.dev"
+      CORGI_DB_HOST: corgi-db
+    depends_on: ["corgi-celery-beat"]
+    command: ./run_celery_cpu.sh
     # TODO: add healthcheck
     volumes:
       - .:/opt/app-root/src:z

--- a/run_celery_cpu.sh
+++ b/run_celery_cpu.sh
@@ -3,7 +3,7 @@
 # custom run script for starting corgi celery service in corgi-stage and corgi-prod environments.
 
 # Remove any left-over PID files in case the container is being restarted to prevent errors such as:
-# ERROR: Pidfile (/tmp/slow.pid) already exists.
-rm -f /tmp/slow.pid
+# ERROR: Pidfile (/tmp/cpu.pid) already exists.
+rm -f /tmp/cpu.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -P eventlet -c 20 -Q slow,fast -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/cpu.pid -Q cpu -n celery@%h

--- a/run_celery_fast.sh
+++ b/run_celery_fast.sh
@@ -6,7 +6,4 @@
 # ERROR: Pidfile (/tmp/fast.pid) already exists.
 rm -f /tmp/fast.pid
 
-# Reduce the concurrency slightly free up more DB connections for ad-hoc tasks
-# Can probably introduce a CONN_MAX_AGE to allow DB connection reuse and therefore higher concurrency
-# Probably best to wait to we upgrade to Django 4 or later where we also have CONN_HEALTH_CHECKS
-exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -P eventlet -c 3 -Q fast -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/fast.pid -Q fast -n celery@%h

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -651,7 +651,7 @@ def test_extract_image_components():
 
 
 @pytest.mark.vcr(match_on=["method", "scheme", "host", "port", "path", "body"])
-@patch("corgi.tasks.sca.slow_software_composition_analysis.delay")
+@patch("corgi.tasks.sca.cpu_software_composition_analysis.delay")
 def test_fetch_rpm_build(mock_sca):
     slow_fetch_brew_build(1705913)
     srpm = Component.objects.srpms().get(name="cockpit")
@@ -697,7 +697,7 @@ def test_fetch_rpm_build(mock_sca):
 
 
 @patch("corgi.tasks.brew.Brew")
-@patch("corgi.tasks.brew.slow_software_composition_analysis.delay")
+@patch("corgi.tasks.brew.cpu_software_composition_analysis.delay")
 @patch("corgi.tasks.brew.slow_load_errata.delay")
 @patch("corgi.tasks.brew.slow_fetch_brew_build.delay")
 def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, mock_sca, mock_brew):

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -15,7 +15,7 @@ from corgi.tasks.sca import (
     _download_lookaside_sources,
     _get_distgit_sources,
     _scan_files,
-    slow_software_composition_analysis,
+    cpu_software_composition_analysis,
 )
 from tests.factories import (
     ContainerImageComponentFactory,
@@ -364,7 +364,7 @@ def test_slow_software_composition_analysis(
 
     with open(syft_results, "r") as mock_scan_results:
         mock_syft.return_value = mock_scan_results.read()
-    slow_software_composition_analysis(build_id)
+    cpu_software_composition_analysis(build_id)
     expected_syft_call_arg_list = [
         call(
             [


### PR DESCRIPTION
See CORGI-386 for details of why singleton lock expiry was set.

I'm also splitting out sca tasks to a dedicated 'cpu' queue with prefork worker. When testing locally I see the syft process sometimes uses up alot of CPU.

The fast queue was also changed to prefork and concurrency reduced because we almost never have many fast tasks to process.