### PR TITLE
CORGI-508: Fix related url bugs

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1117,10 +1117,15 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # github download urls are just zip files like below:
         # https://github.com/RedHatProductSecurity/django-mptt/archive/commit_hash.zip
         purl_data = PackageURL.from_string(purl)
+
+        namespace = purl_data.namespace
         name = purl_data.name
         version = purl_data.version
 
-        if name and version:
+        if namespace and name and version:
+            return f"https://github.com/{namespace}/{name}/archive/{version}.zip"
+        elif name and version:
+            # Name should embed namespace if not discovered explicitly
             return f"https://github.com/{name}/archive/{version}.zip"
         return ""
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1091,30 +1091,39 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             qualifiers=qualifiers,
         )
 
-    def strip_release_from_version(self, purl_version: str) -> str:
+    def strip_namespace(self, purl: str) -> str:
+        """Remove "redhat/" that we prepend to namespace strings in our purls"""
+        if self.namespace == Component.Namespace.REDHAT and purl:
+            # purls like pkg:golang/redhat/otherstuff cause issues with purl2url
+            purl = purl.replace("/redhat/", "/", 1)
+        return purl
+
+    def strip_release(self, purl_version: str) -> str:
         """Remove self.release that we append to version strings in our purls"""
         # TODO: Need to look at other enhancements / fixes for our purls
         #  Some of them are missing recommended / necessary information for purl2url
         #  Maybe we should add ?release= as a domain-specific qualifier
         #  Instead of appending to upstream versions
-        if self.release:
-            return purl_version.rsplit("-", maxsplit=1)[0]
+        if self.release and purl_version:
+            purl_version = purl_version.replace(f"-{self.release}", "", 1)
         return purl_version
 
-    def _build_github_download_url(self, purl: str) -> str:
+    @staticmethod
+    def _build_github_download_url(purl: str) -> str:
         """Return a GitHub download URL from the `purl` string."""
         # TODO: Open PR for this upstream
         # github download urls are just zip files like below:
         # https://github.com/RedHatProductSecurity/django-mptt/archive/commit_hash.zip
         purl_data = PackageURL.from_string(purl)
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
 
         if name and version:
             return f"https://github.com/{name}/archive/{version}.zip"
         return ""
 
-    def _build_golang_download_url(self) -> str:
+    @classmethod
+    def _build_golang_download_url(cls, purl: str) -> str:
         """
         Return a download URL from the `purl` string for golang.
         Due to the non deterministic nature of go package locations
@@ -1123,11 +1132,11 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # Copied from open PR upstream, not merged yet:
         # https://github.com/package-url/packageurl-python/pull/113/files
 
-        purl_data = PackageURL.from_string(self.purl)
+        purl_data = PackageURL.from_string(purl)
 
         namespace = purl_data.namespace
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
 
         download_url = purl_data.qualifiers.get("download_url")
 
@@ -1189,18 +1198,19 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             else:
                 return f"https://pkg.go.dev/{namespace}/{name}@{version}"
 
-    def _build_golang_repo_url(self) -> str:
+    @classmethod
+    def _build_golang_repo_url(cls, purl: str) -> str:
         """
         Return a golang repository URL from the `purl` string.
         Due to the non deterministic nature of go package locations
         this function works in a best effort basis.
         """
 
-        purl_data = PackageURL.from_string(self.purl)
+        purl_data = PackageURL.from_string(purl)
 
         namespace = purl_data.namespace
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
 
         if not (namespace and name and version):
             return ""
@@ -1238,12 +1248,13 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             else:
                 return f"https://pkg.go.dev/{namespace}/{name}@{version}"
 
-    def _build_maven_download_url(self) -> str:
+    @staticmethod
+    def _build_maven_download_url(purl: str) -> str:
         """Return a maven download URL from the `purl` string."""
         # TODO: Open PR for this upstream
         # Based on existing url2purl logic for Maven, and official docs:
         # https://maven.apache.org/repositories/layout.html
-        purl_data = PackageURL.from_string(self.purl)
+        purl_data = PackageURL.from_string(purl)
         central_maven_server = "https://repo1.maven.org/maven2"
 
         namespace = purl_data.namespace
@@ -1252,7 +1263,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             namespace = "/".join(namespace)
 
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
         classifier = purl_data.qualifiers.get("classifier")
         classifier = f"-{classifier}" if classifier else ""
         extension = purl_data.qualifiers.get("type")
@@ -1269,17 +1280,18 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         else:
             return ""
 
-    def _build_maven_repo_url(self) -> str:
+    @staticmethod
+    def _build_maven_repo_url(purl: str) -> str:
         """Return a maven repository URL from the `purl` string."""
         # TODO: Open PR for this upstream
         # Based on existing url2purl logic for Maven, and official docs:
         # https://maven.apache.org/repositories/layout.html
-        purl_data = PackageURL.from_string(self.purl)
+        purl_data = PackageURL.from_string(purl)
         central_maven_server = "https://mvnrepository.com/artifact"
 
         namespace = purl_data.namespace
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
 
         classifier = purl_data.qualifiers.get("classifier")
         classifier = f"-{classifier}" if classifier else ""
@@ -1288,16 +1300,17 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             return f"{central_maven_server}/{namespace}/{name}/{version}{classifier}"
         return ""
 
-    def _build_pypi_download_url(self) -> str:
+    @staticmethod
+    def _build_pypi_download_url(purl: str) -> str:
         """Return a PyPI download URL from the `purl` string."""
         # TODO: Open PR for this upstream
         #  Or don't, this predictable URL is a legacy thing we're not really supposed to use
         # https://stackoverflow.com/questions/47781035/does-pypi-have-simple-urls-for-package-downloads#47840593
-        purl_data = PackageURL.from_string(self.purl)
+        purl_data = PackageURL.from_string(purl)
         central_pypi_server = "https://pypi.io/packages/source"
 
         name = purl_data.name
-        version = self.strip_release_from_version(purl_data.version)
+        version = purl_data.version
         if name and version:
             return f"{central_pypi_server}/{name[0]}/{name}/{name}-{version}.tar.gz"
         return ""
@@ -1332,20 +1345,27 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
     def _build_repo_url_for_type(self) -> str:
         """Get an upstream repo URL based on a purl"""
+        # Remove Red Hat-specific identifiers that break purl2url
+        purl = self.strip_namespace(self.purl)
+        purl_dict = PackageURL.from_string(purl).to_dict()
+        purl_dict["version"] = self.strip_release(purl_dict["version"])
+        purl = PackageURL(**purl_dict).to_string()
+
         if self.type == Component.Type.GEM:
             # Work around a bug in the library
-            purl = self.purl.replace("pkg:gem/", "pkg:rubygems/")
+            purl = purl.replace("pkg:gem/", "pkg:rubygems/")
             related_url = purl2url.get_repo_url(purl)
 
         elif self.type == Component.Type.GENERIC:
             related_url = self.related_url
             if not related_url:
                 # Usually (15k of 17k) generic upstream components point at Github
+                # TODO: Should this be purl.startswith()?
                 if self.name.startswith("github.com/"):
-                    purl = self.purl.replace("pkg:generic/github.com/", "pkg:github/")
+                    purl = purl.replace("pkg:generic/github.com/", "pkg:github/")
                     related_url = purl2url.get_repo_url(purl) or ""
                 elif self.name.startswith("git@github.com:"):
-                    purl = self.purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
+                    purl = purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
                     related_url = purl2url.get_repo_url(purl) or ""
                 # else the component isn't hosted on Github, so we don't know
 
@@ -1363,14 +1383,14 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
                 pass
 
         elif self.type == Component.Type.GOLANG:
-            related_url = self._build_golang_repo_url()
+            related_url = self._build_golang_repo_url(purl)
 
         elif self.type == Component.Type.MAVEN:
-            related_url = self._build_maven_repo_url()
+            related_url = self._build_maven_repo_url(purl)
 
         elif self.type in Component.REMOTE_SOURCE_COMPONENT_TYPES:
             # All other remote-source component types are natively supported by purl2url
-            related_url = purl2url.get_repo_url(self.purl)
+            related_url = purl2url.get_repo_url(purl)
 
         else:
             # RPM or OCI have values set on ingestion, don't overwrite them
@@ -1467,25 +1487,31 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
     def _build_download_url_for_type(self) -> str:
         """Get a source code or binary download URL based on a purl"""
+        # Remove Red Hat-specific identifiers that break purl2url
+        purl = self.strip_namespace(self.purl)
+        purl_dict = PackageURL.from_string(purl).to_dict()
+        purl_dict["version"] = self.strip_release(purl_dict["version"])
+        purl = PackageURL(**purl_dict).to_string()
+
         if self.type == Component.Type.GEM:
             # Work around a bug in the library:
             # https://github.com/package-url/packageurl-python/pull/114
-            purl_str = self.purl.replace("pkg:gem/", "pkg:rubygems/")
-            download_url = purl2url.get_download_url(purl_str)
+            purl = purl.replace("pkg:gem/", "pkg:rubygems/")
+            download_url = purl2url.get_download_url(purl)
 
         elif self.type == Component.Type.GENERIC:
             # purl2url can't support this type very well, for obvious reasons
             # just return a download URL if the purl has an explicit one
-            purl = PackageURL.from_string(self.purl)
-            download_url = purl.qualifiers.get("download_url", "")
+            purl_obj = PackageURL.from_string(purl)
+            download_url = purl_obj.qualifiers.get("download_url", "")
 
             if not download_url:
                 # Usually (15k of 17k) generic upstream components point at Github
                 if self.name.startswith("github.com/"):
-                    purl = self.purl.replace("pkg:generic/github.com/", "pkg:github/")
+                    purl = purl.replace("pkg:generic/github.com/", "pkg:github/")
                     download_url = self._build_github_download_url(purl)
                 elif self.name.startswith("git@github.com:"):
-                    purl = self.purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
+                    purl = purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
                     download_url = self._build_github_download_url(purl)
                 # else the component isn't hosted on Github, so we don't know
 
@@ -1504,20 +1530,20 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
                 pass
 
         elif self.type == Component.Type.GITHUB:
-            download_url = self._build_github_download_url(self.purl)
+            download_url = self._build_github_download_url(purl)
 
         elif self.type == Component.Type.GOLANG:
-            download_url = self._build_golang_download_url()
+            download_url = self._build_golang_download_url(purl)
 
         elif self.type == Component.Type.MAVEN:
-            download_url = self._build_maven_download_url()
+            download_url = self._build_maven_download_url(purl)
 
         elif self.type == Component.Type.PYPI:
-            download_url = self._build_pypi_download_url()
+            download_url = self._build_pypi_download_url(purl)
 
         elif self.type in Component.REMOTE_SOURCE_COMPONENT_TYPES:
             # All other remote-source component types are natively supported by purl2url
-            download_url = purl2url.get_download_url(self.purl)
+            download_url = purl2url.get_download_url(purl)
 
         # All other component types are either not currently supported or have no downloadable
         # artifacts (e.g. RHEL module builds).

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1371,16 +1371,18 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         elif self.type == Component.Type.GENERIC:
             related_url = self.related_url
-            if not related_url:
-                # Usually (15k of 17k) generic upstream components point at Github
-                # TODO: Should this be purl.startswith()?
-                if self.name.startswith("github.com/"):
-                    purl = purl.replace("pkg:generic/github.com/", "pkg:github/")
-                    related_url = purl2url.get_repo_url(purl) or ""
-                elif self.name.startswith("git@github.com:"):
-                    purl = purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
-                    related_url = purl2url.get_repo_url(purl) or ""
-                # else the component isn't hosted on Github, so we don't know
+            # Usually (15k of 17k) generic upstream components point at Github
+            generic_pkg_on_github_http = "pkg:generic/github.com/"
+            generic_pkg_on_github_git = "pkg:generic/git%40github.com:"
+            github_pkg = "pkg:github/"
+
+            if purl.startswith(generic_pkg_on_github_http):
+                purl = purl.replace(generic_pkg_on_github_http, github_pkg)
+                related_url = purl2url.get_repo_url(purl) or ""
+            elif purl.startswith(generic_pkg_on_github_git):
+                purl = purl.replace(generic_pkg_on_github_git, github_pkg)
+                related_url = purl2url.get_repo_url(purl) or ""
+            # else the component isn't hosted on Github, so we don't know
 
             if "openshift-priv" in related_url:
                 # Sometimes we need to redirect to the public OpenShift repos
@@ -1520,11 +1522,15 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
             if not download_url:
                 # Usually (15k of 17k) generic upstream components point at Github
-                if self.name.startswith("github.com/"):
-                    purl = purl.replace("pkg:generic/github.com/", "pkg:github/")
+                generic_pkg_on_github_http = "pkg:generic/github.com/"
+                generic_pkg_on_github_git = "pkg:generic/git%40github.com:"
+                github_pkg = "pkg:github/"
+
+                if purl.startswith(generic_pkg_on_github_http):
+                    purl = purl.replace(generic_pkg_on_github_http, github_pkg)
                     download_url = self._build_github_download_url(purl)
-                elif self.name.startswith("git@github.com:"):
-                    purl = purl.replace("pkg:generic/git%40github.com:", "pkg:github/")
+                elif purl.startswith(generic_pkg_on_github_git):
+                    purl = purl.replace(generic_pkg_on_github_git, github_pkg)
                     download_url = self._build_github_download_url(purl)
                 # else the component isn't hosted on Github, so we don't know
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1024,7 +1024,9 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         # Red Hat components should be namespaced, everything else is assumed to be upstream.
         if self.namespace == Component.Namespace.REDHAT:
-            purl_data["namespace"] = str(self.namespace).lower()
+            # Don't wipe out Maven / other purl namespaces if they already exist
+            existing_namespace = purl_data.get("namespace", "")
+            purl_data["namespace"] = f"{Component.Namespace.REDHAT.lower()}/{existing_namespace}"
 
         return PackageURL(type=str(self.type).lower(), **purl_data)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -467,22 +467,38 @@ def test_purl2url():
     assert component.download_url.endswith(f"{component.name}-{component.version}.gem")
 
     component = ComponentFactory(
-        namespace=Component.Namespace.REDHAT, type=Component.Type.GENERIC, release=release
+        namespace=Component.Namespace.REDHAT,
+        name="user/repo",
+        type=Component.Type.GENERIC,
+        release=release,
     )
     assert component.download_url == ""
+    assert component.related_url == ""
     orig_name = component.name
-    component.name = f"github.com/{component.name}"
-    assert component.download_url.startswith("https://github.com/")
-    assert component.download_url.endswith(f"{orig_name}/archive/{component.version}.zip")
-    component.name = f"git@github.com:{component.name}"
-    assert component.download_url.startswith("https://github.com/")
-    assert component.download_url.endswith(f"{orig_name}/archive/{component.version}.zip")
+
+    component.name = f"github.com/{orig_name}"
+    component.save()
+    assert component.download_url == f"https://{component.name}/archive/{component.version}.zip"
+    assert component.related_url == f"https://{component.name}/tree/{component.version}"
+
+    component.name = f"git@github.com:{orig_name}"
+    component.save()
+    assert (
+        component.download_url == f"https://github.com/{orig_name}/archive/{component.version}.zip"
+    )
+    assert component.related_url == f"https://github.com/{orig_name}/tree/{component.version}"
 
     component = ComponentFactory(
-        namespace=Component.Namespace.REDHAT, type=Component.Type.GITHUB, release=release
+        namespace=Component.Namespace.REDHAT,
+        name="user/repo",
+        type=Component.Type.GITHUB,
+        release=release,
     )
-    assert component.download_url.startswith("https://github.com/")
-    assert component.download_url.endswith(f"{component.name}/archive/{component.version}.zip")
+    assert (
+        component.download_url
+        == f"https://github.com/{component.name}/archive/{component.version}.zip"
+    )
+    assert component.related_url == f"https://github.com/{component.name}/tree/{component.version}"
 
     # semantic version
     # name with namespace component

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -447,6 +447,7 @@ def test_get_upstream_container():
 
 
 def test_purl2url():
+    release = "Must_be_removed_from_every_purl_before_building_URL"
     component = ComponentFactory(type=Component.Type.RPM, arch="src")
     assert component.download_url == Component.RPM_PACKAGE_BROWSER
     component = ComponentFactory(type=Component.Type.RPM)
@@ -459,11 +460,15 @@ def test_purl2url():
     component.meta_attr["pull"] = []
     assert component.download_url == Component.CONTAINER_CATALOG_SEARCH
 
-    component = ComponentFactory(type=Component.Type.GEM, release="")
+    component = ComponentFactory(
+        namespace=Component.Namespace.REDHAT, type=Component.Type.GEM, release=release
+    )
     assert component.download_url.startswith("https://rubygems.org/downloads/")
     assert component.download_url.endswith(f"{component.name}-{component.version}.gem")
 
-    component = ComponentFactory(type=Component.Type.GENERIC)
+    component = ComponentFactory(
+        namespace=Component.Namespace.REDHAT, type=Component.Type.GENERIC, release=release
+    )
     assert component.download_url == ""
     orig_name = component.name
     component.name = f"github.com/{component.name}"
@@ -473,7 +478,9 @@ def test_purl2url():
     assert component.download_url.startswith("https://github.com/")
     assert component.download_url.endswith(f"{orig_name}/archive/{component.version}.zip")
 
-    component = ComponentFactory(type=Component.Type.GITHUB)
+    component = ComponentFactory(
+        namespace=Component.Namespace.REDHAT, type=Component.Type.GITHUB, release=release
+    )
     assert component.download_url.startswith("https://github.com/")
     assert component.download_url.endswith(f"{component.name}/archive/{component.version}.zip")
 
@@ -481,9 +488,10 @@ def test_purl2url():
     # name with namespace component
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         name="4d63.com/gochecknoglobals",
         version="v3.0.0",
+        release=release,
     )
     assert component.download_url.startswith("https://pkg.go.dev/")
     assert component.download_url.endswith(f"{component.name}@{component.version}")
@@ -491,18 +499,20 @@ def test_purl2url():
     # no namespace
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         name="gochecknoglobals",
         version="v3.0.0",
+        release=release,
     )
     assert component.download_url == ""
 
     # non schemantic version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         name="4d63.com/gochecknoglobals",
         version="v3.0.0-6",
+        release=release,
     )
 
     assert component.download_url == ""
@@ -511,9 +521,10 @@ def test_purl2url():
     # pseudo version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         name="github.com/14rcole/gopopulate",
         version="v0.0.0-20180821133914-b175b219e774",
+        release=release,
     )
     assert component.download_url == "https://github.com/14rcole/gopopulate/tree/b175b219e774"
     assert component.related_url == "https://github.com/14rcole/gopopulate/"
@@ -521,9 +532,10 @@ def test_purl2url():
     # pseudo version with namespace length of 3
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         version="v0.10.1-0.20221206164259-31a0ef8b04df",
         name="github.com/3scale/3scale-operator/controllers/" "capabilities",
+        release=release,
     )
     assert component.download_url == "https://github.com/3scale/3scale-operator/tree/31a0ef8b04df"
     assert component.related_url == "https://github.com/3scale/3scale-operator/"
@@ -531,9 +543,10 @@ def test_purl2url():
     # semantic version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         version="1.18.0",
         name="github.com/18F/hmacauth",
+        release=release,
     )
     assert component.download_url == "https://github.com/18F/hmacauth/releases/tag/1.18.0"
     assert component.related_url == "https://github.com/18F/hmacauth/"
@@ -541,9 +554,10 @@ def test_purl2url():
     # semantic version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         version="v1.18.0",
         name="github.com/18F/hmacauth",
+        release=release,
     )
     assert component.download_url == "https://github.com/18F/hmacauth/releases/tag/v1.18.0"
     assert component.related_url == "https://github.com/18F/hmacauth/"
@@ -551,9 +565,10 @@ def test_purl2url():
     # incompatiable version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
-        namespace=Component.Namespace.UPSTREAM,
+        namespace=Component.Namespace.REDHAT,
         version="v51.2.0+incompatible",
         name="github.com/Azure/azure-sdk-for-go/services/dns/" "mgmt/2016-04-01/dns",
+        release=release,
     )
     assert (
         component.download_url == "https://github.com/Azure/azure-sdk-for-go/releases/tag/v51.2.0"
@@ -565,6 +580,7 @@ def test_purl2url():
         namespace=Component.Namespace.REDHAT,
         name="io.vertx/vertx-grpc",
         version="4.3.7.redhat-00002",
+        release=release,
     )
     assert component.download_url == "https://repo1.maven.org/maven2/io/vertx/vertx-grpc/4.3.7/"
     assert (
@@ -575,10 +591,11 @@ def test_purl2url():
     # maven with group_id
     component = ComponentFactory(
         type=Component.Type.MAVEN,
-        namespace="",
+        namespace=Component.Namespace.REDHAT,
         meta_attr={"group_id": "io.prestosql.benchto"},
         name="benchto-driver",
         version="0.7",
+        release=release,
     )
     assert (
         component.download_url == "https://repo1.maven.org/maven2/io/prestosql/benchto/"
@@ -592,10 +609,11 @@ def test_purl2url():
     # maven with classifier and type
     component = ComponentFactory(
         type=Component.Type.MAVEN,
-        namespace="",
+        namespace=Component.Namespace.REDHAT,
         meta_attr={"classifier": "noapt", "type": "jar", "group_id": "io.dekorate"},
         name="knative-annotations",
         version="2.11.3.redhat-00001",
+        release=release,
     )
 
     assert (
@@ -608,12 +626,24 @@ def test_purl2url():
     )
 
     # empty version
-    component = ComponentFactory(type=Component.Type.MAVEN, name="test", version="")
+    component = ComponentFactory(
+        namespace=Component.Namespace.REDHAT,
+        type=Component.Type.MAVEN,
+        name="test",
+        version="",
+        release=release,
+    )
     assert component.download_url == ""
     assert component.related_url == ""
 
     # pypi component
-    component = ComponentFactory(type=Component.Type.PYPI, name="aiohttp", version="3.6.2")
+    component = ComponentFactory(
+        namespace=Component.Namespace.REDHAT,
+        type=Component.Type.PYPI,
+        name="aiohttp",
+        version="3.6.2",
+        release=release,
+    )
 
     assert (
         component.download_url == "https://pypi.io/packages/source/a/aiohttp/"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -493,8 +493,11 @@ def test_purl2url():
         version="v3.0.0",
         release=release,
     )
-    assert component.download_url.startswith("https://pkg.go.dev/")
-    assert component.download_url.endswith(f"{component.name}@{component.version}")
+    assert (
+        component.download_url
+        == f"https://proxy.golang.org/{component.name}/@v/{component.version}.zip"
+    )
+    assert component.related_url == f"https://pkg.go.dev/{component.name}@{component.version}"
 
     # no namespace
     component = ComponentFactory(
@@ -504,17 +507,6 @@ def test_purl2url():
         version="v3.0.0",
         release=release,
     )
-    assert component.download_url == ""
-
-    # non schemantic version
-    component = ComponentFactory(
-        type=Component.Type.GOLANG,
-        namespace=Component.Namespace.REDHAT,
-        name="4d63.com/gochecknoglobals",
-        version="v3.0.0-6",
-        release=release,
-    )
-
     assert component.download_url == ""
     assert component.related_url == ""
 
@@ -526,19 +518,27 @@ def test_purl2url():
         version="v0.0.0-20180821133914-b175b219e774",
         release=release,
     )
-    assert component.download_url == "https://github.com/14rcole/gopopulate/tree/b175b219e774"
-    assert component.related_url == "https://github.com/14rcole/gopopulate/"
+    assert (
+        component.download_url == "https://github.com/14rcole/gopopulate/archive/b175b219e774.zip"
+    )
+    assert component.related_url == "https://github.com/14rcole/gopopulate/tree/b175b219e774"
 
     # pseudo version with namespace length of 3
     component = ComponentFactory(
         type=Component.Type.GOLANG,
         namespace=Component.Namespace.REDHAT,
+        name="github.com/3scale/3scale-operator/controllers/capabilities",
         version="v0.10.1-0.20221206164259-31a0ef8b04df",
-        name="github.com/3scale/3scale-operator/controllers/" "capabilities",
         release=release,
     )
-    assert component.download_url == "https://github.com/3scale/3scale-operator/tree/31a0ef8b04df"
-    assert component.related_url == "https://github.com/3scale/3scale-operator/"
+    assert (
+        component.download_url
+        == "https://github.com/3scale/3scale-operator/archive/31a0ef8b04df.zip"
+    )
+    assert (
+        component.related_url
+        == f"https://github.com/3scale/3scale-operator/tree/{component.version.split('-')[-1]}"
+    )
 
     # semantic version
     component = ComponentFactory(
@@ -548,32 +548,19 @@ def test_purl2url():
         name="github.com/18F/hmacauth",
         release=release,
     )
-    assert component.download_url == "https://github.com/18F/hmacauth/releases/tag/1.18.0"
-    assert component.related_url == "https://github.com/18F/hmacauth/"
+    assert component.download_url == "https://github.com/18f/hmacauth/archive/1.18.0.zip"
+    assert component.related_url == "https://github.com/18f/hmacauth/tree/1.18.0"
 
-    # semantic version
+    # +incompatible in version
     component = ComponentFactory(
         type=Component.Type.GOLANG,
         namespace=Component.Namespace.REDHAT,
-        version="v1.18.0",
-        name="github.com/18F/hmacauth",
-        release=release,
-    )
-    assert component.download_url == "https://github.com/18F/hmacauth/releases/tag/v1.18.0"
-    assert component.related_url == "https://github.com/18F/hmacauth/"
-
-    # incompatiable version
-    component = ComponentFactory(
-        type=Component.Type.GOLANG,
-        namespace=Component.Namespace.REDHAT,
+        name="github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2016-04-01/dns",
         version="v51.2.0+incompatible",
-        name="github.com/Azure/azure-sdk-for-go/services/dns/" "mgmt/2016-04-01/dns",
         release=release,
     )
-    assert (
-        component.download_url == "https://github.com/Azure/azure-sdk-for-go/releases/tag/v51.2.0"
-    )
-    assert component.related_url == "https://github.com/Azure/azure-sdk-for-go/"
+    assert component.download_url == "https://github.com/azure/azure-sdk-for-go/archive/v51.2.0.zip"
+    assert component.related_url == "https://github.com/azure/azure-sdk-for-go/tree/v51.2.0"
 
     component = ComponentFactory(
         type=Component.Type.MAVEN,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -585,10 +585,13 @@ def test_purl2url():
         version="4.3.7.redhat-00002",
         release=release,
     )
-    assert component.download_url == "https://repo1.maven.org/maven2/io/vertx/vertx-grpc/4.3.7/"
     assert (
-        component.related_url == "https://mvnrepository.com/artifact/redhat/io.vertx/"
-        "vertx-grpc/4.3.7"
+        component.download_url
+        == f"https://maven.repository.redhat.com/ga/io/vertx/vertx-grpc/{component.version}"
+    )
+    assert (
+        component.related_url
+        == f"https://mvnrepository.com/artifact/{component.name}/{component.version}"
     )
 
     # maven with group_id
@@ -602,7 +605,7 @@ def test_purl2url():
     )
     assert (
         component.download_url == "https://repo1.maven.org/maven2/io/prestosql/benchto/"
-        "benchto-driver/0.7/"
+        "benchto-driver/0.7"
     )
     assert (
         component.related_url == "https://mvnrepository.com/artifact/io.prestosql.benchto/"
@@ -620,12 +623,16 @@ def test_purl2url():
     )
 
     assert (
-        component.download_url == "https://repo1.maven.org/maven2/io/dekorate/"
-        "knative-annotations/2.11.3/"
+        component.download_url == "https://maven.repository.redhat.com/ga/"
+        f"{component.meta_attr['group_id'].replace('.', '/')}/"
+        f"{component.name}/{component.version}/"
+        f"{component.name}-{component.version}"
+        f"-{component.meta_attr['classifier']}.{component.meta_attr['type']}"
     )
     assert (
-        component.related_url == "https://mvnrepository.com/artifact/io.dekorate/"
-        "knative-annotations/2.11.3"
+        component.related_url == f"https://mvnrepository.com/artifact/"
+        f"{component.meta_attr['group_id']}/"
+        f"{component.name}/{component.version}"
     )
 
     # empty version


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs I think this is ready for review. But of course it's late on Friday and I just found another last-minute bug, so who knows :shrug: I'll look this over again first thing Monday morning, so there's no rush to review if you're busy. This fixes:

1. Links for any component type that were broken due to internal identifiers (release, namespace) not being removed correctly / in all cases
2. Generic links that wouldn't update after they were first added
3. Github links that didn't include the namespace (user name) by mistake
4. Golang links that failed to generate properly due to some incorrect code copied from upstream, or that pointed to the repo's about page instead of a downloadable binary artifact
5. Maven links that were broken due to a trailing slash, missing data in the purl, or pointing to the wrong Maven server

After this is merged, we need to call .save() again for all remote-source component types, then reload all containers. I'll start that reloading in stage next week if we think that's OK. Or I can wait for others to debug the performance issues first, so I don't muddy the waters with a massive load.

Have a good weekend!