### PR TITLE
CORGI-432: Minor bugfixes and ingestion optimizations

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -339,7 +339,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
     def manifest(self, request: Request, uuid: Union[str, None] = None) -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         manifest = json.loads(obj.manifest)
         return Response(manifest)
 
@@ -418,7 +418,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
             return self.queryset.filter(productvariants__ofuri=ofuri)
         else:
             # No matching model instance found, or invalid ofuri
-            return self.queryset
+            raise Http404
 
     @extend_schema(
         parameters=[
@@ -460,7 +460,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
     def manifest(self, request: Request, uuid: str = "") -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         manifest = json.loads(obj.manifest)
         return Response(manifest)
 
@@ -472,10 +472,10 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         if utils.running_prod():
             # This is only temporary for OpenLCS testing
             # Do not enable in production until we add OIDC authentication
-            return Response(status=403)
+            return Response(status=status.HTTP_403_FORBIDDEN)
         component = self.queryset.filter(uuid=uuid).using("default").first()
         if not component:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         copyright_text = request.data.get("copyright_text")
         license_concluded = request.data.get("license_concluded")
@@ -488,7 +488,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
             and not openlcs_scan_version
         ):
             # At least one of above is required, else Bad Request
-            return Response(status=400)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         # if it's None, it wasn't included in the request
         # But it might be "" if the user wants to empty out the value
@@ -501,7 +501,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         if openlcs_scan_version is not None:
             component.openlcs_scan_version = openlcs_scan_version
         component.save()
-        response = Response(status=302)
+        response = Response(status=status.HTTP_302_FOUND)
         response["Location"] = f"/api/{CORGI_API_VERSION}/components/{component.uuid}"
         return response
 
@@ -509,7 +509,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
     def provides(self, request: Request, uuid: Union[str, None] = None) -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         dicts = get_component_taxonomy(
             obj,
             ComponentNode.PROVIDES_NODE_TYPES,
@@ -520,7 +520,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
     def taxonomy(self, request: Request, uuid: Union[str, None] = None) -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
         dicts = get_component_taxonomy(obj, tuple(ComponentNode.ComponentNodeType.values))
         return Response(dicts)
 

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -33,10 +33,12 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
         pass
     else:
         if not force_process:
-            logger.info("Already processed build_id %s, only saving product taxonomy", build_id)
-            softwarebuild.save_product_taxonomy()
-            for related_component in softwarebuild.components.get_queryset():
-                related_component.save_component_taxonomy()
+            logger.info("Already processed build_id %s", build_id),
+            if save_product:
+                logger.info("Only saving product taxonomy for build_id %s", build_id)
+                softwarebuild.save_product_taxonomy()
+                for related_component in softwarebuild.components.get_queryset():
+                    related_component.save_component_taxonomy()
             return
         else:
             logger.info("Fetching brew build with build_id: %s", build_id)
@@ -119,7 +121,7 @@ def slow_fetch_brew_build(build_id: int, save_product: bool = True, force_proces
     logger.info("Fetching brew builds for %s", build_ids)
     for b_id in build_ids:
         logger.info("Requesting fetch of nested build: %s", b_id)
-        slow_fetch_brew_build.delay(b_id, force_process=force_process)
+        slow_fetch_brew_build.delay(b_id, save_product=save_product, force_process=force_process)
 
     logger.info("Requesting software composition analysis for %s", build_id)
     if settings.SCA_ENABLED:

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -73,7 +73,7 @@ def cpu_software_composition_analysis(build_id: int, force_process: bool = False
     logger.info("Started software composition analysis for %s", build_id)
     software_build = SoftwareBuild.objects.get(build_id=build_id)
 
-    component_qs = Component.objects.filter(software_build=software_build)
+    component_qs = Component.objects.filter(software_build_id=build_id)
     try:
         # Get root component for this build.
         root_component = component_qs.root_components().get()

--- a/corgi/web/views.py
+++ b/corgi/web/views.py
@@ -114,6 +114,10 @@ def tasks_list(request):
 @require_safe
 def running_tasks(request):
     def add_tasks(ret, task_dict, status, scheduled=False):
+        # Celery sometimes randomly fails (network glitches?)
+        # Nested call chain is too complex to understand / file a bug for
+        if not task_dict:
+            return None
         for worker in task_dict:
             for task in task_dict[worker]:
                 if scheduled:

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -782,7 +782,7 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
     # Verify calls were made to slow_fetch_brew_build.delay for rpm builds
     assert len(mock_fetch_brew_build.call_args_list) == len(RPM_BUILD_IDS)
     mock_fetch_brew_build.assert_has_calls(
-        tuple(call(build_id, force_process=False) for build_id in RPM_BUILD_IDS),
+        tuple(call(build_id, save_product=True, force_process=False) for build_id in RPM_BUILD_IDS),
         any_order=True,
     )
     mock_load_errata.assert_called_with("RHEA-2021:4610", force_process=False)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Some minor bugfixes / tweaks I tested while reingesting data for CORGI-432.

I think that the change to save_product_taxonomy should save 1 query per component, and I deployed this to stage for testing, but I couldn't easily measure the actual DB calls made or if it improved performance. Curious if others have any thoughts about this change - happy to remove if we want to leave alone for now.