### PR TITLE
Fix a small amount of inline styling that was missed and the /docs API endpoint

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,9 +17,10 @@ DEBUG = False
 # Mail these people on uncaught exceptions that result in 500 errors
 # Also mail these people once a day if any Celery task failed in the past 24 hours
 # Technically, "twice a day" - you'll get an email from stage and prod
-ADMINS = [
-    tuple(name_and_email.split(";")) for name_and_email in os.getenv("CORGI_ADMINS", "").split(",")
-]
+ADMINS = tuple(
+    tuple(name_and_email.split(";"))
+    for name_and_email in os.getenv("CORGI_ADMINS", ";root@localhost").split(",")
+)
 
 DOCS_URL = os.getenv("CORGI_DOCS_URL")
 OPENSHIFT_BUILD_COMMIT = os.getenv("OPENSHIFT_BUILD_COMMIT")

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -345,13 +345,17 @@ class Brew:
             # Legacy OSBS builds such as 1890187 copy source code into dist-git but specify where
             # the source code came from using the 'go' stanza in container.yaml
             # ref: https://osbs.readthedocs.io/en/osbs_ocp3/users.html#go
-            go_modules = []
-            if "go" in build_info["extra"]["image"]:
-                for module in build_info["extra"]["image"]["go"]["modules"]:
-                    if "module" in module:
-                        go_modules.append(module["module"])
-            if go_modules:
-                component["meta"]["upstream_go_modules"] = go_modules
+            # Handle case when "go" key is present but value is None
+            go = build_info["extra"]["image"].get("go", {})
+
+            # AND handle case when "modules" key is present but value is None
+            if go and go.get("modules", []):
+                go_modules = tuple(
+                    module["module"] for module in go["modules"] if module.get("module")
+                )
+                if go_modules:
+                    # Tuple above can be empty if .get("module") name is always None / an empty str
+                    component["meta"]["upstream_go_modules"] = go_modules
 
             # builds such as 1911112 have all their info in typeinfo as they use remote_sources map
             # in remote_source json, and tar download urls by cachito url

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -694,7 +694,7 @@ class Brew:
             "stream": modulemd["data"]["stream"],
             "context": modulemd["data"]["context"],
             "components": modulemd["data"].get("components", []),
-            "rpms": modulemd["data"]["xmd"]["mbs"]["rpms"],
+            "rpms": modulemd["data"]["xmd"]["mbs"].get("rpms", []),
             "source": ["koji.getBuild"],
         }
         module = {

--- a/corgi/core/constants.py
+++ b/corgi/core/constants.py
@@ -1,8 +1,7 @@
-from django.db.models import Q
-
 """
     model constants
 """
+from django.db.models import Q
 
 CONTAINER_DIGEST_FORMATS = (
     "application/vnd.docker.distribution.manifest.v2+json",
@@ -16,7 +15,7 @@ CORGI_COMPONENT_TAXONOMY_VERSION = "v1"
 NODE_LEVEL_MODEL_MAPPING = {
     0: "product",
     1: "product_version",
-    2: "Product_stream",
+    2: "product_stream",
     3: "product_variant",
     4: "channel",
 }

--- a/corgi/web/static/base.css
+++ b/corgi/web/static/base.css
@@ -6,6 +6,10 @@
   margin: 3px 0 5px 20px;
 }
 
+.marginleft {
+  margin-left: 1em;
+}
+
 .whitefont {
   font-size: 14px;
   text-decoration: none;
@@ -14,4 +18,8 @@
 
 .paddingbottom {
   padding-bottom: 5px;
+}
+
+.paddingright {
+  padding-right: 0.5em;
 }

--- a/corgi/web/templates/app_status.html
+++ b/corgi/web/templates/app_status.html
@@ -4,5 +4,5 @@
 {% block title %}Tasks{% endblock %}
 
 {% block body %}
-<h2 style="margin-left: 1em;">{{ msg }}</h2>
+<h2 class="marginleft">{{ msg }}</h2>
 {% endblock %}

--- a/corgi/web/templates/task_list.html
+++ b/corgi/web/templates/task_list.html
@@ -9,7 +9,7 @@
       <div class="card-pf">
         <div class="card-pf-body">
           <h1 class="card-pf-title">
-            <span style="padding-right: 0.5em">Tasks</span>
+            <span class="paddingright">Tasks</span>
             {% if running %}
             <span class="label label-info">Queued (cpu): {{ cpu_queue_len }}</span>
             <span class="label label-info">Queued (fast): {{ fast_queue_len }}</span>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   redis-exporter:
     container_name: redis-exporter
-    image: quay.io/oliver006/redis_exporter:latest
+    image: quay.io/oliver006/redis_exporter@sha256:6ef9be804859638d84a588b387009e3695e1e29cd8f45a1197d6d923b49ae9b7
     environment:
       REDIS_ADDR: "redis://redis:6379"
       REDIS_EXPORTER_CHECK_KEYS: "slow,fast"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,11 +6,17 @@ django-celery-results
 django-csp
 django-filter
 eventlet
+
 # The latest main-branch commit on our fork of django-mptt
 # This includes a fix for concurrent writes causing tree corruption
-https://github.com/RedHatProductSecurity/django-mptt/archive/25d49a400d349740c5295e4301f29a98ae025a07.zip#egg=django-mptt
-https://github.com/encode/django-rest-framework/archive/cc3c89a11c7ee9cf7cfd732e0a329c318ace71b2.zip#egg=djangorestframework
-drf-spectacular[sidecar]
+django-mptt @ https://github.com/RedHatProductSecurity/django-mptt/archive/25d49a400d349740c5295e4301f29a98ae025a07.zip#egg=django-mptt
+
+# Unreleased Django-REST-Framework commit with a fix for strong Content-Security-Policies
+djangorestframework @ https://github.com/encode/django-rest-framework/archive/cc3c89a11c7ee9cf7cfd732e0a329c318ace71b2.zip#egg=djangorestframework
+
+# Unreleased drf-spectacular commit with a fix for strong Content-Security-Policies
+drf-spectacular[sidecar] @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip#egg=drf-spectacular
+
 flower
 gunicorn[gevent]
 koji

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,9 +113,8 @@ dnspython==2.2.1 \
     --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
     --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
     # via eventlet
-drf-spectacular[sidecar]==0.24.2 \
-    --hash=sha256:b276e6f7bda6dfb911e742dab87c6e97bc67da2dafe82d6fd8df7cec6c8b03ec \
-    --hash=sha256:be32417594080a52f996afd83fd47ea9c2b83cbf13f6d3fbf3de809a0dfa7ead
+drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
+    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via -r requirements/base.in
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -303,9 +303,8 @@ dnspython==2.2.1 \
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   eventlet
-drf-spectacular[sidecar]==0.24.2 \
-    --hash=sha256:b276e6f7bda6dfb911e742dab87c6e97bc67da2dafe82d6fd8df7cec6c8b03ec \
-    --hash=sha256:be32417594080a52f996afd83fd47ea9c2b83cbf13f6d3fbf3de809a0dfa7ead
+drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
+    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -315,7 +314,6 @@ drf-spectacular-sidecar==2022.11.1 \
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   drf-spectacular
 eventlet==0.33.1 \
     --hash=sha256:a085922698e5029f820cf311a648ac324d73cec0e4792877609d978a4b5bbf31 \
     --hash=sha256:afbe17f06a58491e9aebd7a4a03e70b0b63fd4cf76d8307bae07f280479b1515

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -215,16 +215,13 @@ dnspython==2.2.1 \
     # via
     #   -r requirements/base.txt
     #   eventlet
-drf-spectacular[sidecar]==0.24.2 \
-    --hash=sha256:b276e6f7bda6dfb911e742dab87c6e97bc67da2dafe82d6fd8df7cec6c8b03ec \
-    --hash=sha256:be32417594080a52f996afd83fd47ea9c2b83cbf13f6d3fbf3de809a0dfa7ead
+drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
+    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via -r requirements/base.txt
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \
     --hash=sha256:503860a34d4215d6b3c46d54b90d991dd0d202363e3b69b832348f08e4a8634b
-    # via
-    #   -r requirements/base.txt
-    #   drf-spectacular
+    # via -r requirements/base.txt
 eventlet==0.33.1 \
     --hash=sha256:a085922698e5029f820cf311a648ac324d73cec0e4792877609d978a4b5bbf31 \
     --hash=sha256:afbe17f06a58491e9aebd7a4a03e70b0b63fd4cf76d8307bae07f280479b1515


### PR DESCRIPTION
There's a related issue with the /docs API returning an error - it works locally but not in stage. I see this line in the traceback:
```
File "/usr/local/lib/python3.9/site-packages/drf_spectacular/views.py", line 117, in _get_sidecar_url
    return static(f'drf_spectacular_sidecar/{package}')
```

Which seems to cause this error:
```
File "/usr/local/lib/python3.9/site-packages/django/contrib/staticfiles/storage.py", line 417, in stored_name
    raise ValueError("Missing staticfiles manifest entry for '%s'" % clean_name)

Exception Type: ValueError at /api/v1/schema/docs
Exception Value: Missing staticfiles manifest entry for 'drf_spectacular_sidecar/swagger-ui-dist'
```

Perhaps it's because we don't redirect 'drf_spectacular_sidecar/swagger-ui-dist', with no trailing slash, to 'drf_spectacular_sidecar/swagger-ui-dist/' with a trailing slash.

This is controlled by the APPEND_SLASH setting:
```
APPEND_SLASH = False  # Default: True
# If True, and request URL doesn't match any patterns in URLconf
# and request URL doesn’t end in slash
# HTTP redirect is issued to same URL with slash appended
# Note that the redirect may cause any data submitted in a POST request to be lost
# With False, our URLconf controls. "api/path/" won't match, should give a 404
# Only "api/path" should succeed
```

I'm still not sure why it works locally...might deploy an experimental fix from this branch for testing. I'll tag when this is ready for review.