### PR TITLE
CORGI-472: Fix related url for SRPMs and upstream containers

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -56,6 +56,42 @@ from .serializers import (
 
 logger = logging.getLogger(__name__)
 
+INCLUDE_FIELDS_PARAMETER = OpenApiParameter(
+    "include_fields",
+    type={"type": "array", "items": {"type": "string"}},
+    location=OpenApiParameter.QUERY,
+    description=(
+        "Include only specified fields in the response. "
+        "Multiple values may be separated by commas. "
+        "Example: `include_fields=software_build.build_id,name`"
+    ),
+)
+
+EXCLUDE_FIELDS_PARAMETER = OpenApiParameter(
+    "exclude_fields",
+    type={"type": "array", "items": {"type": "string"}},
+    location=OpenApiParameter.QUERY,
+    description=(
+        "Exclude only specified fields in the response. "
+        "Multiple values may be separated by commas. "
+        "Example: `exclude_fields=software_build.build_id,name`"
+    ),
+)
+
+
+# Use below as a decorator on all viewsets that support
+# ?include_fields&exclude_fields= parameters
+# A custom IncludeExcludeFieldsViewSet class that other
+# ViewSet classes inherit from does not work
+INCLUDE_EXCLUDE_FIELDS_SCHEMA = extend_schema_view(
+    list=extend_schema(
+        parameters=[INCLUDE_FIELDS_PARAMETER, EXCLUDE_FIELDS_PARAMETER],
+    ),
+    retrieve=extend_schema(
+        parameters=[INCLUDE_FIELDS_PARAMETER, EXCLUDE_FIELDS_PARAMETER],
+    ),
+)
+
 
 @extend_schema(request=None, responses=None)
 @api_view(["GET"])
@@ -217,57 +253,7 @@ def get_component_taxonomy(
     return dicts
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=build_id,name`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=build_id,name`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=SoftwareBuildSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=build_id,name`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=build_id,name`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class SoftwareBuildViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled until auth is added
     """View for api/v1/builds"""
 
@@ -286,57 +272,7 @@ class ProductDataViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled u
     ordering_field = "name"
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ProductSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ProductViewSet(ProductDataViewSet):
     """View for api/v1/products"""
 
@@ -368,57 +304,7 @@ class ProductViewSet(ProductDataViewSet):
             raise Http404
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ProductVersionSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ProductVersionViewSet(ProductDataViewSet):
     """View for api/v1/product_versions"""
 
@@ -449,57 +335,7 @@ class ProductVersionViewSet(ProductDataViewSet):
             raise Http404
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ProductStreamSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ProductStreamViewSetSet(ProductDataViewSet):
     """View for api/v1/product_streams"""
 
@@ -555,57 +391,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
         return Response(manifest)
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ProductVariantSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ProductVariantViewSetSet(ProductDataViewSet):
     """View for api/v1/product_variants"""
 
@@ -636,57 +422,7 @@ class ProductVariantViewSetSet(ProductDataViewSet):
             raise Http404
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ChannelSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,ofuri`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,ofuri`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ChannelViewSet(ReadOnlyModelViewSet):
     """View for api/v1/channels"""
 
@@ -697,57 +433,7 @@ class ChannelViewSet(ReadOnlyModelViewSet):
     lookup_url_kwarg = "uuid"
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,version`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,version`"
-                ),
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        responses=ComponentSerializer,
-        parameters=[
-            OpenApiParameter(
-                "include_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Include only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `include_fields=name,version`"
-                ),
-            ),
-            OpenApiParameter(
-                "exclude_fields",
-                type={"type": "array", "items": {"type": "string"}},
-                location=OpenApiParameter.QUERY,
-                description=(
-                    "Exclude only specified fields in the response. "
-                    "Multiple values may be separated by commas."
-                    "Example: `exclude_fields=name,version`"
-                ),
-            ),
-        ],
-    ),
-)
+@INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled until auth is added
     """View for api/v1/components"""
 

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -255,7 +255,7 @@ def save_component(
 
 
 def save_srpm(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentNode:
-    obj, created = Component.objects.get_or_create(
+    obj, created = Component.objects.update_or_create(
         name=build_data["meta"].get("name"),
         type=build_data["type"],
         arch=build_data["meta"].get("arch", ""),
@@ -264,6 +264,7 @@ def save_srpm(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentNode:
         defaults={
             "license_declared_raw": build_data["meta"].get("license", ""),
             "description": build_data["meta"].get("description", ""),
+            "related_url": build_data["meta"].get("url", ""),
             "software_build": softwarebuild,
             "meta_attr": build_data["meta"],
             "namespace": build_data["namespace"],
@@ -281,7 +282,7 @@ def save_srpm(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentNode:
     # Handle case when key is present but value is None
     related_url = build_data["meta"].get("url", "")
     if related_url:
-        new_upstream, created = Component.objects.get_or_create(
+        new_upstream, created = Component.objects.update_or_create(
             type=build_data["type"],
             namespace=Component.Namespace.UPSTREAM,
             name=build_data["meta"].get("name"),

--- a/openapi.yml
+++ b/openapi.yml
@@ -33,7 +33,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=build_id,name`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -41,7 +41,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=build_id,name`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -97,7 +97,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=build_id,name`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -105,7 +105,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=build_id,name`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       tags:
       - v1
       responses:
@@ -127,7 +127,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -135,7 +135,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -186,7 +186,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -194,7 +194,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:
@@ -240,7 +240,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,version`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -248,7 +248,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,version`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -397,7 +397,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,version`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -405,7 +405,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,version`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:
@@ -538,7 +538,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -546,7 +546,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -618,7 +618,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -626,7 +626,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:
@@ -680,7 +680,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -688,7 +688,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -760,7 +760,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -768,7 +768,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:
@@ -801,7 +801,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -809,7 +809,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -881,7 +881,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -889,7 +889,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:
@@ -922,7 +922,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -930,7 +930,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - name: limit
         required: false
         in: query
@@ -1002,7 +1002,7 @@ paths:
           items:
             type: string
         description: 'Exclude only specified fields in the response. Multiple values
-          may be separated by commas.Example: `exclude_fields=name,ofuri`'
+          may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
         name: include_fields
         schema:
@@ -1010,7 +1010,7 @@ paths:
           items:
             type: string
         description: 'Include only specified fields in the response. Multiple values
-          may be separated by commas.Example: `include_fields=name,ofuri`'
+          may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: path
         name: uuid
         schema:


### PR DESCRIPTION
@jasinner Quick fix for a bug that caused related_urls to be unset for SRPMs and upstream containers. I'm opening this now so you can review and I can merge tomorrow to partially unblock the OSC team.

I'll also open another MR tomorrow that generates the related_url information for remote-source components (with tests).

I haven't figured out how we're going to fix the existing data yet. I recall at one point, OSIDB had a very long-running migration that tried to touch every row in some table, which caused issues for them. Do you think it's safe to try to fix this data as part of a migration?

Is it better to merge this as-is, then manually reingest all the builds which link to SRPM components or upstream container components where the name starts with "github.com"? I can kick that off in my morning, then keep an eye on it throughout the day and revoke (cancel) all the slow_fetch_brew_build() tasks if the DB gets overloaded.

Eventually, I need to do a larger refactoring as part of CORGI-313. That will include cleaning up and / or combining our many different codepaths, plus adding more thorough tests that will catch these kinds of issues in the future.