### PR TITLE
Fix Gitlab CI pipeline's image version to match Dockerfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ sonarqube:
 test:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi8/ubi:8.6
+  image: registry.redhat.io/ubi8/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1
@@ -105,7 +105,7 @@ test:
 test-migrations:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi8/ubi:8.6
+  image: registry.redhat.io/ubi8/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1


### PR DESCRIPTION
Quick fix I missed in my first PR. Note that image building was already tested manually (ansible playbooks were run against the fix-cves branch).