### PR TITLE
CORGI-472: Ensure related_url is always set using purl2url

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -321,8 +321,10 @@ class Brew:
         remote_sources: dict[str, Tuple] = {}
         # TODO: Should we raise an error if build_info["extra"] is missing?
         if build_info["extra"]:
-            if "index" in build_info["extra"]["image"]:
-                component["meta"]["digests"] = build_info["extra"]["image"]["index"]["digests"]
+            index = build_info["extra"]["image"].get("index", {})
+            if index:
+                component["meta"]["digests"] = index["digests"]
+                component["meta"]["pull"] = index.get("pull", [])
 
             if "parent_build_id" in build_info["extra"]["image"]:
                 parent_image = build_info["extra"]["image"]["parent_build_id"]

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -2,7 +2,7 @@ import logging
 import re
 import uuid as uuid
 from abc import abstractmethod
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -883,6 +883,10 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         UPSTREAM = "UPSTREAM"
         REDHAT = "REDHAT"
 
+    RPM_PACKAGE_BROWSER = "https://access.redhat.com/downloads/content/package-browser"
+    CONTAINER_CATALOG_SEARCH = "https://catalog.redhat.com/software/containers/search"
+    MAVEN_CENTRAL_SERVER = "https://repo1.maven.org/maven2"
+
     REMOTE_SOURCE_COMPONENT_TYPES = (
         Type.CARGO,
         Type.GEM,
@@ -1098,6 +1102,19 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             return f"https://github.com/{name}/archive/{version}.zip"
         return ""
 
+    def _get_download_url(
+        self, namespace_parts: list[str], name: str, version: Optional[str], path: Optional[str]
+    ):
+        if len(namespace_parts) == 2:
+            url = f"https://{namespace_parts[0]}/{namespace_parts[1]}/{name}/"
+        else:
+            url = f"https://{namespace_parts[0]}/{namespace_parts[1]}/{namespace_parts[2]}/"
+        if path:
+            url = url + path
+        if version:
+            url = url + version
+        return url
+
     def _build_golang_download_url(self) -> str:
         """
         Return a download URL from the `purl` string for golang.
@@ -1123,8 +1140,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         if "github.com" in namespace:
 
-            namespace = namespace.split("/")
-            exp = re.compile(r"v\d+")
+            namespace_parts = namespace.split("/")
 
             # if the version is a pseudo version and contains several sections
             # separated by - the last section is a git commit id
@@ -1133,39 +1149,19 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             # what-does-incompatible-in-go-mod-mean-will-it-cause-harm
             if "-" in version:
                 version = version.split("-")[-1]
-                if exp.match(name):
-                    return f"https://{namespace[0]}/{namespace[1]}/{namespace[2]}/tree/{version}"
-                else:
-                    return f"https://{namespace[0]}/{namespace[1]}/{name}/tree/{version}"
+                return self._get_download_url(namespace_parts, purl_data.name, version, "tree/")
 
             # if the version refers to a module using semantic versioning,
             # but not opted to use modules it has a
             # '+incompatible' differentiator in the version what can be just omitted in our case.
             # Ref: https://stackoverflow.com/questions/57355929/
             # what-does-incompatible-in-go-mod-mean-will-it-cause-harm
-            # Ref: https://github.com/golang/go/wiki/
-            # Modules#can-a-module-consume-a-package-that-has-not-opted-in-to-modules
+            # Ref: https://github.com/golang/go/wiki/Modules#can-a-module-consume-a-package-
+            # that-has-not-opted-in-to-modules
 
             version = version.replace("+incompatible", "")
-            # If the referred module is in a directory of a repo,
-            # then parts of the url are added as a part of a tag
-            if len(namespace) >= 3:
-                # Constructing the basic part of the URL
-                url = f"https://{namespace[0]}/{namespace[1]}/{namespace[2]}/releases/tag/"
-                # adding the remains of the path to the tag
-                for i in range(3, len(namespace)):
-                    url += f"{namespace[i]}%2F"
-                # and finally adding the version
-                if exp.match(name):
-                    url = f"{url}{version}"
-                else:
-                    url = f"{url}{name}%2F{version}"
-                return url
-            else:
-                if exp.match(name):
-                    return f"https://{purl_data.namespace}/releases/tag/{version}"
-                else:
-                    return f"https://{purl_data.namespace}/{name}/releases/tag/{version}"
+            return self._get_download_url(namespace_parts, purl_data.name, version, "releases/tag/")
+
         else:
             if "-" in version:
                 # Version is not semantic version, therefore not compatible with pkg.go.dev
@@ -1184,37 +1180,16 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         namespace = purl_data.namespace
         name = purl_data.name
+
         version = self.strip_release_from_version(purl_data.version)
 
         if not (namespace and name and version):
             return ""
 
         if "github.com" in namespace:
+            namespace_parts = namespace.split("/")
+            return self._get_download_url(namespace_parts, name, path=None, version=None)
 
-            namespace = namespace.split("/")
-            exp = re.compile(r"v\d+")
-
-            # if the version is a pseudo version and contains several sections
-            # separated by - the last section is a git commit id
-            # what should be referred in the tree of the repo
-            # https://stackoverflow.com/questions/57355929/
-            # what-does-incompatible-in-go-mod-mean-will-it-cause-harm
-            if "-" in version:
-                if exp.match(name):
-                    return f"https://{namespace[0]}/{namespace[1]}/{namespace[2]}/"
-                else:
-                    return f"https://{namespace[0]}/{namespace[1]}/{name}/"
-
-            # If the referred module is in a directory of a repo,
-            # then parts of the url are added as a part of a tag
-            if len(namespace) >= 3:
-                # Constructing the basic part of the URL
-                return f"https://{namespace[0]}/{namespace[1]}/{namespace[2]}/"
-            else:
-                if exp.match(name):
-                    return f"https://{purl_data.namespace}"
-                else:
-                    return f"https://{purl_data.namespace}/{name}"
         else:
             if "-" in version:
                 # Version is not semantic version, therefore not compatible with pkg.go.dev
@@ -1228,27 +1203,28 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # Based on existing url2purl logic for Maven, and official docs:
         # https://maven.apache.org/repositories/layout.html
         purl_data = PackageURL.from_string(self.purl)
-        central_maven_server = "https://repo1.maven.org/maven2"
-
         namespace = purl_data.namespace
         if namespace:
             namespace = namespace.split(".")
             namespace = "/".join(namespace)
+            namespace = namespace.removeprefix("redhat/")
 
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
+        if ".redhat-" in version:
+            version = version.split(".redhat-", maxsplit=1)[0]
         classifier = purl_data.qualifiers.get("classifier")
         classifier = f"-{classifier}" if classifier else ""
         extension = purl_data.qualifiers.get("type")
 
         if namespace and name and version and extension:
             return (
-                f"{central_maven_server}/{namespace}/{name}/{version}/"
+                f"{self.MAVEN_CENTRAL_SERVER}/{namespace}/{name}/{version}/"
                 f"{name}-{version}{classifier}.{extension}"
             )
 
         elif namespace and name and version:
-            return f"{central_maven_server}/{namespace}/{name}/{version}/"
+            return f"{self.MAVEN_CENTRAL_SERVER}/{namespace}/{name}/{version}/"
 
         else:
             return ""
@@ -1263,7 +1239,9 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         namespace = purl_data.namespace
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
+        if ".redhat-" in version:
+            version = version.split(".redhat-", maxsplit=1)[0]
 
         classifier = purl_data.qualifiers.get("classifier")
         classifier = f"-{classifier}" if classifier else ""
@@ -1522,7 +1500,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # but isn't available in the meta_attr / other properties (CORGI-342). Get it with:
         # rpm -q --qf %{SIGPGP:pgpsig} aspell-devel-0.60.8-8.el9.x86_64 | tail -c8
         if self.type == Component.Type.RPM:
-            return "https://access.redhat.com/downloads/content/package-browser"
+            return self.RPM_PACKAGE_BROWSER
 
         # Image ex:
         # /software/containers/container-native-virtualization/hco-bundle-registry/5ccae1925a13467289f2475b
@@ -1539,9 +1517,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             pull_url = self.meta_attr.get("pull", [])
             # First pull URL is based on hash, others are based on tags
             # if we have an empty list, just return a generic URL
-            pull_url = (
-                pull_url[0] if pull_url else "https://catalog.redhat.com/software/containers/search"
-            )
+            pull_url = pull_url[0] if pull_url else self.CONTAINER_CATALOG_SEARCH
             return pull_url
 
         else:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1530,13 +1530,19 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # 5d9347b8dd19c70159f2f6e4?architecture=s390x&tag=v4.4.0-202007171809.p0
         # We can't build URLs like above because the hash is required,
         # but doesn't match any hash in the meta_attr / other properties.
-        # We could use repository_url instead, if we decide to store it on the model.
-        # Currently it's only in the meta_attr and should not be used (CORGI-341).
+        # repository_url is the customer-facing download location, but per OpenLCS
+        # they want to see the internal registry-proxy URL from Brew.
 
         # TODO: self.filename, AKA the filename of the image archive a container is included in,
         #  is always unset. This is not the digest SHA but the config layer SHA.
         elif self.type == Component.Type.CONTAINER_IMAGE:
-            return "https://catalog.redhat.com/software/containers/search"
+            pull_url = self.meta_attr.get("pull", [])
+            # First pull URL is based on hash, others are based on tags
+            # if we have an empty list, just return a generic URL
+            pull_url = (
+                pull_url[0] if pull_url else "https://catalog.redhat.com/software/containers/search"
+            )
+            return pull_url
 
         else:
             # Usually a remote-source component

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1085,6 +1085,19 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             return purl_version.rsplit("-", maxsplit=1)[0]
         return purl_version
 
+    def _build_github_download_url(self, purl: str) -> str:
+        """Return a GitHub download URL from the `purl` string."""
+        # TODO: Open PR for this upstream
+        # github download urls are just zip files like below:
+        # https://github.com/RedHatProductSecurity/django-mptt/archive/commit_hash.zip
+        purl_data = PackageURL.from_string(purl)
+        name = purl_data.name
+        version = self.strip_release_from_version(purl_data.version)
+
+        if name and version:
+            return f"https://github.com/{name}/archive/{version}.zip"
+        return ""
+
     def save_component_taxonomy(self):
         """Link related components together using foreign keys. Avoids repeated MPTT tree lookups"""
         upstreams = self.get_upstreams_pks(using="default")

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1272,6 +1272,20 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             return f"{central_maven_server}/{namespace}/{name}/{version}{classifier}"
         return ""
 
+    def _build_pypi_download_url(self) -> str:
+        """Return a PyPI download URL from the `purl` string."""
+        # TODO: Open PR for this upstream
+        #  Or don't, this predictable URL is a legacy thing we're not really supposed to use
+        # https://stackoverflow.com/questions/47781035/does-pypi-have-simple-urls-for-package-downloads#47840593
+        purl_data = PackageURL.from_string(self.purl)
+        central_pypi_server = "https://pypi.io/packages/source"
+
+        name = purl_data.name
+        version = self.strip_release_from_version(purl_data.version)
+        if name and version:
+            return f"{central_pypi_server}/{name[0]}/{name}/{name}-{version}.tar.gz"
+        return ""
+
     def save_component_taxonomy(self):
         """Link related components together using foreign keys. Avoids repeated MPTT tree lookups"""
         upstreams = self.get_upstreams_pks(using="default")

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -396,7 +396,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
             if not related_url:
                 # Handle case when key is present but value is None
                 related_url = ""
-                if component_name.startswith("github.com"):
+                if component_name.startswith("github.com/"):
                     related_url = f"https://{component_name}"
                 if "openshift-priv" in related_url:
                     # Component name is something like github.com/openshift-priv/cluster-api

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -216,10 +216,14 @@ def save_component(
     if not (softwarebuild and parent.obj is not None and parent.obj.is_srpm()):
         softwarebuild = None
 
-    # Handle case when key is present but value is None
     related_url = meta.pop("url", "")
-    if related_url is None:
+    if not related_url:
+        # Only RPMs have a URL header, containers might have below
+        related_url = meta.get("repository_url", "")
+    if not related_url:
+        # Handle case when key is present but value is None
         related_url = ""
+
     obj, _ = Component.objects.update_or_create(
         type=component_type,
         name=meta.pop("name", ""),
@@ -326,6 +330,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
         release=build_data["meta"]["release"],
         defaults={
             "software_build": softwarebuild,
+            "related_url": build_data["meta"].get("repository_url", ""),
             "meta_attr": build_data["meta"],
             "namespace": build_data.get("namespace", ""),
         },

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -263,9 +263,9 @@ kombu==5.2.3 \
     --hash=sha256:81a90c1de97e08d3db37dbf163eaaf667445e1068c98bfd89f051a40e9f6dbbd \
     --hash=sha256:eeaeb8024f3a5cfc71c9250e45cddb8493f269d74ada2f74909a93c59c4b4179
     # via celery
-packageurl-python==0.9.9 \
-    --hash=sha256:07aa852d1c48b0e86e625f6a32d83f96427739806b269d0f8142788ee807114b \
-    --hash=sha256:872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09
+packageurl-python==0.10.4 \
+    --hash=sha256:5c91334f942cd55d45eb0c67dd339a535ef90e25f05b9ec016ad188ed0ef9048 \
+    --hash=sha256:bf8a1ffe755634776f6563904d792fb0aa13b377fc86115c36fe17f69b6e59db
     # via -r requirements/base.in
 prometheus-client==0.14.1 \
     --hash=sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -711,9 +711,9 @@ mypy-extensions==0.4.3 \
     #   -r requirements/test.txt
     #   black
     #   mypy
-packageurl-python==0.9.9 \
-    --hash=sha256:07aa852d1c48b0e86e625f6a32d83f96427739806b269d0f8142788ee807114b \
-    --hash=sha256:872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09
+packageurl-python==0.10.4 \
+    --hash=sha256:5c91334f942cd55d45eb0c67dd339a535ef90e25f05b9ec016ad188ed0ef9048 \
+    --hash=sha256:bf8a1ffe755634776f6563904d792fb0aa13b377fc86115c36fe17f69b6e59db
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -553,9 +553,9 @@ mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
     # via mypy
-packageurl-python==0.9.9 \
-    --hash=sha256:07aa852d1c48b0e86e625f6a32d83f96427739806b269d0f8142788ee807114b \
-    --hash=sha256:872a0434b9a448b3fa97571711f69dd2a3fb72345ad66c90b17d827afea82f09
+packageurl-python==0.10.4 \
+    --hash=sha256:5c91334f942cd55d45eb0c67dd339a535ef90e25f05b9ec016ad188ed0ef9048 \
+    --hash=sha256:bf8a1ffe755634776f6563904d792fb0aa13b377fc86115c36fe17f69b6e59db
     # via -r requirements/base.txt
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -193,6 +193,7 @@ def test_get_component_data(
             "name",
             "digests",
             "source",
+            "pull",
         }
     else:
         assert list(c.keys()) == [


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, this isn't ready for a "full" review yet. Pushing anyway so people can tell me if I'm wildly off-base with this approach. Only look at the changes in models.py - everything else was an unfinished first attempt that I need to go clean up.

For RPMs and some containers, we can set the related_url during ingestion based on values from Brew. For all other (remote-source) components, we want to use purl2url to find some upstream repo URL based on the purl.

purl2url supports most of our types, but needed some tweaking to work around bugs in the library, edge cases in our data, and purl / component types that aren't supported yet.