### PR TITLE
CORGI-396 update user guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -22,14 +22,14 @@ Most endpoints provide a paginated data response.
 
 ##### cURL
 ```bash
-$ curl "https://${CORGI_DOMAIN}/api/v1/components"
+$ curl "https://${CORGI_HOST}/api/v1/components"
 ```
 
 ##### python
 ```python
 import requests
 
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components")
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components")
 response.raise_for_status()
 ```
 
@@ -42,11 +42,11 @@ the UUID addresses listed below.
 ##### cURL
 
 ```bash
-curl "curl -L https://${CORGI_DOMAIN}/api/v1/components?purl=pkg:npm/is-svg@2.1.0"
+curl -L https://${CORGI_HOST}/api/v1/components?purl=pkg:npm/is-svg@2.1.0
 ```
 
 ```bash
-$ curl "https://${CORGI_DOMAIN}/api/v1/components/2fe16efb-11cb-4cd2-b31b-d769ba821073"
+$ curl "https://${CORGI_HOST}/api/v1/components/2fe16efb-11cb-4cd2-b31b-d769ba821073"
 ```
 
 ##### python
@@ -54,7 +54,7 @@ $ curl "https://${CORGI_DOMAIN}/api/v1/components/2fe16efb-11cb-4cd2-b31b-d769ba
 ```python
 import requests
 purl = "pkg://npm/is-svg@2.1.0"
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components?purl={purl}")
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components?purl={purl}")
 response.raise_for_status()
 ```
 
@@ -62,7 +62,7 @@ response.raise_for_status()
 import requests
 
 component_id = "2fe16efb-11cb-4cd2-b31b-d769ba821073"
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components/{component_id}")
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components/{component_id}")
 response.raise_for_status()
 ```
 
@@ -72,7 +72,7 @@ response.raise_for_status()
 
 ##### cURL
 ```bash
-$ curl "https://${CORGI_DOMAIN}/api/v1/components?name=curl"
+$ curl "https://${CORGI_HOST}/api/v1/components?name=curl"
 ```
 
 ##### python
@@ -80,7 +80,7 @@ $ curl "https://${CORGI_DOMAIN}/api/v1/components?name=curl"
 import requests
 
 params = {"name": "curl"}
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components", params=params)
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components", params=params)
 response.raise_for_status()
 ```
 
@@ -90,7 +90,7 @@ Some URL parameters provide regular expression matching (prefixed by `re_`).
 
 ##### cURL
 ```bash
-$ curl "https://${CORGI_DOMAIN}/api/v1/components?re_name=^curl$"
+$ curl "https://${CORGI_HOST}/api/v1/components?re_name=^curl$"
 ```
 
 ##### python
@@ -98,7 +98,7 @@ $ curl "https://${CORGI_DOMAIN}/api/v1/components?re_name=^curl$"
 import requests
 
 params = {"re_name": "^curl$"}
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components", params=params)
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components", params=params)
 response.raise_for_status()
 ```
 
@@ -108,7 +108,7 @@ You may also perform full text search:
 
 ##### cURL
 ```bash
-$ curl "https://${CORGI_DOMAIN}/api/v1/components?search=openjdk
+$ curl "https://${CORGI_HOST}/api/v1/components?search=openjdk
 ```
 
 ##### python
@@ -117,7 +117,7 @@ $ curl "https://${CORGI_DOMAIN}/api/v1/components?search=openjdk
 import requests
 
 params = {"search": "openjdk"}
-response = requests.get(f"https://{CORGI_DOMAIN}/api/v1/components", params=params)
+response = requests.get(f"https://{CORGI_HOST}/api/v1/components", params=params)
 response.raise_for_status()
 ```
 
@@ -145,7 +145,7 @@ The following is an example of one component (with some data omitted for brevity
 
 ```bash
 {
-    "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Arpm/redhat/rh-nodejs12-npm%406.14.16-12.22.12.2.el7%3Farch%3Daarch64",
+    "link": "https://$CORGI_HOST/api/v1/components?purl=pkg%3Arpm/redhat/rh-nodejs12-npm%406.14.16-12.22.12.2.el7%3Farch%3Daarch64",
     "download_url": "$BREW_WEB_URL/vol/rhel-7/packages/rh-nodejs12-nodejs/6.14.16/12.22.12.2.el7/aarch64/rh-nodejs12-npm-6.14.16-12.22.12.2.el7.aarch64.rpm",
     "uuid": "e3d37dc3-7469-4d52-a50c-4b7f36113511",
     "type": "RPM",
@@ -168,53 +168,53 @@ The following is an example of one component (with some data omitted for brevity
         "BSD"
     ],
     "software_build": {
-        "link": "https://corgi-stage.prodsec.redhat.com/api/v1/builds/2034513",
+        "link": "https://$CORGI_HOST/api/v1/builds/2034513",
         "build_id": 2034513,
         "type": "BREW",
         "name": "rh-nodejs12-nodejs",
-        "source": "git://pkgs.devel.redhat.com/rpms/nodejs#dba41e058293ae79f9b239b6f49c50e5d70f88d3"
+        "source": "git://pkgs.example.com/rpms/nodejs#dba41e058293ae79f9b239b6f49c50e5d70f88d3"
     },
     "errata": [],
     "products": [
         {
             "ofuri": "o:redhat:rhscl",
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/products?ofuri=o:redhat:rhscl&type=SRPM&limit=3000",
+            "link": "https://$CORGI_HOST/api/v1/products?ofuri=o:redhat:rhscl&type=SRPM&limit=3000",
             "name": "rhscl"
         }
     ],
     "product_versions": [
         {
             "ofuri": "o:redhat:rhscl:3",
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/product_versions?ofuri=o:redhat:rhscl:3&type=SRPM&limit=3000",
+            "link": "https://$CORGI_HOST/api/v1/product_versions?ofuri=o:redhat:rhscl:3&type=SRPM&limit=3000",
             "name": "rhscl-3"
         }
     ],
     "product_streams": [
         {
             "ofuri": "o:redhat:rhscl:3.8.z",
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/product_streams?ofuri=o:redhat:rhscl:3.8.z&type=SRPM&limit=3000",
+            "link": "https://$CORGI_HOST/api/v1/product_streams?ofuri=o:redhat:rhscl:3.8.z&type=SRPM&limit=3000",
             "name": "rhscl-3.8.z"
         },
         {
             "ofuri": "o:redhat:rhscl:3.9",
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/product_streams?ofuri=o:redhat:rhscl:3.9&type=SRPM&limit=3000",
+            "link": "https://$CORGI_HOST/api/v1/product_streams?ofuri=o:redhat:rhscl:3.9&type=SRPM&limit=3000",
             "name": "rhscl-3.9"
         }
     ],
     "product_variants": [],
     "sources": [
         {
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Asrpm/redhat/rh-nodejs12-nodejs%4012.22.12-2.el7%3Farch%3Dsrc",
+            "link": "https://$CORGI_HOST/api/v1/components?purl=pkg%3Asrpm/redhat/rh-nodejs12-nodejs%4012.22.12-2.el7%3Farch%3Dsrc",
             "purl": "pkg:srpm/redhat/rh-nodejs12-nodejs@12.22.12-2.el7?arch=src"
         }
     ],
     "provides": [
         {
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Anpm/lodash.restparam%403.6.1",
+            "link": "https://$CORGI_HOST/api/v1/components?purl=pkg%3Anpm/lodash.restparam%403.6.1",
             "purl": "pkg:npm/lodash.restparam@3.6.1"
         },
         {
-            "link": "https://corgi-stage.prodsec.redhat.com/api/v1/components?purl=pkg%3Anpm/wcwidth%401.0.1",
+            "link": "https://$CORGI_HOST/api/v1/components?purl=pkg%3Anpm/wcwidth%401.0.1",
             "purl": "pkg:npm/wcwidth@1.0.1"
         },
         [...SNIP...]
@@ -281,20 +281,20 @@ Take for example `NPM` artifact `is-svg` version `2.1.0`
 If you know the exact purl syntax you can search for it directly. Notice I added the -L flag to curl which follows redirects.
 
 ```bash
-curl -s -L https://{CORGI_HOST}/api/v1/components?purl=pkg:npm/is-svg@2.1.0
+curl -s -L https://${CORGI_HOST}/api/v1/components?purl=pkg:npm/is-svg@2.1.0
 ```
 
 Alternatively use the type, name and version fields:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?type=NPM&name=is-svg&version=2.1.0'
+curl -s https://${CORGI_HOST}/api/v1/components?type=NPM&name=is-svg&version=2.1.0
 ```
 
 This query returns a list of results include the component count. The component data can be found in the results field.
 The sources field lists all versions of all components which embed this component, it's useful to process the results on the client side to get a clearer picture of the packages included:
 
 ```bash
-$ curl -L -s 'https://{CORGI_HOST}/api/v1/components?purl=pkg:npm/is-svg@2.1.0' | jq '.sources[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
+$ curl -L -s https://${CORGI_HOST}/api/v1/components?purl=pkg:npm/is-svg@2.1.0 | jq '.sources[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
 pkg:container/redhat/console-ui-container
 pkg:container/redhat/devspaces-machineexec-rhel8-container
 pkg:container/redhat/devspaces-theia-rhel8-container
@@ -329,20 +329,20 @@ pkg:srpm/redhat/mozjs60
 Let's say you wanted to know which product streams the openshift-enterprise-console-container was shipped to. We could do component search using that name. Just using the name alone however returns nearly 500 results currently:
 
 ```bash
-$ curl -s 'https://{CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container' | jq '.count'
+$ curl -s https://${CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container | jq '.count'
 467
 ```
 
 Let's narrow down by specifying the arch to be 'noarch'. No arch containers represent an image index. It's sha256 digest can be used to pull the image on a container image registry client of any arch. In our data model noarch containers are parents of arch specific containers, or to use the taxonomy from the schema noarch containers provide arch specific containers.
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container&arch=noarch&limit=500' | jq '.results[] | .purl'
+curl -s "https://${CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container&arch=noarch&limit=500" | jq '.results[] | .purl'
 ```
 
 If we wanted to know which product streams this container was shipped to, we could filter and sort the results by product_streams field eg:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container&arch=noarch&limit=500' | jq '.results[] | .product_streams[] | .ofuri' | sort | uniq
+curl -s "https://${CORGI_HOST}/api/v1/components?name=openshift-enterprise-console-container&arch=noarch&limit=500" | jq '.results[] | .product_streams[] | .ofuri' | sort | uniq
 "o:redhat:openshift:4.10.z"
 "o:redhat:openshift:4.11.z"
 "o:redhat:openshift:4.4.z"
@@ -361,7 +361,7 @@ Using the current version of the API, we have to repeat the above query for each
 Suppose we were interested in which container products shipped the polkit RPM package. Since we don't know the version in this case, we search by name and type. Normally when we search for an RPM package we are interested in SRPMs, but they are not installed in containers, only arch specific RPMs are installed. We could choose any arch to search for, but let's use x86_64 as an example in this case. I made sure all results where included in a single query by increasing the limit to 50. Also let's process the results so that we only see a single container results, not all versions.
 
 ```bash
-$ curl -s 'https://{CORGI_HOST}/api/v1/components?type=RPM&name=polkit&&arch=x86_64&limit=50' | jq '.results[] | .sources[] | .purl' | grep 'pkg:container' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
+$ curl -s "https://${CORGI_HOST}/api/v1/components?type=RPM&name=polkit&&arch=x86_64&limit=50" | jq '.results[] | .sources[] | .purl' | grep 'pkg:container' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
 pkg:container/redhat/assisted-installer-agent-container
 pkg:container/redhat/cephcsi-container
 pkg:container/redhat/cluster-node-tuning-operator-container
@@ -393,7 +393,7 @@ pkg:container/redhat/vm-import-virtv2v-container
 If we wanted to know which product streams these containers ship to, we can look at the product_streams field for each of these containers one by one, for example:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?name=rhacm-assisted-installer-agent-container&arch=noarch' | jq '.results[] | .product_streams[] | .ofuri' | sort | uniq
+curl -s "https://${CORGI_HOST}/api/v1/components?name=rhacm-assisted-installer-agent-container&arch=noarch" | jq '.results[] | .product_streams[] | .ofuri' | sort | uniq
 "o:redhat:rhacm:2.3.z"
 "o:redhat:rhacm:2.4.z"
 ```
@@ -407,7 +407,7 @@ Upstream path could mean a few things, for example it could include golang modul
 Regardless everything in Component Registry is a component, so we can utilize regular expressions to search for components with a substring in the name, eg:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?re_name=github.com/ulikunitz/xz' | jq '.results[] | .purl'
+curl -s "https://${CORGI_HOST}/api/v1/components?re_name=github.com/ulikunitz/xz" | jq '.results[] | .purl'
 "pkg:golang/github.com/ulikunitz/xz@v0.5.9"
 "pkg:golang/github.com/ulikunitz/xz@0.5.10"
 "pkg:golang/github.com/ulikunitz/xz@v0.5.8"
@@ -423,7 +423,7 @@ curl -s 'https://{CORGI_HOST}/api/v1/components?re_name=github.com/ulikunitz/xz'
 If you want to exclude wildcard matches use a `name` query instead:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?name=github.com/ulikunitz/xz' | jq '.results[] | .purl'
+curl -s "https://${CORGI_HOST}/api/v1/components?name=github.com/ulikunitz/xz" | jq '.results[] | .purl'
 "pkg:golang/github.com/ulikunitz/xz@0.5.10"
 "pkg:golang/github.com/ulikunitz/xz@v0.5.10"
 "pkg:golang/github.com/ulikunitz/xz@v0.5.4"
@@ -437,7 +437,7 @@ curl -s 'https://{CORGI_HOST}/api/v1/components?name=github.com/ulikunitz/xz' | 
 Another example query, which returns both `golang` and `generic` results:
 
 ```bash
-curl -L -s 'https://{CORGI_HOST}/api/v1/components?re_name=github.com/3scale/apicast&limit=50' | jq '.results[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
+curl -L -s "https://${CORGI_HOST}/api/v1/components?re_name=github.com/3scale/apicast&limit=50" | jq '.results[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
 pkg:generic/github.com/3scale/apicast
 pkg:generic/github.com/3scale/apicast-operator
 pkg:golang/github.com/3scale/apicast-operator
@@ -460,7 +460,7 @@ Notice the `generic` namespace is used to denote an upstream source in Component
 You can use the `type` url parameters on the `components` endpoint to limit results to a single type. For example if we want to only include upstream types in the previous query, we use a query such as:
 
 ```bash
-curl -L -s 'https://{CORGI_HOST}/api/v1/components?type=UPSTREAM&re_name=github.com/3scale/apicast&limit=50' | jq '.results[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
+curl -L -s "https://${CORGI_HOST}/api/v1/components?type=UPSTREAM&re_name=github.com/3scale/apicast&limit=50" | jq '.results[] | .purl' | awk -F@ '{print $1}' | cut -c2- | sort | uniq
 pkg:generic/github.com/3scale/apicast
 pkg:generic/github.com/3scale/apicast-operator
 ```
@@ -468,7 +468,7 @@ pkg:generic/github.com/3scale/apicast-operator
 The types available to filter results on can be found in the openapi schema. These types are subject to change in future versions.
 
 ```bash
-curl -s https://{CORGI_HOST}/api/v1/schema?format=json | jq '.paths[] | .get | select(.operationId == "v1_components_list") | .parameters[] | select(.name == "type")'
+curl -s https://${CORGI_HOST}/api/v1/schema?format=json | jq '.paths[] | .get | select(.operationId == "v1_components_list") | .parameters[] | select(.name == "type")'
 {
   "in": "query",
   "name": "type",
@@ -495,7 +495,7 @@ curl -s https://{CORGI_HOST}/api/v1/schema?format=json | jq '.paths[] | .get | s
 The dependencies (dependent components) of a component are listed in the `provides` field of that component. For example:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?nvr=bare-metal-event-relay-operator-container-v4.11.1-56&arch=noarch' | jq '.results[] | .provides[] | .purl' | sort
+curl -s "https://${CORGI_HOST}/api/v1/components?nvr=bare-metal-event-relay-operator-container-v4.11.1-56&arch=noarch" | jq '.results[] | .provides[] | .purl' | sort
 "pkg:container/redhat/bare-metal-event-relay-operator-container@v4.11.1-56?arch=x86_64&digest=sha256:5350a1cc503912f67ef02f13bfbd0dac159d96d52fea96590f2e2fef0cb5c01d"
 "pkg:rpm/redhat/audit-libs@3.0.7-2.el8.2?arch=x86_64"
 "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch"
@@ -508,21 +508,21 @@ curl -s 'https://{CORGI_HOST}/api/v1/components?nvr=bare-metal-event-relay-opera
 Let's start listing all the active product streams in Component Registry. By default inactive product streams (those not listed as active in product_definitions) are excluded when listing all product_streams using the following query.
 
 ```bash
-$ curl -s 'https://{CORGI_HOST}/api/v1/product_streams' | jq '.count'
+$ curl -s https://${CORGI_HOST}/api/v1/product_streams | jq '.count'
 311
 ```
 
 If we wanted to include inactive streams as well, we'd do it like this:
 
 ```bash
-$ curl -s 'https://{CORGI_HOST}/api/v1/product_streams?active=all' | jq '.count'
+$ curl -s https://${CORGI_HOST}/api/v1/product_streams?active=all | jq '.count'
 1162
 ```
 
 Another useful property of product_streams we can filter on (client side) is the build_count. We can use a query such as this to limit the results to only the active product streams for which we have builds recorded.
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/product_streams?limit=311' | jq '.results[] | select(.build_count > 0) | .ofuri, .build_count'
+curl -s https://${CORGI_HOST}/api/v1/product_streams?limit=311 | jq '.results[] | select(.build_count > 0) | .ofuri, .build_count'
 "o:redhat:3amp:2"
 "o:redhat:amq:7"
 "o:redhat:amq-cl:2"
@@ -536,7 +536,7 @@ curl -s 'https://{CORGI_HOST}/api/v1/product_streams?limit=311' | jq '.results[]
 This time including the build_count and sorting by it:
 
 ```bash
-$ curl -s 'https://{CORGI_HOST}/api/v1/product_streams?limit=311' | jq -r '.results[] | select(.build_count > 0) | [.ofuri, .build_count] | @tsv' | sort -t$'\t' -k2 -nr
+$ curl -s https://${CORGI_HOST}/api/v1/product_streams?limit=311 | jq -r '.results[] | select(.build_count > 0) | [.ofuri, .build_count] | @tsv' | sort -t$'\t' -k2 -nr
 o:redhat:rhel:7.9.z	12984
 o:redhat:rhel:7.7.z	11151
 o:redhat:rhel:7.6.z	10594
@@ -552,14 +552,14 @@ o:redhat:openshift:4.6.z	7387
 Let's focus in on the `o:redhat:rhel-br:8.6.0.z` product stream, as it doesn't have too many components, and includes some rhel modules. We can inspect the `components` field of the product stream to get a link to the components filter for the root-level components in that stream:
 
 ```bash
-curl -s -L 'https://{CORGI_HOST}/api/v1/product_streams?ofuri=o:redhat:rhel-br:8.6.0.z' | jq '.components'
-"https://{CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&view=summary"
+curl -s -L https://${CORGI_HOST}/api/v1/product_streams?ofuri=o:redhat:rhel-br:8.6.0.z | jq '.components'
+"https://${CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&view=summary"
 ```
 
 Let's first make sure we're including all results:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&view=summary' | jq '.count'
+curl -s "https://${CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&view=summary" | jq '.count'
 1612
 ```
 
@@ -568,7 +568,7 @@ The reason this figure is less than the builds count (3085) is because the `ofur
 Since there are so many root-level components in the `o:redhat:rhel-br:8.6.0.z` product stream let's limit the results to only rhel modules:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&type=RHEL_MODULE' | jq '.results[] | .purl'
+curl -s "https://${CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&type=RHEL_MODULE" | jq ".results[] | .purl'
 "pkg:rpmmod/redhat/mariadb-devel@10.3-8010020190902091509.cdc1202b?context=cdc1202b&stream=10.3&version=8010020190902091509"
 "pkg:rpmmod/redhat/python38-devel@3.8-8020020200309184510.bbc63041?context=bbc63041&stream=3.8&version=8020020200309184510"
 "pkg:rpmmod/redhat/virt-devel@rhel-820190226174025.9edba152?context=9edba152&stream=rhel&version=820190226174025"
@@ -577,10 +577,10 @@ curl -s 'https://{CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&t
 To inspect the RPMs in those modules, simply inspect the `provides` property of each of them. In order to translate the purl into a url, it's best to use the `link` property instead of `purl` as used above, eg:
 
 ```bash
-curl -s 'https://{CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&type=RHEL_MODULE?limit=1' | jq '.results[] | .link'
-"https://{CORGI_HOST}/api/v1/components?purl=pkg%3Arpmmod/redhat/mariadb-devel%4010.3-8010020190902091509.cdc1202b%3Fcontext%3Dcdc1202b%26stream%3D10.3%26version%3D8010020190902091509"
+curl -s "https://${CORGI_HOST}/api/v1/components?ofuri=o:redhat:rhel-br:8.6.0.z&type=RHEL_MODULE?limit=1" | jq '.results[] | .link'
+"https://${CORGI_HOST}/api/v1/components?purl=pkg%3Arpmmod/redhat/mariadb-devel%4010.3-8010020190902091509.cdc1202b%3Fcontext%3Dcdc1202b%26stream%3D10.3%26version%3D8010020190902091509"
 
-curl -s -L 'https://{CORGI_HOST}/api/v1/components?purl=pkg%3Arpmmod/redhat/mariadb-devel%4010.3-8010020190902091509.cdc1202b%3Fcontext%3Dcdc1202b%26stream%3D10.3%26version%3D8010020190902091509' | jq '.provides[] | .purl'
+curl -s -L https://${CORGI_HOST}/api/v1/components?purl=pkg%3Arpmmod/redhat/mariadb-devel%4010.3-8010020190902091509.cdc1202b%3Fcontext%3Dcdc1202b%26stream%3D10.3%26version%3D8010020190902091509 | jq '.provides[] | .purl'
 "pkg:rpm/redhat/Judy-devel@1.0.5-18.module%2Bel8%2B2765%2Bcfa4f87b?arch=s390x"
 "pkg:rpm/redhat/Judy-devel@1.0.5-18.module%2Bel8%2B2765%2Bcfa4f87b?arch=aarch64"
 "pkg:rpm/redhat/mariadb-embedded-debuginfo@10.3.17-1.module%2Bel8.1.0%2B3974%2B90eded84?arch=i686"


### PR DESCRIPTION
Fixed some bash escaping issues. Also adjusted purls in the examples after changes in CORGI-224.

I set the description to include CORGI-396 just because an example there now shows how you can filter out container-sources client side.