### PR TITLE
CORGI-475: Support OpenLCS sending license declared if they have this info

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -865,11 +865,13 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
 
         copyright_text = request.data.get("copyright_text")
         license_concluded = request.data.get("license_concluded")
+        license_declared = request.data.get("license_declared")
         openlcs_scan_url = request.data.get("openlcs_scan_url")
         openlcs_scan_version = request.data.get("openlcs_scan_version")
         if (
             not copyright_text
             and not license_concluded
+            and not license_declared
             and not openlcs_scan_url
             and not openlcs_scan_version
         ):
@@ -882,6 +884,11 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
             component.copyright_text = copyright_text
         if license_concluded is not None:
             component.license_concluded_raw = license_concluded
+        if license_declared is not None:
+            if component.license_declared_raw:
+                # The field already has an existing value, don't allow overwrites
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+            component.license_declared_raw = license_declared
         if openlcs_scan_url is not None:
             component.openlcs_scan_url = openlcs_scan_url
         if openlcs_scan_version is not None:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs @rhyw FYI, I'm going to merge this so OpenLCS isn't blocked, but please feel free to leave concerns / questions here.

Currently we allow OpenLCS to send copyright_text and license_concluded from their scan results. Sometimes OpenLCS also has license_declared (from the license / manifest files in the package source code).

If Corgi does not already have this data, we allow OpenLCS to submit it. If Corgi already has a non-empty value for license_declared (for RPMs, we get this from Brew), don't allow OpenLCS to overwrite it (raise 400 Bad Request).