### PR TITLE
CORGI-391 - ensure we bias sort el# on latest filter

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -651,7 +651,7 @@ class ProductStream(ProductModel):
                         ),
                         el_match=Func(
                             F("release"),
-                            Value("el([0-9]+)"),
+                            Value(".([a-z]*el[6-9]+)"),
                             function="regexp_match",
                             output=fields.ArrayField(IntegerField()),
                         ),


### PR DESCRIPTION
Further refinement of sorting for 'latest filter' to take into account things like .ael7b vs. .el7 ... el7 should take precedence.

All the gory details described in CORGI-391. 

There maybe future related refinements along these lines though for now it is an explicit choice to not be comprehensive in this specific PR for safety.

Once this is reviewed and merged it probably gives us data parity.

**Note**- also took the opportunity to constrain el# values so we have a clear 'call to action' if/when el10 happens.

**Note** - CI currently fail due to other commits

