### PR TITLE
CORGI-432: Fix contention in PCR table after recent MR

### DIFF
--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -100,7 +100,7 @@ def slow_load_errata(erratum_name, force_process: bool = False):
             app.send_task(
                 "corgi.tasks.brew.slow_fetch_brew_build",
                 args=(build_id,),
-                kwargs={"force_process": False},
+                kwargs={"save_product": False, "force_process": force_process},
             )
 
     if force_process:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Quick sanity check please, I've made enough oopses as it is.

Originally corgi.tasks.errata_tool.slow_load_errata used app.send_task to avoid a circular import with the slow_fetch_brew_build task:
```
app.send_task(
    "corgi.tasks.brew.slow_fetch_brew_build",
     args=(build_id, False),
)
```

In order to reprocess all builds, not just the top-level ones, I changed that hardcoded "False" arg above to the "force_process" kwarg instead. This was sort-of correct because it let us force-reprocess Brew builds linked to this erratum, if we were also reprocessing the top-level Brew build:

```
app.send_task(
    "corgi.tasks.brew.slow_fetch_brew_build",
     args=(build_id),
     kwargs={"force_process": force_process}
)
```

But that change also caused issues. The second arg to slow_fetch_brew_build (which was hardcoded to False in the old code) is actually "save_product" and not "force_process". In CORGI-21 we added the "save_product" option to avoid calling save_product_taxonomy in a slow_fetch_brew_build task.

The "save_product" option is set to True by default, and False whenever we call slow_fetch_brew_build from slow_load_errata. This fixed an issue with contention on the PCR table, when saving taxonomies for many builds linked to one erratum. The correct approach was to save all the taxonomies at once, only after we finished loading all the builds.

So I put back that "save_product": False value, this time using the kwarg name instead of just a hardcoded arg value, to make it more clear what "False" actually means in this context. I also set the "force_process" kwarg for the slow_fetch_brew_build task, based on its value in the slow_load_errata task.

I deployed this change to stage for testing, and it seems like tasks are being processed faster now. But maybe more is needed:

1) We now force calling save_product_taxonomy in the SCA task if force_process is set to True. Maybe this also creates contention on the PCR table. Should I get rid of the force_process kwarg in the SCA task?

2) If some build we're force-processing is linked to any errata (via errata_tags in the Brew data), we also try to force-process those errata (correct). But if some erratum we're force-processing is linked to any Brew builds (via relations in the PCR table), we also try to force-process those builds.

Am I misunderstanding how this code works / our data is linked together? Or if above is correct, I think this causes infinite recursion - should I get rid of the force_process kwarg in the call to app.send_task?
```
app.send_task(
    "corgi.tasks.brew.slow_fetch_brew_build",
     args=(build_id),
     kwargs={"save_product": False}
)
```