### PR TITLE
switch slow workers to prefork

### DIFF
--- a/run_celery_slow.sh
+++ b/run_celery_slow.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/slow.pid) already exists.
 rm -f /tmp/slow.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -P eventlet -c 10 -Q slow -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/slow.pid -Q slow -n celery@%h


### PR DESCRIPTION
CORGI-380 and CORGI-376

Try to avoid stuck slow workers by reverting them to the default 'prefork' pool, and also reducing concurrency to the application wide default of 5.