### PR TITLE
Fix celery slow queue length

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -3,8 +3,7 @@ import logging
 from celery import Celery  # type: ignore[attr-defined]
 from celery.app import trace
 from celery.app.log import TaskFormatter
-from celery.signals import after_setup_logger, after_setup_task_logger, worker_ready
-from celery_singleton import clear_locks
+from celery.signals import after_setup_logger, after_setup_task_logger
 
 from config.settings.base import LOG_DATE_FORMAT, LOG_FORMAT_END, LOG_FORMAT_START
 
@@ -24,11 +23,6 @@ CELERY_TASK_LOG_FORMAT = (
     f"{LOG_FORMAT_START}, process_name=%(processName)s, task_name=%(task_name)s, "
     f"task_id=%(task_id)s, {LOG_FORMAT_END}"
 )
-
-
-@worker_ready.connect
-def unlock_all(**kwargs):
-    clear_locks(app)
 
 
 @after_setup_logger.connect

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -487,7 +487,6 @@ def fetch_unprocessed_relations(
 ) -> int:
     relations_query = (
         ProductComponentRelation.objects.filter(type=relation_type, created_at__gte=created_since)
-        .order_by("created_at")
         .values_list("build_id", flat=True)
         .distinct()
     )

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -17,7 +17,7 @@ from corgi.core.models import (
     ProductStream,
     SoftwareBuild,
 )
-from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
+from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, get_last_success_for_task
 from corgi.tasks.errata_tool import slow_load_errata
 from corgi.tasks.sca import cpu_software_composition_analysis
 
@@ -481,10 +481,12 @@ def fetch_modular_builds(relations_query: QuerySet, force_process: bool = False)
 
 
 def fetch_unprocessed_relations(
-    relation_type: ProductComponentRelation.Type, force_process: bool = False
+    relation_type: ProductComponentRelation.Type,
+    created_since: timezone.datetime,
+    force_process: bool = False,
 ) -> int:
     relations_query = (
-        ProductComponentRelation.objects.filter(type=relation_type)
+        ProductComponentRelation.objects.filter(type=relation_type, created_at__gte=created_since)
         .order_by("created_at")
         .values_list("build_id", flat=True)
         .distinct()
@@ -508,7 +510,17 @@ def fetch_unprocessed_relations(
     retry_kwargs=RETRY_KWARGS,
     soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
-def fetch_unprocessed_brew_tag_relations(force_process: bool = False) -> int:
+def fetch_unprocessed_brew_tag_relations(
+    force_process: bool = False, days_created_since: int = 0
+) -> int:
+    if days_created_since:
+        created_dt = timezone.now() - timezone.timedelta(days=days_created_since)
+    else:
+        created_dt = get_last_success_for_task(
+            "corgi.tasks.brew.fetch_unprocessed_brew_tag_relations"
+        )
     return fetch_unprocessed_relations(
-        ProductComponentRelation.Type.BREW_TAG, force_process=force_process
+        ProductComponentRelation.Type.BREW_TAG,
+        force_process=force_process,
+        created_since=created_dt,
     )

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -54,8 +54,8 @@ def get_last_success_for_task(task_name: str) -> timezone.datetime:
     """
     last_success = (
         TaskResult.objects.filter(task_name=task_name, status="SUCCESS")
-        .order_by("-date_done")
-        .values_list("date_done", flat=True)
+        .order_by("-date_created")
+        .values_list("date_created", flat=True)
         .first()
     )
     return (


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This should address some issues with our slow queue due to processing duplicate tasks in our queue / relations in the PCR table. I've added more detailed notes to the commit message for the big changes. Quick sanity check appreciated, or please let me know if this should sit until Jason's back and can review himself next week. Thanks!