### PR TITLE
CORGI-313: Fix some errors in related_url saving code

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -530,16 +530,16 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
                                 "build_id": None,
                                 "build_type": None,
                                 "build_source_url": None,
-                                "related_url": None,
-                                "upstream_purl": None,
+                                "related_url": ps_component.related_url,
+                                "download_url": ps_component.download_url,
+                                "upstream_purl": ps_component.upstreams.values_list(
+                                    "purl", flat=True
+                                ).first(),
                             }
                             if ps_component.software_build:
                                 component["build_id"] = ps_component.software_build.build_id
                                 component["build_type"] = ps_component.software_build.build_type
                                 component["build_source_url"] = ps_component.software_build.source
-                            if ps_component.upstreams.all():
-                                component["related_url"] = ps_component.upstreams.all().first().related_url  # type: ignore # noqa
-                                component["upstream_purl"] = ps_component.upstreams.all().first().purl  # type: ignore # noqa
                             latest_components.append(component)
                 return Response({"results": latest_components})
             if view == "product":


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This might fix the recent error in monitoring emails about a related_url that's being set to NULL / None.

The field itself is supposed to default to an empty string, but the JSON dictionary we get this data from might have a related_url key that's present with a value of None. In that case, .get() would return None (as expected) and creating the component inside our DB would then fail. The fix is just to force any None values to an empty string.

There are many other (known) bugs lurking in the codepaths here, so there will be follow-up MRs to address all of those and make our component-saving code more consistent. I'm opening this one separately to see if this actually does fix the issue, and to prepare for reloading containers. I need to start this reload ASAP to unblock OpenLCS.