### PR TITLE
CORGI-374, CORGI-376: Fix more errors from daily monitoring email

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -362,4 +362,7 @@ APP_STREAMS_LIFE_CYCLE_URL = os.getenv("CORGI_APP_STREAMS_LIFE_CYCLE_URL", "")
 MANIFEST_HINTS_URL = os.getenv("CORGI_MANIFEST_HINTS_URL")
 
 LOOKASIDE_CACHE_BASE_URL = f"https://{os.getenv('CORGI_LOOKASIDE_CACHE_URL')}/repo"
+
+# Set to False to disable software composition analysis tasks.
+SCA_ENABLED = strtobool(os.getenv("CORGI_SCA_ENABLED", "true"))
 SCA_SCRATCH_DIR = os.getenv("CORGI_SCA_SCATCH_DIR", "/tmp")

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -118,7 +118,8 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
         slow_fetch_brew_build.delay(b_id)
 
     logger.info("Requesting software composition analysis for %s", build_id)
-    cpu_software_composition_analysis.delay(build_id)
+    if settings.SCA_ENABLED:
+        cpu_software_composition_analysis.delay(build_id)
 
     logger.info("Finished fetching brew build: %s", build_id)
 

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -61,9 +61,9 @@ def setup_periodic_tasks(sender, **kwargs):
     upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)
     upsert_cron_task("brew", "load_brew_tags", hour=5, minute=0)
     upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=6, minute=0)
-    upsert_cron_task("yum", "load_yum_repositories", hour=7, minute=0)
-    upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=8, minute=0)
-    upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=9, minute=0)
+    upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=7, minute=0)
+    upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)
+    upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
     upsert_cron_task("monitoring", "email_failed_tasks", hour=11, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -153,6 +153,8 @@ def _clone_source(source_url: str, build_id: int) -> Tuple[Path, str, str]:
 
     git_remote = f"{url.scheme}://{url.netloc}{url.path}"
     path_parts = url.path.rsplit("/", 2)
+    if len(path_parts) != 3:
+        raise ValueError(f"Build {build_id} had a source_url with a too-short path: {source_url}")
     package_type = path_parts[1]
     package_name = path_parts[2]
     commit = url.fragment

--- a/run_celery_slow.sh
+++ b/run_celery_slow.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/slow.pid) already exists.
 rm -f /tmp/slow.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -P eventlet -c 12 -Q slow,fast -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -P eventlet -c 10 -Q slow -n celery@%h


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs As title says, plus a possible fix for the high CPU usage issue that our slow workers keep hitting. Those slow workers use the eventlet pool and should only process I/O bound tasks.

But they're still configured to pull CPU-bound tasks from the fast queue. If any of the greenthreads inside the eventlet worker pick up a CPU-bound task, they won't be able to yield as often (not doing any I/O) so end up blocking the worker. Then the other 19 greenthreads on the eventlet worker will get starved of CPU time / never execute, which is probably why our tasks look like they're hanging.

Even if that's not *the* issue, it at least simplifies our queueing setup. Now slow workers only process slow tasks, fast workers only process fast tasks, and CPU workers only process SCA tasks (which are the only tasks in the CPU queue). So our setup becomes a little easier to reason about and debug.

Not going to merge this to avoid destabilizing things over the weekend, but opening now so Jason can review in his morning. Hope you enjoyed your time off!