### PR TITLE
CORGI-365 - ensure latest filter sorts by ascending 'release'

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -635,7 +635,7 @@ class ProductStream(ProductModel):
                         productstreams__ofuri=self.ofuri,
                     )
                     .exclude(software_build__isnull=True)
-                    .order_by("release")
+                    .order_by("-release")
                     .order_by("-software_build__completion_time")
                     .values("uuid")[:1]
                 )


### PR DESCRIPTION
reverting last exp change ... turns out we did not deploy original