### PR TITLE
CORGI-382: Add multidb routing in more places

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,7 +1,7 @@
 {# Component manifest, obj is a Component here #}
 {% extends "base_manifest.json" %}
 {% block packages %}
-{% for component in obj.provides.get_queryset %}
+{% for component in obj.provides_queryset %}
         {% include "package_manifest.json" %}
     {% endfor %}
     {

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -3,7 +3,7 @@
 {% block packages %}
 {% for component in obj.get_latest_components %}{# Below will eventually become component.manifest #}
         {% include "package_manifest.json" %}
-        {% for provided in component.provides.get_queryset %}
+        {% for provided in component.provides_queryset %}
             {% include "package_manifest.json" with component=provided %}
         {% endfor %}
     {% endfor %}

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -704,9 +704,9 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
         "pkg:rpm/redhat/cockpit-system@251-1.el8?arch=noarch",
     ):
         assert package in provides
-    assert len(srpm.get_upstreams_purls()) == 1
+    assert len(srpm.get_upstreams_purls(using="default")) == 1
     # SRPM has no sources of its own (nor is it embedded in any other component)
-    assert srpm.get_sources_purls().count() == 0
+    assert srpm.get_sources_purls(using="default").count() == 0
     cockpit_system = Component.objects.get(
         type=Component.Type.RPM,
         namespace=Component.Namespace.REDHAT,
@@ -717,7 +717,7 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
     )
     assert cockpit_system.software_build
     # Cockpit has its own SRPM
-    assert sorted(cockpit_system.get_sources_purls()) == [
+    assert sorted(cockpit_system.get_sources_purls(using="default")) == [
         "pkg:rpm/redhat/cockpit@251-1.el8?arch=src"
     ]
     jquery = Component.objects.get(
@@ -728,7 +728,9 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
     )
     assert not jquery.software_build
     # jQuery is embedded in Cockpit
-    assert sorted(jquery.get_sources_purls()) == ["pkg:rpm/redhat/cockpit@251-1.el8?arch=src"]
+    assert sorted(jquery.get_sources_purls(using="default")) == [
+        "pkg:rpm/redhat/cockpit@251-1.el8?arch=src"
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -695,14 +695,14 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
     assert srpm.software_build
     assert srpm.software_build.build_id
     assert srpm.epoch == 0
-    provides = srpm.get_provides_purls()
+    provides = srpm.get_provides_purls(using="default")
     assert len(provides) == 30
-    for package in [
+    for package in (
         "pkg:npm/jquery@3.5.1",
         "pkg:generic/xstatic-patternfly-common@3.59.5",
         "pkg:generic/xstatic-bootstrap-datepicker-common@1.9.0",
         "pkg:rpm/redhat/cockpit-system@251-1.el8?arch=noarch",
-    ]:
+    ):
         assert package in provides
     assert len(srpm.get_upstreams_purls()) == 1
     # SRPM has no sources of its own (nor is it embedded in any other component)

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -24,7 +24,10 @@ from .factories import (
 )
 
 logger = logging.getLogger()
-pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.django_db(databases=("default", "read_only"), transaction=True),
+]
 
 
 def test_product_manifest_properties():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -220,8 +220,8 @@ def test_get_roots():
         purl=rpm.purl,
         defaults={"obj": rpm},
     )
-    assert rpm.get_roots == [srpm_cnode]
-    assert srpm.get_roots == [srpm_cnode]
+    assert rpm.get_roots(using="default") == [srpm_cnode]
+    assert srpm.get_roots(using="default") == [srpm_cnode]
 
     nested = ComponentFactory(name="nested")
     ComponentNode.objects.get_or_create(
@@ -230,7 +230,7 @@ def test_get_roots():
         purl=nested.purl,
         defaults={"obj": nested},
     )
-    assert nested.get_roots == [srpm_cnode]
+    assert nested.get_roots(using="default") == [srpm_cnode]
 
     container = ContainerImageComponentFactory(name="container")
     container_cnode, _ = ComponentNode.objects.get_or_create(
@@ -246,8 +246,8 @@ def test_get_roots():
         purl=container_rpm.purl,
         defaults={"obj": container_rpm},
     )
-    assert not container_rpm.get_roots
-    assert container.get_roots == [container_cnode]
+    assert not container_rpm.get_roots(using="default")
+    assert container.get_roots(using="default") == [container_cnode]
 
     container_source = ComponentFactory(
         name="container_source", namespace=Component.Namespace.UPSTREAM, type=Component.Type.GITHUB
@@ -258,7 +258,7 @@ def test_get_roots():
         purl=container_source.purl,
         defaults={"obj": container_source},
     )
-    assert container_source.get_roots == [container_cnode]
+    assert container_source.get_roots(using="default") == [container_cnode]
     container_nested = ComponentFactory(name="container_nested", type=Component.Type.NPM)
     ComponentNode.objects.get_or_create(
         type=ComponentNode.ComponentNodeType.PROVIDES,
@@ -266,7 +266,7 @@ def test_get_roots():
         purl=container_nested.purl,
         defaults={"obj": container_nested},
     )
-    assert container_nested.get_roots == [container_cnode]
+    assert container_nested.get_roots(using="default") == [container_cnode]
 
 
 def test_product_component_relations():
@@ -301,6 +301,7 @@ def test_product_component_relations_errata():
     assert rhel_8_2 in c.productstreams.get_queryset()
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_stream_builds():
     rhel_8_2_build = SoftwareBuildFactory()
     rhel_8_2_base_build = SoftwareBuildFactory()
@@ -373,7 +374,7 @@ def test_get_upstream():
         purl=srpm_upstream.purl,
         defaults={"obj": srpm_upstream},
     )
-    assert sorted(rpm.get_upstreams_purls()) == [srpm_upstream.purl]
+    assert sorted(rpm.get_upstreams_purls(using="default")) == [srpm_upstream.purl]
 
 
 def test_get_upstream_container():
@@ -391,7 +392,7 @@ def test_get_upstream_container():
         purl=container_rpm.purl,
         defaults={"obj": container_rpm},
     )
-    assert container_rpm.get_upstreams_purls() == set()
+    assert container_rpm.get_upstreams_purls(using="default") == set()
 
     container_source = ContainerImageComponentFactory(name="container_source")
     container_source_cnode, _ = ComponentNode.objects.get_or_create(
@@ -408,7 +409,7 @@ def test_get_upstream_container():
         purl=container_source.purl,
         defaults={"obj": container_nested},
     )
-    assert sorted(container_nested.get_upstreams_purls()) == [container_source.purl]
+    assert sorted(container_nested.get_upstreams_purls(using="default")) == [container_source.purl]
 
     container_o_source = ComponentFactory(
         name="contain_upstream_other",
@@ -431,7 +432,9 @@ def test_get_upstream_container():
         purl=container_other_nested.purl,
         defaults={"obj": container_other_nested},
     )
-    assert sorted(container_other_nested.get_upstreams_purls()) == [container_o_source.purl]
+    assert sorted(container_other_nested.get_upstreams_purls(using="default")) == [
+        container_o_source.purl
+    ]
 
 
 def test_duplicate_insert_fails():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -49,6 +49,7 @@ def test_productstream_model():
     assert p1.cpe == "cpe:/o:redhat:enterprise_linux:8"
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_cpes():
     p1 = ProductFactory(name="RHEL")
     pv1 = ProductVersionFactory(name="RHEL-7", version="7", products=p1)
@@ -191,7 +192,7 @@ def test_component_provides():
         purl=dev_comp.purl,
         defaults={"obj": dev_comp},
     )
-    assert dev_comp.purl in upstream.get_provides_purls()
+    assert dev_comp.purl in upstream.get_provides_purls(using="default")
 
 
 def test_software_build_model():


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Follow-up MR to shift more load to the read-only DB, which I missed the first time around. Please don't feel rushed to review this - I'm only opening this so I don't forget, but this can certainly wait until after the holidays.

The changes here:
1) Make templates / manifests use the read-only DB, including the cpes ProductModel property, the get_latest_components ProductStream model function, and the get_provides_* Component model functions.

2) Make the builds and coverage ProductModel properties use the read-only DB, which are only used for reporting as far as I can tell.

3) Make the get_sources_* and get_upstreams_* Component model functions use the read-only DB, when they are being used by a serializer / our API.

4) Make the get_sources_* and get_upstreams_* Component model functions use the default writable DB instance, when they're being used by save_component_taxonomy(). This avoids race conditions where we might read stale data from the replica DB and then save it into the primary DB, overwriting more current data.