### PR TITLE
CORGI-516 - optimise manifest generation

### DIFF
--- a/corgi/web/templates/provided_relationships_manifest.json
+++ b/corgi/web/templates/provided_relationships_manifest.json
@@ -2,10 +2,10 @@
     {
       "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
       "relationshipType": {% if node.type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
-      "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
+      "spdxElementId": "SPDXRef-{{node.object_id}}"
     },
     {
       "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
       "relationshipType": "CONTAINS",
-      "spdxElementId": "SPDXRef-{{node.obj.uuid}}"
+      "spdxElementId": "SPDXRef-{{node.object_id}}"
     },{% endfor %}


### PR DESCRIPTION
Follow up to PR #338

This applies the same principle applied there (for setting provides many to many component relationships) to ComponentNode relationship required by manifest generation.