### PR TITLE
CORGI-228 enable persistent url for product streams and components

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -69,7 +69,6 @@ class ComponentFilter(FilterSet):
 class ProductDataFilter(FilterSet):
     """Class that filters queries to Product-related list views."""
 
-    name = CharFilter()
     re_name = CharFilter(lookup_expr="regex", field_name="name")
     re_ofuri = CharFilter(lookup_expr="regex", field_name="ofuri")
     tags = TagFilter()

--- a/openapi.yml
+++ b/openapi.yml
@@ -427,10 +427,6 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
       - name: offset
         required: false
         in: query
@@ -558,10 +554,6 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
       - name: offset
         required: false
         in: query
@@ -668,10 +660,6 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
       - name: offset
         required: false
         in: query
@@ -778,10 +766,6 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
       - name: offset
         required: false
         in: query

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -318,8 +318,7 @@ def test_rpm_detail(client, api_path):
     assert response.status_code == 200
     assert response.json()["count"] == 1
     response = client.get(f"{api_path}/components?purl={quote(c1.purl)}")
-    assert response.status_code == 302
-    assert response.headers["Location"] == f"{api_path}/components/{c1.uuid}"
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -336,7 +335,7 @@ def test_purl_reserved(client, api_path):
     )
     assert response.status_code == 200
     response = client.get(f"{api_path}/components?purl={quote(c1.purl)}")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -482,10 +481,10 @@ def test_products(client, api_path):
     assert response.json()["count"] == 2
 
     response = client.get(f"{api_path}/products?ofuri=o:redhat:rhel-av")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     response = client.get(f"{api_path}/products?ofuri=o:redhat:rhel")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -498,10 +497,10 @@ def test_product_versions(client, api_path):
     assert response.json()["count"] == 2
 
     response = client.get(f"{api_path}/product_versions?ofuri=o:redhat:rhel-av:8")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     response = client.get(f"{api_path}/product_versions?ofuri=o:redhat:rhel:8")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -518,10 +517,10 @@ def test_product_streams(client, api_path):
     assert response.json()["count"] == 2
 
     response = client.get(f"{api_path}/product_streams?ofuri=o:redhat:rhel-av:8.5.0-z")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     response = client.get(f"{api_path}/product_streams?ofuri=o:redhat:rhel:8.5.0-z")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -534,10 +533,10 @@ def test_product_variants(client, api_path):
     assert response.json()["count"] == 2
 
     response = client.get(f"{api_path}/product_variants?ofuri={pv_appstream.ofuri}")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
     response = client.get(f"{api_path}/product_variants?ofuri={pv_baseos.ofuri}")
-    assert response.status_code == 302
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db(databases=("read_only",))


### PR DESCRIPTION
As per CORGI-228, resources should be addressable with consistent URLs instead of redirecting to their uuid identities.

For product streams this would be with name or ofuri
```
http://localhost:8000/api/v1/product_streams?name=ansible_automation_platform-2.1
http://localhost:8000/api/v1/product_streams?ofuri=o:redhat:ansible_automation_platform:2.1
```

For components this would be with purl
```
http://localhost:8000/api/v1/components?purl=pkg%3Arpm%2Fredhat%2Fpython-inflection%400.5.1-2.el8pc%3Farch%3Dsrc
```

Note- if this looks good then I can expand this to products, product versions, etc