### PR TITLE
CORGI-501: fixes view=latest which should return a set of components

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -739,13 +739,6 @@ def test_filter_latest_by_name():
     srpm.productstreams.add(ps)
     assert ps.filter_latest_nevra_by_name(component_name="sdb") == "sdb-1.2.1-21.el7.src"
 
-    # test strict_search=True
-    srpm = SrpmComponentFactory(name="sdb2", version="1.2.1", release="22")
-    srpm.productstreams.add(ps)
-    assert "sdb2-1.2.1-22.src" == ps.filter_latest_nevra_by_name(
-        component_name="sdb", strict_search=True
-    )
-
     # test no result
     ps = ProductStreamFactory(name="rhel-7.7.z")
     assert not ps.filter_latest_nevra_by_name(component_name="sdb")


### PR DESCRIPTION
#325 fixed latest filters but also introduced regression when doing view=latest&(re_)name={}

this fixes that.
 
Note- While I was 'in the area', added missing using('read only') to some queries.