### PR TITLE
remove extraonous comma from licenseconcluded field in manifest

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -17,7 +17,7 @@
         "filesAnalyzed": false,
         "homepage": {% if obj.related_url %}"{{obj.related_url}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
+        "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
         "name": "{{obj.name}}",
         "originator": "NOASSERTION",

--- a/corgi/web/templates/package_manifest.json
+++ b/corgi/web/templates/package_manifest.json
@@ -12,7 +12,7 @@
     "filesAnalyzed": false,
     "homepage": {% if component.related_url %}"{{component.related_url}}"{% else %}"NOASSERTION"{% endif %},
     "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-    "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}",{% else %}"NOASSERTION"{% endif %},
+    "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
     "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
     "name": "{{component.name}}",
     "originator": "NOASSERTION",


### PR DESCRIPTION
Fixes issue generating manifest eg:

/api/v1/product_streams/0bebb273-5c5b-472a-8586-d9d051c371a2/manifest