### PR TITLE
add load unprocessed management command

### DIFF
--- a/corgi/tasks/management/commands/loadunprocessedrelations.py
+++ b/corgi/tasks/management/commands/loadunprocessedrelations.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+
+from corgi.tasks.brew import fetch_unprocessed_brew_tag_relations
+from corgi.tasks.pulp import fetch_unprocessed_cdn_relations
+from corgi.tasks.yum import fetch_unprocessed_yum_relations
+
+
+class Command(BaseCommand):
+
+    help = "Fetch unprocessed builds from the relations table"
+
+    def handle(self, *args, **options):
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Loading unprocessed YUM relations",
+            )
+        )
+        fetch_unprocessed_yum_relations.delay()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Loading unprocessed BREW_TAG relations",
+            )
+        )
+        fetch_unprocessed_brew_tag_relations.delay()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Loading unprocessed CDN relations",
+            )
+        )
+        fetch_unprocessed_cdn_relations.delay()


### PR DESCRIPTION
This adds a management command for loading all the unprocessed relations. It's expected these tasks will take some time to complete. In order to monitor progress use the django_celery_results data, ie:

```
In [11]: TaskResult.objects.filter(
    ...:     task_name="corgi.tasks.brew.fetch_unprocessed_brew_tag_relations"
    ...: ).order_by("date_done").last().date_done
Out[11]: datetime.datetime(2022, 12, 5, 1, 39, 2, 181804, tzinfo=<UTC>)

In [12]: TaskResult.objects.filter(
    ...:     task_name="corgi.tasks.brew.fetch_unprocessed_brew_tag_relations"
    ...: ).order_by("date_done").last().result
Out[12]: '587'

In [13]: TaskResult.objects.filter(
    ...:     task_name="corgi.tasks.pulp.fetch_unprocessed_cdn_relations"
    ...: ).order_by("date_done").last().date_done
Out[13]: datetime.datetime(2022, 12, 5, 1, 39, 2, 170818, tzinfo=<UTC>)

In [14]: TaskResult.objects.filter(
    ...:     task_name="corgi.tasks.pulp.fetch_unprocessed_cdn_relations"
    ...: ).order_by("date_done").last().result
Out[14]: '0'
```

