### PR TITLE
CORGI-507 dont load all sources into memory

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -129,7 +129,7 @@ def get_channel_data_list(manager: Manager["Channel"]) -> list[dict[str, str]]:
     # And channels have no ofuri, so we return a model UUID link instead
     return [
         {"name": name, "link": get_model_id_link("channels", uuid), "uuid": str(uuid)}
-        for (name, uuid) in manager.values_list("name", "uuid").using("read_only")
+        for (name, uuid) in manager.values_list("name", "uuid").using("read_only").iterator()
     ]
 
 
@@ -151,7 +151,9 @@ def get_product_data_list(
     # we're accessing the reverse side of a relation with many objects (via a manager)
     return [
         {"name": name, "link": get_model_ofuri_link(model_name, ofuri), "ofuri": ofuri}
-        for (name, ofuri) in obj_or_manager.values_list("name", "ofuri").using("read_only")
+        for (name, ofuri) in obj_or_manager.values_list("name", "ofuri")
+        .using("read_only")
+        .iterator()
     ]
 
 
@@ -407,7 +409,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
     @staticmethod
     def get_provides(instance: Component) -> list[dict[str, str]]:
         return get_component_data_list(
-            instance.provides.values_list("purl", flat=True).using("read_only")
+            instance.provides.values_list("purl", flat=True).using("read_only").iterator()
         )
 
     @staticmethod
@@ -419,7 +421,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
     @staticmethod
     def get_upstreams(instance: Component) -> list[dict[str, str]]:
         return get_component_data_list(
-            instance.upstreams.values_list("purl", flat=True).using("read_only")
+            instance.upstreams.values_list("purl", flat=True).using("read_only").iterator()
         )
 
     @staticmethod

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -413,7 +413,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
     @staticmethod
     def get_sources(instance: Component) -> list[dict[str, str]]:
         return get_component_data_list(
-            instance.sources.values_list("purl", flat=True).using("read_only")
+            instance.sources.values_list("purl", flat=True).using("read_only").iterator()
         )
 
     @staticmethod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 1.5G  # Keep in sync with OpenShift mem limits to catch OOM problems
     ports:
       - "8008:8008"
     env_file:

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -16,7 +16,7 @@ access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"
 # Ensure wsgi.url_scheme is set to HTTPS, by trusting the X_FORWARDED_PROTO header set by the proxy
 forwarded_allow_ips = "*"
 
-timeout = 600
+timeout = 300
 
 if not running_dev():
     # Saves memory in the worker process, but breaks --reload


### PR DESCRIPTION
Trying to load a component with many sources such as 'pkg:rpm/redhat/cracklib-dicts@2.9.6-15.el8?arch=x86_64' results the gunicorn worker crash, which could lead to 504 errors from haproxy in OpenShift since the worker is not able to service the request within the haproxy timeout window of 300s.

This change reduces the memory required to query a component with many sources by not caching the component.sources attribute in memory.