### PR TITLE
CORGI-510 fix json decode error for manifest with backslash in value

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -34,6 +34,11 @@ class ManifestFile(ABC):
         # to generate valid JSON and escape quotes + newlines
         # But this may output ugly Unicode like "\u000A",
         # so we convert from JSON back to JSON to get "\n" instead
+
+        # This is a workaround for packages detected by Syft 0.60.1 that have a trailing backslash
+        # see https://github.com/anchore/syft/issues/1644
+        content = content.replace("\\", "\\\\")
+
         content = json.loads(content)
         return json.dumps(content, indent=2, sort_keys=True)
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime
+from json import JSONDecodeError
 
 import jsonschema
 import pytest
@@ -231,3 +232,19 @@ def setup_products_and_components():
     # Link the components to the ProductModel instances
     build.save_product_taxonomy()
     return component, stream, provided, dev_provided
+
+
+def test_manifest_backslash():
+    """Test that a tailing backslash in a purl doesn't break rendering"""
+
+    stream = ProductStreamFactory()
+    sb = SoftwareBuildFactory(
+        completion_time=datetime.strptime("2017-03-29 12:13:29 GMT+0000", "%Y-%m-%d %H:%M:%S %Z%z")
+    )
+    component = SrpmComponentFactory(version="2.8.0 \\", software_build=sb)
+    component.productstreams.add(stream)
+
+    try:
+        stream.manifest
+    except JSONDecodeError:
+        assert False


### PR DESCRIPTION
This escapes backslashes from manifest json values which cause json validation errors during a rendering of a manifest.