### PR TITLE
CORGI-443: Fix CVEs by upgrading Python, UBI dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi:8.6
+FROM registry.redhat.io/ubi8/ubi
 
 ARG PIP_INDEX_URL="https://pypi.org/simple"
 ENV PYTHONUNBUFFERED=1 \

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,9 +13,7 @@ django-mptt @ https://github.com/RedHatProductSecurity/django-mptt/archive/25d49
 # Unreleased Django-REST-Framework commit with a fix for strong Content-Security-Policies
 djangorestframework @ https://github.com/encode/django-rest-framework/archive/cc3c89a11c7ee9cf7cfd732e0a329c318ace71b2.zip#egg=djangorestframework
 
-# Unreleased drf-spectacular commit with a fix for strong Content-Security-Policies
-drf-spectacular[sidecar] @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip#egg=drf-spectacular
-
+drf-spectacular[sidecar]
 flower
 gunicorn[gevent]
 koji

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,6 @@ django-celery-beat
 django-celery-results
 django-csp
 django-filter
-eventlet
 
 # The latest main-branch commit on our fork of django-mptt
 # This includes a fix for concurrent writes causing tree corruption

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -109,10 +109,6 @@ djangorestframework @ https://github.com/encode/django-rest-framework/archive/cc
     # via
     #   -r requirements/base.in
     #   drf-spectacular
-dnspython==2.2.1 \
-    --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
-    --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
-    # via eventlet
 drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
     --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via -r requirements/base.in
@@ -120,10 +116,6 @@ drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \
     --hash=sha256:503860a34d4215d6b3c46d54b90d991dd0d202363e3b69b832348f08e4a8634b
     # via drf-spectacular
-eventlet==0.33.1 \
-    --hash=sha256:a085922698e5029f820cf311a648ac324d73cec0e4792877609d978a4b5bbf31 \
-    --hash=sha256:afbe17f06a58491e9aebd7a4a03e70b0b63fd4cf76d8307bae07f280479b1515
-    # via -r requirements/base.in
 flower==1.2.0 \
     --hash=sha256:46493c7e8d9ca2167e8a46eb97ae8d280997cb40a81993230124d74f0fe40bac \
     --hash=sha256:ae2977cf7343c526cf44def8c7e7173db8dedb8249b91ba4b88cfd18e7a2d486
@@ -219,9 +211,7 @@ greenlet==1.1.2 \
     --hash=sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce \
     --hash=sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c \
     --hash=sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b
-    # via
-    #   eventlet
-    #   gevent
+    # via gevent
 gssapi==1.7.2 \
     --hash=sha256:0b02bbdd850c079b1d453546579fc283f0646f56ff4b39cd3b0e27263a6af97e \
     --hash=sha256:145bee55bff2461d2704b958bb6f45f6abf11442efe0f2e7a612f0ab049613f2 \
@@ -406,7 +396,6 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   click-repl
-    #   eventlet
     #   koji
     #   python-dateutil
 splitstream==1.2.6 \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,9 +65,9 @@ decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
     # via gssapi
-django==3.2.15 \
-    --hash=sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713 \
-    --hash=sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b
+django==3.2.16 \
+    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
+    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
     # via
     #   -r requirements/base.in
     #   django-celery-beat

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -109,8 +109,9 @@ djangorestframework @ https://github.com/encode/django-rest-framework/archive/cc
     # via
     #   -r requirements/base.in
     #   drf-spectacular
-drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
-    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
+drf-spectacular[sidecar]==0.25.1 \
+    --hash=sha256:789696f9845ef2397c52f66154aec6d96411baf6aa09a5d40c5f0b0e99f6b3d8 \
+    --hash=sha256:d58684e702f5ad436c5bd1735d46df0e123e64de883092d38f1debb9fa4a03c9
     # via -r requirements/base.in
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -295,13 +295,6 @@ djangorestframework-stubs==1.7.0 \
     --hash=sha256:3ac1447fc87f68fe7d8622d4725b5cef820bcc17918f36c7da3f667363fb7a43 \
     --hash=sha256:6e8a80a0716d8af02aa387dae47f8ef97b6c0efdf159d83a5918d582f8b1ea07
     # via -r requirements/test.txt
-dnspython==2.2.1 \
-    --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
-    --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
-    #   eventlet
 drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
     --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via
@@ -310,12 +303,6 @@ drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff3
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \
     --hash=sha256:503860a34d4215d6b3c46d54b90d991dd0d202363e3b69b832348f08e4a8634b
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
-eventlet==0.33.1 \
-    --hash=sha256:a085922698e5029f820cf311a648ac324d73cec0e4792877609d978a4b5bbf31 \
-    --hash=sha256:afbe17f06a58491e9aebd7a4a03e70b0b63fd4cf76d8307bae07f280479b1515
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -446,7 +433,6 @@ greenlet==1.1.2 \
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-    #   eventlet
     #   gevent
 gssapi==1.7.2 \
     --hash=sha256:0b02bbdd850c079b1d453546579fc283f0646f56ff4b39cd3b0e27263a6af97e \
@@ -998,7 +984,6 @@ six==1.16.0 \
     #   -r requirements/test.txt
     #   click-repl
     #   django-coverage-plugin
-    #   eventlet
     #   koji
     #   python-dateutil
     #   requests-mock

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -205,9 +205,9 @@ detect-secrets==1.2.0 \
     --hash=sha256:51a8fc5d89340ba6d0c688049fc3381a2f24c6fbaf2f542e15f5b873b95bafe3 \
     --hash=sha256:c160e897b3d0e81bf9cf0f6cc2e5e6434fa609a159f9a2849fcae0a08b4e2a30
     # via -r requirements/lint.txt
-django==3.2.15 \
-    --hash=sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713 \
-    --hash=sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b
+django==3.2.16 \
+    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
+    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -295,8 +295,9 @@ djangorestframework-stubs==1.7.0 \
     --hash=sha256:3ac1447fc87f68fe7d8622d4725b5cef820bcc17918f36c7da3f667363fb7a43 \
     --hash=sha256:6e8a80a0716d8af02aa387dae47f8ef97b6c0efdf159d83a5918d582f8b1ea07
     # via -r requirements/test.txt
-drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
-    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
+drf-spectacular[sidecar]==0.25.1 \
+    --hash=sha256:789696f9845ef2397c52f66154aec6d96411baf6aa09a5d40c5f0b0e99f6b3d8 \
+    --hash=sha256:d58684e702f5ad436c5bd1735d46df0e123e64de883092d38f1debb9fa4a03c9
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -306,6 +307,7 @@ drf-spectacular-sidecar==2022.11.1 \
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
+    #   drf-spectacular
 executing==0.8.2 \
     --hash=sha256:32fc6077b103bd19e6494a72682d66d5763cf20a106d5aa7c5ccbea4e47b0df7 \
     --hash=sha256:c23bf42e9a7b9b212f185b1b2c3c91feb895963378887bb10e64a2e612ec0023

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -208,22 +208,12 @@ djangorestframework-stubs==1.7.0 \
     --hash=sha256:3ac1447fc87f68fe7d8622d4725b5cef820bcc17918f36c7da3f667363fb7a43 \
     --hash=sha256:6e8a80a0716d8af02aa387dae47f8ef97b6c0efdf159d83a5918d582f8b1ea07
     # via -r requirements/test.in
-dnspython==2.2.1 \
-    --hash=sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e \
-    --hash=sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f
-    # via
-    #   -r requirements/base.txt
-    #   eventlet
 drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
     --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
     # via -r requirements/base.txt
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \
     --hash=sha256:503860a34d4215d6b3c46d54b90d991dd0d202363e3b69b832348f08e4a8634b
-    # via -r requirements/base.txt
-eventlet==0.33.1 \
-    --hash=sha256:a085922698e5029f820cf311a648ac324d73cec0e4792877609d978a4b5bbf31 \
-    --hash=sha256:afbe17f06a58491e9aebd7a4a03e70b0b63fd4cf76d8307bae07f280479b1515
     # via -r requirements/base.txt
 factory-boy==3.2.1 \
     --hash=sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e \
@@ -332,7 +322,6 @@ greenlet==1.1.2 \
     --hash=sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b
     # via
     #   -r requirements/base.txt
-    #   eventlet
     #   gevent
 gssapi==1.7.2 \
     --hash=sha256:0b02bbdd850c079b1d453546579fc283f0646f56ff4b39cd3b0e27263a6af97e \
@@ -748,7 +737,6 @@ six==1.16.0 \
     #   -r requirements/base.txt
     #   click-repl
     #   django-coverage-plugin
-    #   eventlet
     #   koji
     #   python-dateutil
     #   requests-mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -208,13 +208,16 @@ djangorestframework-stubs==1.7.0 \
     --hash=sha256:3ac1447fc87f68fe7d8622d4725b5cef820bcc17918f36c7da3f667363fb7a43 \
     --hash=sha256:6e8a80a0716d8af02aa387dae47f8ef97b6c0efdf159d83a5918d582f8b1ea07
     # via -r requirements/test.in
-drf-spectacular @ https://github.com/tfranzel/drf-spectacular/archive/0f01020ff378135033855ad5bf100d99f9a14440.zip \
-    --hash=sha256:3f00c1df0635600cbcfebb06a1ab879a608ac16de5692cf7e7e3771edbbc9997
+drf-spectacular[sidecar]==0.25.1 \
+    --hash=sha256:789696f9845ef2397c52f66154aec6d96411baf6aa09a5d40c5f0b0e99f6b3d8 \
+    --hash=sha256:d58684e702f5ad436c5bd1735d46df0e123e64de883092d38f1debb9fa4a03c9
     # via -r requirements/base.txt
 drf-spectacular-sidecar==2022.11.1 \
     --hash=sha256:46614fb4eff1bccbac176d74bd76e0240ab459dc62d9fd8b9d4d1479fb76ba0a \
     --hash=sha256:503860a34d4215d6b3c46d54b90d991dd0d202363e3b69b832348f08e4a8634b
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   drf-spectacular
 factory-boy==3.2.1 \
     --hash=sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e \
     --hash=sha256:eb02a7dd1b577ef606b75a253b9818e6f9eaf996d94449c9d5ebb124f90dc795

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -140,9 +140,9 @@ decorator==5.1.0 \
     # via
     #   -r requirements/base.txt
     #   gssapi
-django==3.2.15 \
-    --hash=sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713 \
-    --hash=sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b
+django==3.2.16 \
+    --hash=sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121 \
+    --hash=sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d
     # via
     #   -r requirements/base.txt
     #   django-celery-beat


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This MR upgrades UBI to version 8.7 to fix some CVEs in various RPM dependencies. Version 8.6 which we were using before doesn't have any upgraded version of these packages (and hasn't been updated / rebuilt in three months). I also upgraded Django to 3.2.16 which only includes a CVE fix. This CVE doesn't affect us anyway, but upgrading to fix it will stop some alert spam.

At this point we could also go ahead and switch to UBI version 9. Please let me know if you'd like me to make that upgrade here. Otherwise I think I'll leave that for a future MR, since I'm not sure how much time it will take to identify and debug any issues with our RPM dependencies.