### PR TITLE
CORGI-420: Remove broken /taxonomy endpoint from ProductModel subclasses

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -522,27 +522,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductStream'
           description: ''
-  /api/v1/product_streams/{uuid}/taxonomy:
-    get:
-      operationId: v1_product_streams_taxonomy_retrieve
-      description: View for api/v1/product_streams
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product stream.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductStream'
-          description: ''
   /api/v1/product_variants:
     get:
       operationId: v1_product_variants_list
@@ -614,27 +593,6 @@ paths:
   /api/v1/product_variants/{uuid}:
     get:
       operationId: v1_product_variants_retrieve
-      description: View for api/v1/product_variants
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product variant.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductVariant'
-          description: ''
-  /api/v1/product_variants/{uuid}/taxonomy:
-    get:
-      operationId: v1_product_variants_taxonomy_retrieve
       description: View for api/v1/product_variants
       parameters:
       - in: path
@@ -742,27 +700,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductVersion'
           description: ''
-  /api/v1/product_versions/{uuid}/taxonomy:
-    get:
-      operationId: v1_product_versions_taxonomy_retrieve
-      description: View for api/v1/product_versions
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product version.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProductVersion'
-          description: ''
   /api/v1/products:
     get:
       operationId: v1_products_list
@@ -834,27 +771,6 @@ paths:
   /api/v1/products/{uuid}:
     get:
       operationId: v1_products_retrieve
-      description: View for api/v1/products
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this product.
-        required: true
-      tags:
-      - v1
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
-  /api/v1/products/{uuid}/taxonomy:
-    get:
-      operationId: v1_products_taxonomy_retrieve
       description: View for api/v1/products
       parameters:
       - in: path


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs It doesn't work and probably hasn't for a while (ever since we added channels). There are no links to the /taxonomy endpoints from any detail view, so users probably aren't even aware that these pages exist. Or if anyone was using them, we'd be seeing error emails every time they visited that page :)

They also aren't mentioned in our user guide, although the endpoints are documented in the OpenAPI schema.

Fixing the /taxonomy endpoint is possible, but seems pointless since the same information (plus extra info) is already available on the detail view for a particular ProductModel subclass.

The /taxonomy endpoint was also never implemented for Channels. Again, fixing this is possible but duplicates info in the detail view.

The /taxonomy endpoint for Components will stay since it's working.