### PR TITLE
CORGI-466 add product view to components

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -483,6 +483,57 @@ class ProductStreamSerializer(ProductModelSerializer):
         ]
 
 
+class ProductStreamSummarySerializer(ProductModelSerializer):
+    manifest = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_link(instance: ProductStream) -> str:
+        return get_model_ofuri_link("product_streams", instance.ofuri)
+
+    class Meta(ProductModelSerializer.Meta):
+        model = ProductStream
+        fields = [
+            "link",
+            "ofuri",
+            "name",
+            "components",
+            "upstreams",
+            "manifest",
+        ]
+
+
+class ComponentProductStreamSummarySerializer(ProductModelSerializer):
+    """custom component view displaying product information."""
+
+    component_link = serializers.SerializerMethodField(read_only=True)
+    manifest = serializers.SerializerMethodField(read_only=True)
+    component_purl = serializers.SerializerMethodField(read_only=True)
+
+    def get_component_purl(self, obj):
+        return obj.component_purl
+
+    @staticmethod
+    def get_link(instance: ProductStream) -> str:
+        return get_model_ofuri_link("product_streams", instance.ofuri)
+
+    @staticmethod
+    def get_component_link(instance: Component) -> str:
+        return get_component_purl_link(instance.component_purl)  # type: ignore
+
+    class Meta(ProductModelSerializer.Meta):
+        model = ProductStream
+        fields = [
+            "link",
+            "ofuri",
+            "name",
+            "components",
+            "upstreams",
+            "manifest",
+            "component_link",
+            "component_purl",
+        ]
+
+
 class ProductVariantSerializer(ProductModelSerializer):
     products = serializers.SerializerMethodField()
     product_versions = serializers.SerializerMethodField()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -526,6 +526,10 @@ def test_product_streams(client, api_path):
     assert response.status_code == 200
     assert response.json()["name"] == "rhel-av-8.5.0-z"
 
+    response = client.get(f"{api_path}/product_streams?re_name=rhel&view=summary")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_variants(client, api_path):
@@ -645,6 +649,10 @@ def test_product_components_versions(client, api_path):
     response = client.get(f"{api_path}/components?ofuri=o:redhat:rhel:7")
     assert response.status_code == 200
     assert response.json()["count"] == 1
+
+    response = client.get(f"{api_path}/components?name=curl&view=product")
+    assert response.status_code == 200
+    assert response.json()["count"] == 2
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)


### PR DESCRIPTION
This adds a bit of 'sugar' making it easy to understand which products a component(s) is contained by. 

```
https://<HOST>/api/v1/components?name=curl&view=product
```
will generate 
```
[
    {
        "link": "http://{HOST}/api/v1/product_streams?ofuri=o:redhat:kmm:1",
        "ofuri": "o:redhat:kmm:1",
        "name": "kmm-1",
        "component_link": "http://{HOST}/api/v1/components?purl=pkg%3Arpm/redhat/curl%407.61.1-25.el8_7.1%3Farch%3Dx86_64",
        "component_purl": "pkg:rpm/redhat/curl@7.61.1-25.el8_7.1?arch=x86_64"
    },
    {
        "link": "http://{HOST}/api/v1/product_streams?ofuri=o:redhat:rhel:7.6.z",
        "ofuri": "o:redhat:rhel:7.6.z",
        "name": "rhel-7.6.z",
        "component_link": "http://{HOST}/api/v1/components?purl=pkg%3Arpm/redhat/curl%407.29.0-51.el7%3Farch%3Dppc64le",
        "component_purl": "pkg:rpm/redhat/curl@7.29.0-51.el7?arch=ppc64le"
    }, .... 
]
```
To get a unique list of product streams a component exists in is:
```
curl https://corgi-stage.prodsec.redhat.com/api/v1/components\?name\=curl\&view\=product | jq '.results[].name' | sort | uniq
```

while I was 'in the area' added a summary view to product streams as well (/api/v1/product_streams?view=summary).

**Note**-  pushing this to stage to support a griffon demo eg. experimental - will follow through with documentation, 