### PR TITLE
CORGI-520 invalid purls with colon

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -373,7 +373,7 @@ class Brew:
             # AND handle case when "modules" key is present but value is None
             if go and go.get("modules", []):
                 go_modules = tuple(
-                    module["module"] for module in go["modules"] if module.get("module")
+                    module["module"].removeprefix("https://") for module in go["modules"] if module.get("module")
                 )
                 if go_modules:
                     # Tuple above can be empty if .get("module") name is always None / an empty str


### PR DESCRIPTION
This fixes 2 ways that we can get components with colon in the purl. 

- `git@github.com:` in remote_sources.repo
- `http:` protocol in legacy OSBS builds

I've got a script attached to CORGI-520 which can clean up the data with components of type GENERIC or GOLANG with a colon in their name. It needs to be run to fix up the existing data with the new code in this PR, and https://github.com/RedHatProductSecurity/component-registry/pull/343

I also took the opportunity to improve the PURL we build for remote_sources.repo. I'm not setting the type to GOLANG where it's more appropriate then GENERIC, and switched the namespace from REDHAT to UPSTREAM to more accurately reflect the fact that remote_sources repo is outside the Redhat firewall. 