### PR TITLE
CORGI-432: Fix infinite loop when force-reprocessing errata

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -55,7 +55,7 @@ class ProductManifestFile(ManifestFile):
 
     def render_content(self) -> str:
 
-        latest_components = self.obj.get_latest_components()  # type: ignore
+        latest_components = self.obj.get_latest_components()  # type: ignore[attr-defined]
 
         kwargs_for_template = {
             "obj": self.obj,

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -100,7 +100,10 @@ def slow_load_errata(erratum_name, force_process: bool = False):
             app.send_task(
                 "corgi.tasks.brew.slow_fetch_brew_build",
                 args=(build_id,),
-                kwargs={"save_product": False, "force_process": force_process},
+                # Do not pass force_process through to child tasks
+                # Or Celery will get stuck in an infinite loop
+                # processing the same Brew builds / errata repeatedly
+                kwargs={"save_product": False, "force_process": False},
             )
 
     if force_process:


### PR DESCRIPTION
Quick fix for regression I introduced in previous MR, which I've already deployed to stage and tested. We need to force-reprocess all data for remote source components (which have types like PIP, NPM, etc.). This includes the related Brew build itself, child / nested builds (if any), and related errata that are tagged on each build (if any). Performing SCA a second time may also be necessary.

In other words, we need to pass force_process=True to all the above tasks, including child tasks. Force-processing the related errata is possible, but the slow_load_errata task will also call slow_fetch_brew_build for all build IDs we have relations for. This includes the original / parent Brew build which first triggered the slow_load_errata task.

To avoid an infinite loop in this case, we need slow_load_errata to always call slow_fetch_brew_build with force_process set to False, instead of passing through the force_process value. Failing to do so causes our queue to grow from only 1 force_process task for a single Brew build, to tens of thousands of tasks including the same Brew builds and errata repeatedly.