### PR TITLE
CORGI-420: Fix errors in emails and /taxonomy endpoint

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -211,7 +211,7 @@ def recursive_product_node_to_dict(node):
 def get_component_taxonomy(obj: Component, component_types: list[str]):
     """Look up and return the taxonomy for a particular Component."""
     root_nodes = cache_tree_children(
-        obj.cnodes.get_descendants(include_self=True).using("read_only")
+        obj.cnodes.get_queryset().get_descendants(include_self=True).using("read_only")
     )
     dicts = []
     for n in root_nodes:
@@ -227,7 +227,7 @@ def get_component_taxonomy(obj: Component, component_types: list[str]):
 def get_product_taxonomy(obj: ProductModel):
     """Look up and return the taxonomy for a particular ProductModel instance."""
     root_nodes = cache_tree_children(
-        obj.pnodes.get_descendants(include_self=True).using("read_only")
+        obj.pnodes.get_queryset().get_descendants(include_self=True).using("read_only")
     )
     dicts = []
     for n in root_nodes:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1222,12 +1222,12 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
     @property
     def errata(self) -> list[str]:
         """Return errata that contain component."""
-        if not self.software_build:
+        if not self.software_build_id:
             return []
         errata_qs = (
             ProductComponentRelation.objects.filter(
                 type=ProductComponentRelation.Type.ERRATA,
-                build_id=self.software_build.build_id,
+                build_id=self.software_build_id,
             )
             .values_list("external_system_id", flat=True)
             .distinct()

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1231,6 +1231,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             )
             .values_list("external_system_id", flat=True)
             .distinct()
+            .using("read_only")
         )
         return list(erratum for erratum in errata_qs if erratum)
 

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -1,27 +1,28 @@
 import logging
 import subprocess
 from datetime import timedelta
-from ssl import SSLError
 
-from django.db.utils import InterfaceError
+from django.db.utils import InterfaceError as DjangoInterfaceError
 from django.utils import timezone
 from django_celery_results.models import TaskResult
 from psycopg2.errors import InterfaceError as Psycopg2InterfaceError
+from redis.exceptions import ConnectionError as RedisConnectionError
 from requests.exceptions import RequestException
 
 from corgi.core.models import ProductComponentRelation
 
 BACKOFF_KWARGS = {"max_tries": 5, "jitter": None}
 
+# DjangoInterfaceError should just be a wrapper around Psycopg2InterfaceError
+# But check for and retry both just in case
 # InterfaceError is "connection already closed" or some other connection-level error
 # This can be safely retried. OperationalError is potentially a connection-level error
 # But can also be due to database operation failures that should NOT be retried
 RETRYABLE_ERRORS = (
-    InterfaceError,
+    DjangoInterfaceError,
     Psycopg2InterfaceError,
+    RedisConnectionError,
     RequestException,
-    SSLError,
-    TimeoutError,
 )
 
 RETRY_KWARGS = {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -343,6 +343,7 @@ def test_product_stream_builds():
     assert rhel_8_2_build.build_id not in [int(b) for b in rhel_8_1.builds]
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_errata():
     sb = SoftwareBuildFactory()
     c = ComponentFactory(software_build=sb)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This PR adds RedisConnectionError (high-level Redis error) to the list of exceptions we retry if a Celery task fails.

It also removes low-level errors like SSLError and TimeoutError from the list of retryable errors. Those exceptions should eventually raise some higher-level error like InterfaceError or RequestException. Retrying only high-level errors from specific libraries makes our task retry logic more predictable.

The changes in corgi/api/views.py fix recent bugs / errors seen in emails for the taxonomy endpoints. I also added type hints and combined some identical code, to avoid fixing the same things in multiple places and hopefully prevent these kinds of issues in the future.

Finally, I updated yet another model property to use the read-only DB, since .errata is only used by the API serializers.