### PR TITLE
Fix error when view=summary and component has no linked SoftwareBuild

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from abc import abstractmethod
 from collections import defaultdict
@@ -470,7 +471,15 @@ class ComponentListSerializer(IncludeExcludeFieldsSerializer):
     """List all Components. Add or remove fields using ?include_fields=&exclude_fields="""
 
     link = serializers.SerializerMethodField()
-    build_completion_dt = serializers.DateTimeField(source="software_build.completion_time")
+    build_completion_dt = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_build_completion_dt(instance: Component) -> Optional[datetime.datetime]:
+        if instance.software_build:
+            # instance is a root component with a linked software_build
+            return instance.software_build.completion_time
+        # else the software_build is null / we're not a root component
+        return None
 
     @staticmethod
     def get_link(instance: Component) -> str:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. Originally I thought this was due to recent serializer changes in my MR for CORGI-437, but after looking I don't think that's the case.

I guess maybe we just never used the ?view=summary that often, so we never noticed it wouldn't work when listing out non-root components. I tested manually and this does fix the issue. I really should add a test here but I have a bit too much on my plate at the moment.