### PR TITLE
CORGI-516 deeply nested descendant queries

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -306,10 +306,12 @@ class SoftwareBuild(TimeStampedModel):
         for component in self.components.get_queryset():
             # This is needed for container image builds which pull in components not
             # built at Red Hat, and therefore not assigned a build_id
-            for d in component.cnodes.get_queryset().get_descendants(include_self=True):
-                if not d.obj:
-                    continue
-                components.add(d.obj)
+            for cnode in component.cnodes.get_queryset().prefetch_related("obj"):
+                components.add(cnode.obj)
+                for d in cnode.get_descendants():
+                    if not d.obj:
+                        continue
+                    components.add(d.obj)
 
         for component in components:
             component.save_product_taxonomy(product_details)

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1666,7 +1666,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return self.meta_attr.get("epoch", "")
 
     def get_provides_nodes(self, include_dev: bool = True, using: str = "read_only") -> set[str]:
-        """return a QuerySet of descendants with PROVIDES ComponentNode type"""
+        """return a set of descendant ids with PROVIDES ComponentNode type"""
         # Used in manifests / taxonomies. Returns whole objects to access their properties
         provides_set = set()
 
@@ -1685,8 +1685,27 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             )
         return provides_set
 
+    def get_provides_nodes_queryset(
+        self, include_dev: bool = True, using: str = "read_only"
+    ) -> QuerySet[ComponentNode]:
+        """return a QuerySet of descendants with PROVIDES ComponentNode type"""
+        # TODO - leaving this here for now
+        # Used in manifests / taxonomies. Returns whole objects to access their properties
+        type_list: tuple[ComponentNode.ComponentNodeType, ...] = (
+            ComponentNode.ComponentNodeType.PROVIDES,
+        )
+        if include_dev:
+            type_list = ComponentNode.PROVIDES_NODE_TYPES
+        return (
+            self.cnodes.get_queryset()
+            .get_descendants()
+            .filter(type__in=type_list)
+            .prefetch_related("obj")
+            .using(using)
+        )
+
     def get_sources_nodes(self, include_dev: bool = True, using: str = "read_only") -> set[str]:
-        """Return a QuerySet of ancestors for all PROVIDES ComponentNodes"""
+        """Return a set of ancestors ids for all PROVIDES ComponentNodes"""
         sources_set = set()
         type_list: tuple[ComponentNode.ComponentNodeType, ...] = (
             ComponentNode.ComponentNodeType.PROVIDES,
@@ -1703,6 +1722,17 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
                 .values_list("component__pk", flat=True)
             )
         return sources_set
+
+    def get_sources_nodes_queryset(
+        self, include_dev: bool = True, using: str = "read_only"
+    ) -> QuerySet[ComponentNode]:
+        """return a QuerySet of descendants with PROVIDES ComponentNode type"""
+        # TODO - leaving this here for now
+        # Used in manifests / taxonomies. Returns whole objects to access their properties
+        type_list: tuple[ComponentNode.ComponentNodeType, ...] = (
+            ComponentNode.ComponentNodeType.PROVIDES,
+        )
+        return self.cnodes.filter(type__in=type_list).get_ancestors(include_self=False).using(using)
 
     def get_upstreams_nodes(self, using: str = "read_only") -> list[ComponentNode]:
         """return upstreams component ancestors in family trees"""

--- a/corgi/web/templates/provided_relationships_manifest.json
+++ b/corgi/web/templates/provided_relationships_manifest.json
@@ -1,4 +1,4 @@
-{% for node in component.get_provides_nodes %}
+{% for node in component.get_provides_nodes_queryset %}
     {
       "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
       "relationshipType": {% if node.type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -50,7 +50,7 @@ def test_product_manifest_properties():
 
     num_provided = 0
     for latest_component in stream.get_latest_components():
-        num_provided += latest_component.get_provides_nodes().count()
+        num_provided += len(latest_component.get_provides_nodes())
 
     assert num_provided == 2
 
@@ -134,7 +134,7 @@ def test_component_manifest_properties():
         schema = json.load(spec_file)
     jsonschema.validate(manifest, schema)
 
-    num_provided = component.get_provides_nodes().count()
+    num_provided = len(component.get_provides_nodes())
 
     assert num_provided == 2
 


### PR DESCRIPTION
This avoid excessive memory usage in Postgres by the following pattern:

`c.cnodes.get_queryset().get_<descendants/ancestores>()` for components that participate in many trees, such as "pkg:rpm/redhat/python3-pip-wheel@21.2.3-6.el9?arch=noarch".

It breaks manifest generation because I changed what's returned by Component.get_provides_nodes used by the provided_relationships_manifest template.