### PR TITLE
CORGI-268: Use exact match on product / version / stream / variant name, not ofuri

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -748,17 +748,20 @@ def test_product_components_versions(client, api_path):
     curl_srpm = SrpmComponentFactory(name="curl", software_build=sb2)
     curl_srpm.productstreams.add(ps1)
 
-    response = client.get(f"{api_path}/components?product_streams=o:redhat:rhel:8")
+    response = client.get(f"{api_path}/components?product_streams={ps2.ofuri}")
+    assert response.status_code == 200
+    assert response.json()["count"] == 2
+    response = client.get(f"{api_path}/components?product_streams={ps2.name}")
     assert response.status_code == 200
     assert response.json()["count"] == 2
 
     # ofuri returns 'latest' build root components (eg. including SRPM,
     #  noarch CONTAINER_IMAGE and RHEL_MODULE)
-    response = client.get(f"{api_path}/components?ofuri=o:redhat:rhel:7")
+    response = client.get(f"{api_path}/components?ofuri={ps1.ofuri}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
-    response = client.get(f"{api_path}/components?name=curl&view=product")
+    response = client.get(f"{api_path}/components?name={curl.name}&view=product")
     assert response.status_code == 200
     assert response.json()["count"] == 2
 
@@ -773,10 +776,16 @@ def test_product_components(client, api_path):
     openssl.products.add(rhel)
     curl.products.add(rhel_br)
 
-    response = client.get(f"{api_path}/components?products=o:redhat:rhel")
+    response = client.get(f"{api_path}/components?products={rhel.ofuri}")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+    response = client.get(f"{api_path}/components?products={rhel.name}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
-    response = client.get(f"{api_path}/components?products=o:redhat:rhel-br")
+    response = client.get(f"{api_path}/components?products={rhel_br.ofuri}")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+    response = client.get(f"{api_path}/components?products={rhel_br.name}")
     assert response.status_code == 200
     assert response.json()["count"] == 1


### PR DESCRIPTION
@jasinner I felt bad Hardik had reported this several months ago and we still hadn't done it yet. It's a very simple change so I just went ahead and switched it. Of course if I misunderstood his requirement, then this gets more complicated :stuck_out_tongue:

Before, Hardik would only see results with a URL like below:
https://corgi-stage.prodsec.redhat.com/api/v1/components?products=o:redhat:rhel

Searching for "rhel", "rh", or "o:redhat:rh" wouldn't return any results.

Now, Hardik will only see results with a URL like below:
https://corgi-stage.prodsec.redhat.com/api/v1/components?products=rhel

Searching for "rh", "o:redhat:rh", or "o:redhat:rhel" won't return any results.

I used an exact lookup instead of an icontains lookup to avoid confusion. With an icontains lookup, searching for "rh" or "rhel" would both show results for "rhel". But users would also see results for "rhel-br" which is a completely different product.

This gets worse if you want to find exactly one stream. Searching for something like "openshift-4" would show results for both base streams and z-streams like "openshift-4.7", "openshift-4.7.z", "openshift-4.8", "openshift-4.8.z", and so on. Users probably meant "openshift-4.0" for the original release.

There are other ways of doing this pattern match if people really want it. I think Hardik's complaint is just that the ofuri format is unfamiliar and a little clunky to use in a search. But he knows the name of the product / stream he's interested in, and expects our filters to just find products with matching names.