### PR TITLE
CORGI-437: API / logic changes needed for OSC integration

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -54,6 +54,8 @@ class ComponentFilter(FilterSet):
     upstreams = CharFilter(lookup_expr="purl__icontains")
     re_upstream = CharFilter(lookup_expr="purl__regex", field_name="upstreams")
 
+    el_match = CharFilter(label="RHEL version for layered products", lookup_expr="icontains")
+
 
 class ProductDataFilter(FilterSet):
     """Class that filters queries to Product-related list views."""

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -1,11 +1,13 @@
 import logging
 from abc import abstractmethod
+from collections import defaultdict
 from typing import Iterable, Optional, Union
 from urllib.parse import quote
 from uuid import UUID
 
 from django.conf import settings
 from django.db.models.manager import Manager
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from config import utils
@@ -161,13 +163,123 @@ def get_product_relations(instance_name: str) -> list[dict[str, str]]:
     return [{"type": pcr_type, "external_system_id": pcr_id} for (pcr_type, pcr_id) in related_pcrs]
 
 
+def parse_fields(fields: list[str]) -> tuple[set[str], dict[str, set[str]]]:
+    """
+    Parse each include/exclude item into list of current level fields
+    and dict of next level fields.
+
+    Example:
+        [uuid, affects, affects.uuid, affects.trackers.uuid]
+
+        ->
+
+        ["uuid", "affects"]
+        {"affects": ["uuid", "trackers.uuid"]}
+
+    """
+
+    current_level_fields = set()
+    next_level_fields = defaultdict(set)
+
+    for field in fields:
+        if "." in field:
+            related_field, next_level_field = field.split(".", maxsplit=1)
+            next_level_fields[related_field].add(next_level_field)
+        else:
+            current_level_fields.add(field)
+
+    return (
+        current_level_fields,
+        {key: value for key, value in next_level_fields.items()},
+    )
+
+
+class IncludeExcludeFieldsSerializer(serializers.ModelSerializer):
+    """
+    Abstract serializer for include/exclude fields logic with nested serializers
+
+    include_fields and exclude_fields are obtained either from request or in case
+    of the nested serializer from the context which is passed from the parent
+    serializer
+
+    Filtering on parent serializer:
+        include_fields=uuid,cve_id
+
+    Filtering on nested serializer:
+        include_fields=affects.uuid,affects.trackers
+    """
+
+    class Meta:
+        abstract = True
+
+    def __init__(self, *args, **kwargs):
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
+        request = self.context.get("request")
+
+        # Get include/exclude fields from request
+        if request:
+            include_fields_param = request.query_params.get("include_fields")
+            exclude_fields_param = request.query_params.get("exclude_fields")
+
+            include_fields = include_fields_param.split(",") if include_fields_param else []
+            exclude_fields = exclude_fields_param.split(",") if exclude_fields_param else []
+
+        # Get include/exclude fields from context passed from parent serializer
+        else:
+            include_fields = self.context.get("include_fields", [])
+            exclude_fields = self.context.get("exclude_fields", [])
+
+        (
+            self._include_fields,
+            self._next_level_include_fields,
+        ) = parse_fields(include_fields)
+
+        (
+            self._exclude_fields,
+            self._next_level_exclude_fields,
+        ) = parse_fields(exclude_fields)
+
+        # Drop fields based on include/exclude fields
+        existing_fields = set(self.fields)
+        for field_name in existing_fields:
+            if not self._is_field_visible(field_name):
+                self.fields.pop(field_name, None)
+
+    def _is_field_visible(self, field: str) -> bool:
+        """Get field visibility based on include/exclude fields logic"""
+        # Field is needed for next level include fields, don't drop it
+        if field in self._next_level_include_fields:
+            return True
+
+        # Include fields on current level were given and field is not in it, drop it
+        elif self._include_fields and field not in self._include_fields:
+            return False
+
+        # Field is in exclude fields and not in include fields, drop it
+        elif field in self._exclude_fields and field not in self._include_fields:
+            return False
+
+        # Include fields on current level were not given however there are
+        # next level include fields, drop the field
+        elif not self._include_fields and self._next_level_include_fields:
+            return False
+
+        else:
+            return True
+
+
 class TagSerializer(serializers.Serializer):
     name = serializers.SlugField(allow_blank=False)
     value = serializers.CharField(max_length=1024, allow_blank=True, default="")
     created_at = serializers.DateTimeField(read_only=True)
 
 
-class SoftwareBuildSerializer(serializers.ModelSerializer):
+class SoftwareBuildSerializer(IncludeExcludeFieldsSerializer):
+    """Show detailed information for SoftwareBuild(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     tags = TagSerializer(many=True, read_only=True)
 
     link = serializers.SerializerMethodField(read_only=True)
@@ -201,11 +313,12 @@ class SoftwareBuildSerializer(serializers.ModelSerializer):
             "created_at",
             "last_changed",
             "components",
-            # "meta_attr",
         ]
 
 
-class SoftwareBuildSummarySerializer(serializers.ModelSerializer):
+class SoftwareBuildSummarySerializer(IncludeExcludeFieldsSerializer):
+    """Show summary information for a SoftwareBuild.
+    Add or remove fields using ?include_fields=&exclude_fields="""
 
     link = serializers.SerializerMethodField(read_only=True)
 
@@ -218,7 +331,7 @@ class SoftwareBuildSummarySerializer(serializers.ModelSerializer):
         fields = ["link", "build_id", "build_type", "name", "source"]
 
 
-class ProductTaxonomySerializer(serializers.ModelSerializer):
+class ProductTaxonomySerializer(IncludeExcludeFieldsSerializer):
     @staticmethod
     def get_products(instance: Union[ProductModel, ProductTaxonomyMixin]) -> list[dict[str, str]]:
         return get_product_data_list("products", instance.products)
@@ -250,7 +363,10 @@ class ProductTaxonomySerializer(serializers.ModelSerializer):
 
 
 class ComponentSerializer(ProductTaxonomySerializer):
-    software_build = SoftwareBuildSummarySerializer(many=False)
+    """Show detailed information for a Component.
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
+    software_build = serializers.SerializerMethodField()
     tags = TagSerializer(many=True, read_only=True)
 
     link = serializers.SerializerMethodField(read_only=True)
@@ -266,6 +382,18 @@ class ComponentSerializer(ProductTaxonomySerializer):
     upstreams = serializers.SerializerMethodField()
 
     manifest = serializers.SerializerMethodField(read_only=True)
+
+    @extend_schema_field(SoftwareBuildSummarySerializer(many=False, read_only=True))
+    def get_software_build(self, obj):
+        context = {
+            "include_fields": self._next_level_include_fields.get("software_build", []),
+            "exclude_fields": self._next_level_exclude_fields.get("software_build", []),
+        }
+
+        serializer = SoftwareBuildSummarySerializer(
+            instance=obj.software_build, many=False, read_only=True, context=context
+        )
+        return serializer.data
 
     @staticmethod
     def get_link(instance: Component) -> str:
@@ -332,7 +460,8 @@ class ComponentSerializer(ProductTaxonomySerializer):
         ]
 
 
-class ComponentListSerializer(serializers.ModelSerializer):
+class ComponentListSerializer(IncludeExcludeFieldsSerializer):
+    """List all Components. Add or remove fields using ?include_fields=&exclude_fields="""
 
     link = serializers.SerializerMethodField(read_only=True)
     build_completion_dt = serializers.DateTimeField(
@@ -352,7 +481,6 @@ class ComponentListSerializer(serializers.ModelSerializer):
             "version",
             "nvr",
             "build_completion_dt",
-            # "meta_attr",
         ]
         read_only_fields = fields
 
@@ -413,6 +541,9 @@ class ProductModelSerializer(ProductTaxonomySerializer):
 
 
 class ProductSerializer(ProductModelSerializer):
+    """Show detailed information for Product(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     product_versions = serializers.SerializerMethodField()
     product_streams = serializers.SerializerMethodField()
     product_variants = serializers.SerializerMethodField()
@@ -432,6 +563,9 @@ class ProductSerializer(ProductModelSerializer):
 
 
 class ProductVersionSerializer(ProductModelSerializer):
+    """Show detailed information for ProductVersion(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     products = serializers.SerializerMethodField()
     product_streams = serializers.SerializerMethodField()
     product_variants = serializers.SerializerMethodField()
@@ -451,6 +585,9 @@ class ProductVersionSerializer(ProductModelSerializer):
 
 
 class ProductStreamSerializer(ProductModelSerializer):
+    """Show detailed information for ProductStream(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     manifest = serializers.SerializerMethodField()
 
     products = serializers.SerializerMethodField()
@@ -483,6 +620,9 @@ class ProductStreamSerializer(ProductModelSerializer):
 
 
 class ProductStreamSummarySerializer(ProductModelSerializer):
+    """Show summary information for a ProductStream.
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     manifest = serializers.SerializerMethodField()
 
     @staticmethod
@@ -534,6 +674,9 @@ class ComponentProductStreamSummarySerializer(ProductModelSerializer):
 
 
 class ProductVariantSerializer(ProductModelSerializer):
+    """Show detailed information for ProductVariant(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     products = serializers.SerializerMethodField()
     product_versions = serializers.SerializerMethodField()
     product_streams = serializers.SerializerMethodField()
@@ -557,6 +700,9 @@ class ProductVariantSerializer(ProductModelSerializer):
 
 
 class ChannelSerializer(ProductTaxonomySerializer):
+    """Show detailed information for Channel(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     link = serializers.SerializerMethodField(read_only=True)
     products = serializers.SerializerMethodField()
     product_versions = serializers.SerializerMethodField()
@@ -574,7 +720,6 @@ class ChannelSerializer(ProductTaxonomySerializer):
             "relative_url",
             "type",
             "description",
-            "meta_attr",
             "products",
             "product_versions",
             "product_streams",
@@ -586,7 +731,10 @@ class ChannelSerializer(ProductTaxonomySerializer):
         return get_model_id_link("channels", instance.uuid)
 
 
-class AppStreamLifeCycleSerializer(serializers.ModelSerializer):
+class AppStreamLifeCycleSerializer(IncludeExcludeFieldsSerializer):
+    """Show detailed information for AppStreamLifeCycle(s).
+    Add or remove fields using ?include_fields=&exclude_fields="""
+
     class Meta:
         model = AppStreamLifeCycle
         fields = "__all__"

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -438,6 +438,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
             "tags",
             "version",
             "release",
+            "el_match",
             "arch",
             "nvr",
             "nevra",

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -403,19 +403,6 @@ class ProductModel(TimeStampedModel):
         return ProductComponentRelation.objects.none()
 
     @property
-    def coverage(self) -> float:
-        pnode_children = self.pnodes.get_queryset().get_descendants().using("read_only")
-        # Evaluate queryset once, so it's cached when we reuse it below
-        pnode_children_count = len(pnode_children)
-        if pnode_children_count == 0:
-            return 0
-        build_count = 0
-        for pn in pnode_children:
-            if pn.obj.builds.exists():
-                build_count += 1
-        return round(build_count / pnode_children_count, 2)
-
-    @property
     def cpes(self) -> tuple[str, ...]:
         """Return CPEs for child streams / variants."""
         # include_self=True so we don't have to override this property for streams

--- a/openapi.yml
+++ b/openapi.yml
@@ -164,6 +164,11 @@ paths:
         name: description
         schema:
           type: string
+      - in: query
+        name: el_match
+        schema:
+          type: string
+        description: RHEL version for layered products
       - name: limit
         required: false
         in: query
@@ -1057,6 +1062,12 @@ components:
         release:
           type: string
           readOnly: true
+        el_match:
+          type: array
+          items:
+            type: string
+            maxLength: 200
+          readOnly: true
         arch:
           type: string
           readOnly: true
@@ -1171,6 +1182,7 @@ components:
       - copyright_text
       - description
       - download_url
+      - el_match
       - epoch
       - errata
       - filename

--- a/openapi.yml
+++ b/openapi.yml
@@ -933,6 +933,9 @@ components:
       type: string
     Channel:
       type: object
+      description: |-
+        Show detailed information for Channel(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         uuid:
           type: string
@@ -958,9 +961,6 @@ components:
           $ref: '#/components/schemas/ChannelTypeEnum'
         description:
           type: string
-        meta_attr:
-          type: object
-          additionalProperties: {}
         products:
           type: array
           items:
@@ -1007,6 +1007,9 @@ components:
       type: string
     Component:
       type: object
+      description: |-
+        Show detailed information for a Component.
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1078,7 +1081,9 @@ components:
         openlcs_scan_version:
           type: string
         software_build:
-          $ref: '#/components/schemas/SoftwareBuildSummary'
+          allOf:
+          - $ref: '#/components/schemas/SoftwareBuildSummary'
+          readOnly: true
         errata:
           type: array
           items:
@@ -1332,6 +1337,9 @@ components:
             $ref: '#/components/schemas/SoftwareBuild'
     Product:
       type: object
+      description: |-
+        Show detailed information for Product(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1407,6 +1415,9 @@ components:
       - uuid
     ProductStream:
       type: object
+      description: |-
+        Show detailed information for ProductStream(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1515,6 +1526,9 @@ components:
       - uuid
     ProductVariant:
       type: object
+      description: |-
+        Show detailed information for ProductVariant(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1598,6 +1612,9 @@ components:
       - uuid
     ProductVersion:
       type: object
+      description: |-
+        Show detailed information for ProductVersion(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1673,6 +1690,9 @@ components:
       - uuid
     SoftwareBuild:
       type: object
+      description: |-
+        Show detailed information for SoftwareBuild(s).
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string
@@ -1723,6 +1743,9 @@ components:
       - web_url
     SoftwareBuildSummary:
       type: object
+      description: |-
+        Show summary information for a SoftwareBuild.
+        Add or remove fields using ?include_fields=&exclude_fields=
       properties:
         link:
           type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -358,7 +358,6 @@ paths:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/Component'
-        required: true
       responses:
         '200':
           content:
@@ -954,13 +953,17 @@ components:
           readOnly: true
         name:
           type: string
+          readOnly: true
         relative_url:
           type: string
-          maxLength: 200
+          readOnly: true
         type:
-          $ref: '#/components/schemas/ChannelTypeEnum'
+          allOf:
+          - $ref: '#/components/schemas/ChannelTypeEnum'
+          readOnly: true
         description:
           type: string
+          readOnly: true
         products:
           type: array
           items:
@@ -991,6 +994,7 @@ components:
           readOnly: true
       required:
       - created_at
+      - description
       - last_changed
       - link
       - name
@@ -998,6 +1002,7 @@ components:
       - product_variants
       - product_versions
       - products
+      - relative_url
       - type
       - uuid
     ChannelTypeEnum:
@@ -1022,19 +1027,25 @@ components:
           format: uuid
           readOnly: true
         type:
-          $ref: '#/components/schemas/ComponentTypeEnum'
+          allOf:
+          - $ref: '#/components/schemas/ComponentTypeEnum'
+          readOnly: true
         namespace:
-          $ref: '#/components/schemas/NamespaceEnum'
+          allOf:
+          - $ref: '#/components/schemas/NamespaceEnum'
+          readOnly: true
         purl:
           type: string
-          maxLength: 1024
+          readOnly: true
         name:
           type: string
+          readOnly: true
         description:
           type: string
+          readOnly: true
         related_url:
           type: string
-          maxLength: 1024
+          readOnly: true
         tags:
           type: array
           items:
@@ -1042,24 +1053,25 @@ components:
           readOnly: true
         version:
           type: string
-          maxLength: 1024
+          readOnly: true
         release:
           type: string
-          maxLength: 1024
+          readOnly: true
         arch:
           type: string
-          maxLength: 1024
+          readOnly: true
         nvr:
           type: string
-          maxLength: 1024
+          readOnly: true
         nevra:
           type: string
-          maxLength: 1024
+          readOnly: true
         epoch:
           type: string
           readOnly: true
         copyright_text:
           type: string
+          readOnly: true
         license_concluded:
           type: string
           readOnly: true
@@ -1078,8 +1090,10 @@ components:
           readOnly: true
         openlcs_scan_url:
           type: string
+          readOnly: true
         openlcs_scan_version:
           type: string
+          readOnly: true
         software_build:
           allOf:
           - $ref: '#/components/schemas/SoftwareBuildSummary'
@@ -1150,12 +1164,16 @@ components:
           readOnly: true
         filename:
           type: string
+          readOnly: true
       required:
+      - arch
       - channels
+      - copyright_text
       - description
       - download_url
       - epoch
       - errata
+      - filename
       - license_concluded
       - license_concluded_list
       - license_declared
@@ -1164,11 +1182,18 @@ components:
       - manifest
       - name
       - namespace
+      - nevra
+      - nvr
+      - openlcs_scan_url
+      - openlcs_scan_version
       - product_streams
       - product_variants
       - product_versions
       - products
       - provides
+      - purl
+      - related_url
+      - release
       - software_build
       - sources
       - tags
@@ -1350,11 +1375,13 @@ components:
           readOnly: true
         ofuri:
           type: string
-          maxLength: 1024
+          readOnly: true
         name:
           type: string
+          readOnly: true
         description:
           type: string
+          readOnly: true
         build_count:
           type: integer
           readOnly: true
@@ -1405,8 +1432,10 @@ components:
       - builds
       - channels
       - components
+      - description
       - link
       - name
+      - ofuri
       - product_streams
       - product_variants
       - product_versions
@@ -1428,11 +1457,13 @@ components:
           readOnly: true
         ofuri:
           type: string
-          maxLength: 1024
+          readOnly: true
         name:
           type: string
+          readOnly: true
         description:
           type: string
+          readOnly: true
         build_count:
           type: integer
           readOnly: true
@@ -1459,25 +1490,30 @@ components:
           readOnly: true
         cpe:
           type: string
-          maxLength: 1000
+          readOnly: true
         active:
           type: boolean
+          readOnly: true
         brew_tags:
           type: object
           additionalProperties: {}
+          readOnly: true
         yum_repositories:
           type: array
           items:
             type: string
             maxLength: 200
+          readOnly: true
         composes:
           type: object
           additionalProperties: {}
+          readOnly: true
         et_product_versions:
           type: array
           items:
             type: string
             maxLength: 200
+          readOnly: true
         manifest:
           type: string
           readOnly: true
@@ -1510,13 +1546,20 @@ components:
               type: string
           readOnly: true
       required:
+      - active
+      - brew_tags
       - build_count
       - builds
       - channels
       - components
+      - composes
+      - cpe
+      - description
+      - et_product_versions
       - link
       - manifest
       - name
+      - ofuri
       - product_variants
       - product_versions
       - products
@@ -1524,6 +1567,7 @@ components:
       - tags
       - upstreams
       - uuid
+      - yum_repositories
     ProductVariant:
       type: object
       description: |-
@@ -1539,11 +1583,13 @@ components:
           readOnly: true
         ofuri:
           type: string
-          maxLength: 1024
+          readOnly: true
         name:
           type: string
+          readOnly: true
         description:
           type: string
+          readOnly: true
         build_count:
           type: integer
           readOnly: true
@@ -1601,8 +1647,10 @@ components:
       - builds
       - channels
       - components
+      - description
       - link
       - name
+      - ofuri
       - product_streams
       - product_versions
       - products
@@ -1625,11 +1673,13 @@ components:
           readOnly: true
         ofuri:
           type: string
-          maxLength: 1024
+          readOnly: true
         name:
           type: string
+          readOnly: true
         description:
           type: string
+          readOnly: true
         build_count:
           type: integer
           readOnly: true
@@ -1680,8 +1730,10 @@ components:
       - builds
       - channels
       - components
+      - description
       - link
       - name
+      - ofuri
       - product_streams
       - product_variants
       - products
@@ -1702,14 +1754,17 @@ components:
           readOnly: true
         build_id:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
+          readOnly: true
         build_type:
-          $ref: '#/components/schemas/BuildTypeEnum'
+          allOf:
+          - $ref: '#/components/schemas/BuildTypeEnum'
+          readOnly: true
         name:
           type: string
+          readOnly: true
         source:
           type: string
+          readOnly: true
         tags:
           type: array
           items:
@@ -1752,14 +1807,17 @@ components:
           readOnly: true
         build_id:
           type: integer
-          maximum: 2147483647
-          minimum: -2147483648
+          readOnly: true
         build_type:
-          $ref: '#/components/schemas/BuildTypeEnum'
+          allOf:
+          - $ref: '#/components/schemas/BuildTypeEnum'
+          readOnly: true
         name:
           type: string
+          readOnly: true
         source:
           type: string
+          readOnly: true
       required:
       - build_id
       - build_type


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This is mostly ready for review. The approach shouldn't change and there are detailed comments on the more important / complicated commits, but I still need to:

1. Compare the reconciliation report before and after the latest filter changes, to confirm we have no regressions in coverage (but I'm not expecting any).
2. Confirm there are no performance regressions. Everything was much faster when I tested locally (with large amounts of data), but things were still slow when I deployed to stage for the demo.
3. Add some tests for the new ?include_fields and ?exclude_fields parameters, once I finish above.

I already tested the actual logic, and then demoed to OSC yesterday. They seem happy with the overall approach, but I did emphasize this wasn't finalized yet in case we need to make any changes.