### PR TITLE
CORGI-382: Add multidb routing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -269,7 +269,7 @@
         "filename": "tests/test_sca.py",
         "hashed_secret": "b6bed62bf61a2710e03218decfb836a10a7bce0a",
         "is_verified": true,
-        "line_number": 155,
+        "line_number": 159,
         "is_secret": false
       },
       {
@@ -277,10 +277,10 @@
         "filename": "tests/test_sca.py",
         "hashed_secret": "75272b8978226ca0852fd26fb75ed8c2bd4f4680",
         "is_verified": true,
-        "line_number": 181,
+        "line_number": 185,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-12-15T17:39:55Z"
+  "generated_at": "2022-12-15T20:52:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,14 +137,6 @@
         "is_verified": true,
         "line_number": 16,
         "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": true,
-        "line_number": 17,
-        "is_secret": false
       }
     ],
     "tests/data/2018747/sources": [
@@ -290,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-13T03:51:13Z"
+  "generated_at": "2022-12-15T17:39:55Z"
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -256,7 +256,21 @@ DATABASES = {
         # Prefer password authentication even if a valid Kerberos ticket exists on the system.
         # See: https://www.postgresql.org/docs/devel/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
         "OPTIONS": {"gssencmode": "disable"},
-    }
+    },
+    "read_only": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("CORGI_DB_NAME", "corgi-db"),
+        "USER": os.getenv("CORGI_DB_USER", "corgi-db-user"),
+        "PASSWORD": os.getenv("CORGI_DB_PASSWORD", "test"),
+        # Set up a "read-only" DB that defaults to above locally
+        "HOST": os.getenv("CORGI_DB_HOST_RO", os.getenv("CORGI_DB_HOST", "localhost")),
+        "PORT": os.getenv("CORGI_DB_PORT", "5432"),
+        # Prefer password authentication even if a valid Kerberos ticket exists on the system.
+        # See: https://www.postgresql.org/docs/devel/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
+        "OPTIONS": {"gssencmode": "disable"},
+        # When running tests, mirror all data from the default DB instead of using migrations
+        "TEST": {"MIGRATE": False, "MIRROR": "default"},
+    },
 }
 
 # Default primary key field type

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -9,16 +9,10 @@ DEBUG = True
 
 SECRET_KEY = get_random_secret_key()
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("CORGI_DB_NAME", "corgi-db"),
-        "USER": os.getenv("CORGI_DB_USER", "postgres"),
-        "PASSWORD": os.getenv("CORGI_DB_PASSWORD", "secret"),
-        "HOST": os.getenv("CORGI_DB_HOST", "localhost"),
-        "PORT": os.getenv("CORGI_DB_PORT", "5432"),
-    }
-}
+# Use PG's default admin user to allow creating the test database
+_user = os.getenv("CORGI_DB_USER", "postgres")
+DATABASES["default"]["USER"] = _user  # noqa: F405
+DATABASES["read_only"]["USER"] = _user  # noqa: F405
 
 SESSION_COOKIE_SECURE = False
 

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -81,16 +81,19 @@ def get_model_ofuri_type(ofuri: str) -> tuple[Optional[ProductModel], str]:
     ofuri_len = len(ofuri.split(":"))
 
     if ofuri_len == 3:
-        return Product.objects.filter(ofuri=ofuri).first(), "Product"
+        return Product.objects.filter(ofuri=ofuri).using("read_only").first(), "Product"
     elif ofuri_len == 5:
-        return ProductVariant.objects.filter(ofuri=ofuri).first(), "ProductVariant"
+        return (
+            ProductVariant.objects.filter(ofuri=ofuri).using("read_only").first(),
+            "ProductVariant",
+        )
     elif ofuri_len != 4:
         return missing_or_invalid
 
     # ProductVersions and ProductStreams both have 4 parts in their ofuri
-    if version := ProductVersion.objects.filter(ofuri=ofuri).first():
+    if version := ProductVersion.objects.filter(ofuri=ofuri).using("read_only").first():
         return version, "ProductVersion"
-    elif stream := ProductStream.objects.filter(ofuri=ofuri).first():
+    elif stream := ProductStream.objects.filter(ofuri=ofuri).using("read_only").first():
         return stream, "ProductStream"
     # TODO: Channels don't define an ofuri - should they?
     # else we know it's a version / stream but couldn't find a match
@@ -122,7 +125,7 @@ def get_channel_data_list(manager: Manager["Channel"]) -> list[dict[str, str]]:
     # And channels have no ofuri, so we return a model UUID link instead
     return [
         {"name": name, "link": get_model_id_link("channels", uuid), "uuid": str(uuid)}
-        for (name, uuid) in manager.values_list("name", "uuid")
+        for (name, uuid) in manager.values_list("name", "uuid").using("read_only")
     ]
 
 
@@ -144,7 +147,7 @@ def get_product_data_list(
     # we're accessing the reverse side of a relation with many objects (via a manager)
     return [
         {"name": name, "link": get_model_ofuri_link(model_name, ofuri), "ofuri": ofuri}
-        for (name, ofuri) in obj_or_manager.values_list("name", "ofuri")
+        for (name, ofuri) in obj_or_manager.values_list("name", "ofuri").using("read_only")
     ]
 
 
@@ -154,6 +157,7 @@ def get_product_relations(instance_name: str) -> list[dict[str, str]]:
         ProductComponentRelation.objects.filter(product_ref=instance_name)
         .values_list("type", "external_system_id")
         .distinct("external_system_id")
+        .using("read_only")
     )
     return [{"type": pcr_type, "external_system_id": pcr_id} for (pcr_type, pcr_id) in related_pcrs]
 

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import django_filters.rest_framework
-from django.db import connection
+from django.db import connections
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -117,7 +117,7 @@ class StatusViewSet(GenericViewSet):
         #        (https://wiki.postgresql.org/wiki/Slow_Counting)
         # the following approach provides an estimate for raw table counts which performs
         # much better.
-        with connection.cursor() as cursor:
+        with connections["read_only"].cursor() as cursor:
             cursor.execute("SELECT pg_size_pretty(pg_database_size(current_database()));")
             db_size = cursor.fetchone()
             cursor.execute(

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -490,6 +490,7 @@ def fetch_unprocessed_relations(
         ProductComponentRelation.objects.filter(type=relation_type, created_at__gte=created_since)
         .values_list("build_id", flat=True)
         .distinct()
+        .using("read_only")
     )
     logger.info(f"Processing relations of type {relation_type}")
     processed_builds = 0
@@ -497,7 +498,7 @@ def fetch_unprocessed_relations(
         if not build_id:
             # build_id defaults to "" and int() will fail in this case
             continue
-        if not SoftwareBuild.objects.filter(build_id=int(build_id)).exists():
+        if not SoftwareBuild.objects.filter(build_id=int(build_id)).using("read_only").exists():
             logger.info("Processing CDN relation build with id: %s", build_id)
             slow_fetch_modular_build.delay(build_id, force_process=force_process)
             processed_builds += 1

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -56,6 +56,7 @@ def get_last_success_for_task(task_name: str) -> timezone.datetime:
         TaskResult.objects.filter(task_name=task_name, status="SUCCESS")
         .order_by("-date_created")
         .values_list("date_created", flat=True)
+        .using("read_only")
         .first()
     )
     return (

--- a/corgi/tasks/management/commands/coveragereport.py
+++ b/corgi/tasks/management/commands/coveragereport.py
@@ -10,7 +10,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write("ofuri, #builds, #components")
         self.stdout.write("---------------------------------------")
-        for ps in ProductStream.objects.all():
-            component_count = Component.objects.filter(product_streams__icontains=ps.ofuri).count()
+        for ps in ProductStream.objects.get_queryset().using("read_only"):
+            component_count = (
+                Component.objects.filter(product_streams__icontains=ps.ofuri)
+                .using("read_only")
+                .count()
+            )
             if ps.builds.count() > 0 or component_count > 0:
                 self.stdout.write(f"{ps.ofuri}, {ps.builds.count()}, {component_count}")

--- a/corgi/tasks/management/commands/loadbrewdata.py
+++ b/corgi/tasks/management/commands/loadbrewdata.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         if options["build_ids"]:
             build_ids = options["build_ids"]
         elif options["stream"]:
-            ps = ProductStream.objects.get(name=options["stream"])
+            ps = ProductStream.objects.db_manager("read_only").get(name=options["stream"])
             brew = Brew()
             build_ids = set()
             for brew_tag, inherit in ps.brew_tags.items():

--- a/corgi/tasks/management/commands/loadpulpdata.py
+++ b/corgi/tasks/management/commands/loadpulpdata.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
 
     def get_builds_by_cdn_repo(self, stream_name: str, force_process: bool):
         self.stdout.write(self.style.NOTICE(f"Called save cdn repo with stream {stream_name}"))
-        ps = ProductStream.objects.get(name=stream_name)
+        ps = ProductStream.objects.db_manager("read_only").get(name=stream_name)
         stream_or_variant_names = (stream_name, *ps.productvariants.values_list("name", flat=True))
         relations_query = (
             ProductComponentRelation.objects.filter(
@@ -51,5 +51,6 @@ class Command(BaseCommand):
             )
             .values_list("build_id", flat=True)
             .distinct()
+            .using("read_only")
         )
         fetch_modular_builds(relations_query, force_process=force_process)

--- a/corgi/tasks/management/commands/loadunprocessedrelations.py
+++ b/corgi/tasks/management/commands/loadunprocessedrelations.py
@@ -25,11 +25,12 @@ class Command(BaseCommand):
             )
             .values_list("build_id", flat=True)
             .distinct()
+            .using("read_only")
             .iterator()
         ):
             if not build_id:
                 continue
-            if not SoftwareBuild.objects.filter(build_id=int(build_id)).exists():
+            if not SoftwareBuild.objects.filter(build_id=int(build_id)).using("read_only").exists():
                 self.stdout.write(self.style.SUCCESS(f"Loading build with id: {build_id}"))
                 slow_fetch_modular_build.delay(build_id)
                 processed_builds += 1

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -88,6 +88,7 @@ def email_failed_tasks():
         )
         .order_by("task_name", "date_done")
         .values_list("task_name", "task_args", "task_kwargs", "result", "traceback")
+        .using("read_only")
     )
 
     subject = (

--- a/corgi/web/views.py
+++ b/corgi/web/views.py
@@ -79,7 +79,8 @@ def data_list(request: HttpRequest) -> HttpResponse:
         "data.html",
         {
             "counts": [
-                (model._meta.verbose_name_plural, model.objects.count()) for model in models
+                (model._meta.verbose_name_plural, model.objects.db_manager("read_only").count())
+                for model in models
             ],
             "nbar": "data",  # Navbar identifier
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       POSTGRESQL_DATABASE: corgi-db
       POSTGRESQL_USER: corgi-db-user
       POSTGRESQL_PASSWORD: "test"
-      POSTGRESQL_ADMIN_PASSWORD: "secret"
+      POSTGRESQL_ADMIN_PASSWORD: "test"
     volumes:
       - corgi-pg-data:/var/lib/pgsql/data/
       # Config files in below directory are automatically loaded by postgres at startup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,8 @@ services:
     container_name: corgi-flower
     hostname: flower
     image: corgi
+    env_file:
+      - .env
     environment:
       CORGI_DB_HOST: corgi-db
     depends_on: ["redis", "corgi-db"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ addopts = """
 --strict-config --strict-markers
 """
 markers = [
+    "django_db",
     "unit",
     "integration",
 ]

--- a/run_celery_cpu.sh
+++ b/run_celery_cpu.sh
@@ -6,4 +6,4 @@
 # ERROR: Pidfile (/tmp/cpu.pid) already exists.
 rm -f /tmp/cpu.pid
 
-exec celery -A config worker -E --loglevel info --pidfile /tmp/cpu.pid -Q cpu -n celery@%h
+exec celery -A config worker -E --loglevel info --pidfile /tmp/cpu.pid -c 1 -Q cpu -n celery@%h

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,6 @@ from rest_framework.test import APIClient
 from corgi.api.constants import CORGI_API_VERSION
 
 
-@pytest.fixture(autouse=True)
-def enable_db_access_for_all_tests(db):
-    """Allow using database automatically, without needing to mark each test"""
-    pass
-
-
 @pytest.fixture
 def client():
     return APIClient()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,13 +22,15 @@ from .factories import (
 
 pytestmark = pytest.mark.unit
 
-PRODUCT_DEFINITIONS_CASSETTE = "test_products.yaml"
-
 
 def extract_tag_tuples(tags: list[dict]) -> set[tuple]:
     return {(t["name"], t["value"]) for t in tags}
 
 
+# Different DB names which really point to the same DB run in different transactions by default
+# so writes to "default" don't appear in "read_only" without workarounds
+# https://code.djangoproject.com/ticket/23718#comment:6
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_software_build_details(client, api_path):
     build = SoftwareBuildFactory(tag__name="t0", tag__value="v0")
 
@@ -44,6 +46,7 @@ def test_software_build_details(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 @pytest.mark.parametrize(
     "model, endpoint_name",
     [
@@ -71,6 +74,7 @@ def test_product_data_detail(model, endpoint_name, client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_channel_detail(client, api_path):
     p1 = ChannelFactory(name="Repo1")
 
@@ -83,6 +87,7 @@ def test_channel_detail(client, api_path):
     assert response.json()["name"] == "Repo1"
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_detail(client, api_path):
     c1 = ComponentFactory(name="curl")
 
@@ -95,6 +100,7 @@ def test_component_detail(client, api_path):
     assert response.json()["name"] == "curl"
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_detail_olcs_put(client, api_path):
     """Test that OpenLCS can upload scan results for a component"""
     c1 = ComponentFactory()
@@ -143,6 +149,7 @@ def test_component_detail_olcs_put(client, api_path):
     assert response.status_code == 404
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_detail_dev(client, api_path):
     upstream = ComponentFactory(
         name="upstream",
@@ -184,6 +191,7 @@ def test_component_detail_dev(client, api_path):
     # assert dev_comp.purl in response.json()["provides"][0]["purl"]
 
 
+@pytest.mark.django_db
 def test_component_write_not_allowed(client, api_path):
     # Currently, only read operations are allowed on all models besides tags
     c = ComponentFactory(name="curl")
@@ -193,6 +201,7 @@ def test_component_write_not_allowed(client, api_path):
     assert response.status_code == 405
 
 
+@pytest.mark.django_db(databases=("read_only",))
 def test_component_does_not_exist(client, api_path):
     response = client.get(f"{api_path}/components/18ead2f2-6e0a-409c-8135-79f0f4d7740d")
     assert response.status_code == 404
@@ -262,6 +271,7 @@ def test_component_tags_delete(client, api_path):
     assert response.json()["tags"] == []
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_add_uri(client, api_path):
     c1 = ComponentFactory(
         name="curl",
@@ -278,6 +288,7 @@ def test_component_add_uri(client, api_path):
     assert tags == {"name": "component_review", "value": "https://someexample.org/review/curl.doc"}
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_srpm_detail(client, api_path):
     c1 = SrpmComponentFactory(name="curl-7.19.7-35.el6.src")
     response = client.get(f"{api_path}/components?type=RPM&arch=src")
@@ -293,6 +304,7 @@ def test_srpm_detail(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_rpm_detail(client, api_path):
     c1 = ComponentFactory(
         type=Component.Type.RPM, name="curl", version="7.19.7", release="35.el6", arch="x86_64"
@@ -310,6 +322,7 @@ def test_rpm_detail(client, api_path):
     assert response.headers["Location"] == f"{api_path}/components/{c1.uuid}"
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_purl_reserved(client, api_path):
     c1 = ComponentFactory(
         name="dbus-glib-debuginfo",
@@ -326,6 +339,7 @@ def test_purl_reserved(client, api_path):
     assert response.status_code == 302
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_re_name_filter(client, api_path):
     c1 = ComponentFactory(type=Component.Type.RPM, name="autotrace-devel")
     response = client.get(f"{api_path}/components?type=RPM")
@@ -337,6 +351,7 @@ def test_re_name_filter(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_re_purl_filter(client, api_path):
     c1 = ComponentFactory(
         type=Component.Type.RPM, namespace=Component.Namespace.REDHAT, name="autotrace-devel"
@@ -352,6 +367,7 @@ def test_re_purl_filter(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_nvr_nevra_filter(client, api_path):
     c1 = ComponentFactory(
         type=Component.Type.RPM,
@@ -373,6 +389,7 @@ def test_nvr_nevra_filter(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_filter_component_tags(client, api_path):
     openssl = ComponentFactory(name="openssl", type=Component.Type.RPM, tag=None)
     ComponentTagFactory(tagged_model=openssl, name="prodsec_priority", value="")
@@ -455,6 +472,7 @@ def test_retrieve_lifecycle_defs(requests_mock):
     ] == sorted(data[0].keys())
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_products(client, api_path):
     ProductFactory(name="rhel")
     ProductFactory(name="rhel-av")
@@ -470,6 +488,7 @@ def test_products(client, api_path):
     assert response.status_code == 302
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_versions(client, api_path):
     ProductVersionFactory(name="rhel-8", version="8")
     ProductVersionFactory(name="rhel-av-8", version="8")
@@ -485,6 +504,7 @@ def test_product_versions(client, api_path):
     assert response.status_code == 302
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_streams(client, api_path):
     ProductStreamFactory(name="rhel-8.5.0-z", version="8.5.0-z")
     ProductStreamFactory(name="rhel-av-8.5.0-z", version="8.5.0-z", active=False)
@@ -504,6 +524,7 @@ def test_product_streams(client, api_path):
     assert response.status_code == 302
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_variants(client, api_path):
     pv_appstream = ProductVariantFactory(name="AppStream-8.5.0.Z.MAIN")
     pv_baseos = ProductVariantFactory(name="BaseOS-8.5.0.Z.MAIN")
@@ -519,6 +540,7 @@ def test_product_variants(client, api_path):
     assert response.status_code == 302
 
 
+@pytest.mark.django_db(databases=("read_only",))
 def test_status(client, api_path):
     response = client.get(f"{api_path}/status")
     assert response.status_code == 200
@@ -531,6 +553,7 @@ def test_api_listing(client, api_path):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db(databases=("read_only",))
 def test_api_component_404(client, api_path):
     response = client.get(
         f"{api_path}/components?purl=pkg:rpm/redhat/non-existent-fake-libs@3.26.0-15.el8?arch=x86_64"  # noqa
@@ -543,6 +566,7 @@ def test_api_component_400(client, api_path):
     assert response.status_code == 400
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_components_ofuri(client, api_path):
     """test 'latest' filter on components"""
 
@@ -584,6 +608,7 @@ def test_product_components_ofuri(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_components_versions(client, api_path):
     ps1 = ProductStreamFactory(name="rhel-7", version="7")
     assert ps1.ofuri == "o:redhat:rhel:7"
@@ -619,6 +644,7 @@ def test_product_components_versions(client, api_path):
     assert response.json()["count"] == 1
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_components(client, api_path):
     openssl = ComponentFactory(name="openssl")
     curl = ComponentFactory(name="curl")

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -622,6 +622,7 @@ def test_extract_golang(test_data_file, expected_component):
     assert len(remaining) == 0
 
 
+@pytest.mark.django_db
 def test_save_component():
     software_build = SoftwareBuildFactory()
 
@@ -681,6 +682,7 @@ def test_extract_image_components(mock_koji_session, monkeypatch):
     assert set(noarch_rpms_by_id.keys()) == set(NOARCH_RPM_IDS)
 
 
+@pytest.mark.django_db
 @patch("corgi.tasks.brew.Brew")
 @patch("corgi.tasks.sca.cpu_software_composition_analysis.delay")
 def test_fetch_rpm_build(mock_sca, mock_brew):
@@ -729,6 +731,7 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
     assert sorted(jquery.get_sources_purls()) == ["pkg:rpm/redhat/cockpit@251-1.el8?arch=src"]
 
 
+@pytest.mark.django_db
 @patch("corgi.tasks.brew.Brew")
 @patch("corgi.tasks.brew.cpu_software_composition_analysis.delay")
 @patch("corgi.tasks.brew.slow_load_errata.delay")
@@ -772,6 +775,7 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
     mock_sca.assert_called_with(1781353)
 
 
+@pytest.mark.django_db
 @patch("corgi.core.models.SoftwareBuild.save_product_taxonomy")
 def test_new_software_build_relation(mock_save_prod_tax):
     sb = SoftwareBuildFactory()

--- a/tests/test_errata_data.py
+++ b/tests/test_errata_data.py
@@ -20,7 +20,7 @@ from corgi.tasks.errata_tool import slow_load_errata, update_variant_repos
 
 from .factories import ProductStreamFactory, ProductVariantFactory
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
 
 def test_update_variant_repos():

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -24,7 +24,7 @@ from .factories import (
 )
 
 logger = logging.getLogger()
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
 
 def test_product_manifest_properties():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,7 +27,7 @@ from .factories import (
     SrpmComponentFactory,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
 
 def test_product_model():

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -14,6 +14,7 @@ from corgi.tasks.prod_defs import update_products
 pytestmark = pytest.mark.unit
 
 
+@pytest.mark.django_db
 def test_products(requests_mock):
     with open("tests/data/product-definitions.json") as prod_defs:
         text = prod_defs.read()

--- a/tests/test_rhel_compose.py
+++ b/tests/test_rhel_compose.py
@@ -21,6 +21,7 @@ srpm_build_id = 1
 rpm_nvr = "389-ds-base-1.4.3.28-6.module+el8.6.0+14129+983ceada.x86_64"
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.brew.Brew.brew_srpm_lookup")
 @patch("corgi.collectors.brew.Brew.brew_rpm_lookup")
 def test_fetch_module_data(mock_brew_rpm_lookup, mock_brew_srpm_lookup, requests_mock):
@@ -57,6 +58,7 @@ def test_fetch_module_data(mock_brew_rpm_lookup, mock_brew_srpm_lookup, requests
     assert rpm.srpm == srpm
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.brew.Brew.fetch_rhel_module", return_value={})
 @patch("corgi.tasks.brew.slow_fetch_brew_build.delay")
 def test_get_builds(mock_fetch_rhel_module, mock_slow_fetch_brew_build):
@@ -76,6 +78,7 @@ def test_get_builds(mock_fetch_rhel_module, mock_slow_fetch_brew_build):
     assert mock_slow_fetch_brew_build.call_count == 1
 
 
+@pytest.mark.django_db
 @patch("corgi.tasks.brew.slow_fetch_brew_build.delay")
 def test_fetch_compose_build(mock_fetch_brew):
     modular_rpm = _set_up_rhel_compose()
@@ -91,6 +94,7 @@ def test_fetch_compose_build(mock_fetch_brew):
     assert mock_fetch_brew.called_with(srpm_build_id)
 
 
+@pytest.mark.django_db
 def test_fetch_rhel_module():
     _set_up_rhel_compose()
     assert not Brew.fetch_rhel_module(2)
@@ -135,6 +139,7 @@ def mock_fetch_rpm_data(compose_url, variants):
     yield "1533085"
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.rhel_compose.RhelCompose._fetch_rpm_data", new=mock_fetch_rpm_data)
 def test_save_compose(requests_mock):
     composes = {f"{base_url}/rhel-8/rel-eng/RHEL-8/RHEL-8.4.0-RC-1.2/compose": ["AppStream"]}

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -77,6 +77,7 @@ def test_golist_scan_files(go_source):
     assert GoList.scan_files([archive])
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.go_list.GoList.scan_files")
 def test_add_go_stdlib_version(go_list_scan_files):
     go_list_scan_files.return_value = [
@@ -93,6 +94,7 @@ def test_add_go_stdlib_version(go_list_scan_files):
     Component.objects.get(type=Component.Type.GOLANG, name="go-package", version=GO_STDLIB_VERSION)
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.go_list.GoList.scan_files")
 def test_anchor_node_without_go_stdlib_version(go_list_scan_files):
     go_list_scan_files.return_value = [
@@ -108,6 +110,7 @@ def test_anchor_node_without_go_stdlib_version(go_list_scan_files):
     assert go_package.version == ""
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.go_list.GoList.scan_files")
 def test_go_package_with_version(go_list_scan_files):
     go_list_scan_files.return_value = [
@@ -126,6 +129,7 @@ def test_go_package_with_version(go_list_scan_files):
     assert go_package.version == GO_PACKAGE_VERSION
 
 
+@pytest.mark.django_db
 @patch("corgi.collectors.go_list.GoList.scan_files")
 def test_go_package_type(go_list_scan_files):
     go_list_scan_files.return_value = [
@@ -361,6 +365,7 @@ def mock_clone(package_name: str, build_id: int) -> Tuple[Path, str, str]:
     return target_path, package_type, package_name
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "build_id,is_container,package_name,lookaside_file,download_path,syft_results,expected_purl",
     slow_software_composition_analysis_test_data,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,6 +28,7 @@ def test_not_found(client):
     assert response.status_code == 404
 
 
+@pytest.mark.django_db(databases=("read_only",))
 def test_viewset_ordering(api_path):
     """Test that all ViewSets define an ordering to prevent DRF pagination bugs"""
     for name, cls in views.__dict__.items():

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ passenv =
     CORGI_DB_USER
     CORGI_DB_PASSWORD
     CORGI_DB_HOST
+    CORGI_DB_HOST_RO
     CORGI_DB_PORT
     # Internal hostnames or URLs that appear in build metadata; used in tests
     CORGI_TEST_DOWNLOAD_URL


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This is ready for discussion and review, but let's wait to merge until after Monday's release.

I see CPU usage in our database spike around 6AM UTC, and then go back to normal around 8AM UTC. (No dashboard link since it's an internal resource). This is the same time that the "fetch_unprocessed_*_relations" tasks run. Those tasks only do two things:

1) Find all the relations which were created after the last successful task run
2) For each relation, schedule a slow_fetch_brew_build task for the associated build ID

This only involves a read from the database and a write to Redis (putting a new task onto the queue). The follow-up slow_fetch_brew_build tasks themselves will obviously write a lot of data, but that's separate from the ProductComponentRelations table reading and Celery task scheduling that happens in the fetch_unprocessed_*_relations tasks.

In order to reduce CPU load on the main / writable DB instance in AWS, we can move all read-only workloads onto the read-only replica DB instance:
1) fetch_unprocessed_relations
2) daily monitoring email (only generates a report, doesn't change data)
3) all GET API endpoints (future PUT API endpoints will use the writable DB instance by default, no special action needed)
4) management commands that e.g. generate reports or schedule Celery tasks only, without changing DB data

This means that if we have many users of our web API (or are doing reconciliation), an overloaded (read-only) database will not cause data loss or interfere with ingestion (make slow_fetch_brew_build tasks fail due to timeouts).

It also means that if we are ingesting large amounts of data, an overloaded (writable) database will not reduce performance of our web APIs or cause an outage that could impact our users.

Finally, by spreading load across both the writable and read-only databases, I hope both "overloaded database" outcomes above will be less likely.

Or if this change doesn't reduce the CPU usage / number of SoftTimeLimitExceeded errors, then I'll need to keep debugging the cause of CORGI-386. But splittling the workloads onto separate DBs will at least help me determine what tasks / queries are overloading our database, with a little better granularity than what we have today.

I've deployed this change and the limit increases from CORGI-375 into stage for testing over the weekend. I'll check the error emails and SignalFX dashboards on Monday morning to see if we had fewer errors or better performance, then add a note here with findings.