### PR TITLE
CORGI-365 - ensure latest filter sorts by 'release'

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -635,6 +635,7 @@ class ProductStream(ProductModel):
                         productstreams__ofuri=self.ofuri,
                     )
                     .exclude(software_build__isnull=True)
+                    .order_by("-release")
                     .order_by("-software_build__completion_time")
                     .values("uuid")[:1]
                 )


### PR DESCRIPTION
Deptopia reconciliation is incorrectly reporting as our 'latest filter' is choosing el8 release variants over el9 ... this is because the current sorting used by latest filter is sorted by build date. Sometimes the el8 variant is the latest build but thats not what we want to compare with deptopia with.

A concrete example using **python-future** package from **o:redhat:ansible_automation_platform:2.2**

`/api/v1/components?ofuri=o%3Aredhat%3Aansible_automation_platform%3A2.2&view=summary&name=python-future
`

lists a single component **python-future-0.18.2-5.el8pc**

But we can see we have in corgi both el8 and el9 variants by removing latest filter using ?ofuri= and use ?product_streams=:

`/api/v1/components?product_streams=o%3Aredhat%3Aansible_automation_platform%3A2.2&view=summary&name=python-future
`

which returns both **python-future-0.18.2-5.el8pc** and **python-future-0.18.2-5.el9pc** (we ignore the UPSTREAM component in this listing).

To bias selection to el9 variant of any component build we should also descend sort on 'release'.

**Note**- It is an open question if we should list both el8 and el9 variants ... for now we can emulate deptopia behaviour.