### PR TITLE
CORGI-523 pre-generate manifest and host them using whitenose in static dir

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -9,6 +9,8 @@ from corgi import __version__ as CORGI_VERSION
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
+OUTPUT_FILES_DIR = os.getenv("CORGI_OUTPUT_FILES_DIR", str(BASE_DIR / "corgi/output_files"))
+
 # Added
 CA_CERT = os.getenv("REQUESTS_CA_BUNDLE")
 
@@ -152,6 +154,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "django.contrib.postgres",
@@ -291,7 +294,8 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "/static/"
-STATIC_ROOT = str(BASE_DIR / "staticfiles")
+STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
+STATICFILES_DIRS = [OUTPUT_FILES_DIR]
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Celery config

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -34,8 +34,10 @@ logger = logging.getLogger(__name__)
 # TODO remove running_community check once domain is established
 if not utils.running_dev():
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
+    CORGI_STATIC_URL = f"https://{settings.CORGI_DOMAIN}{settings.STATIC_URL}"
 else:
     CORGI_API_URL = f"http://localhost:8008/api/{CORGI_API_VERSION}"
+    CORGI_STATIC_URL = f"http://localhost:8008{settings.STATIC_URL}"
 
 
 def get_component_data_list(component_list: Iterable[str]) -> list[dict[str, str]]:
@@ -534,7 +536,9 @@ class ProductModelSerializer(ProductTaxonomySerializer):
 
     @staticmethod
     def get_manifest(instance: ProductStream) -> str:
-        return get_model_id_link("product_streams", instance.uuid, manifest=True)
+        if not instance.components.exists():
+            return ""
+        return f"{CORGI_STATIC_URL}{instance.name}-{instance.pk}.json"
 
     @staticmethod
     def get_relations(instance: ProductModel) -> list[dict[str, str]]:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -627,7 +627,7 @@ class ProductStream(ProductModel):
             .values_list("nevra", flat=True)
         )
         if nevras:
-            # Get the latest NVR using python. This only works for valid RPM NVRs
+            # Get the latest NVR using python. This only works for valid RPM NEVRAs
             return sorted(nevras, key=functools.cmp_to_key(compare_packages))[-1]
         else:
             return ""

--- a/corgi/output_files/.gitignore
+++ b/corgi/output_files/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -1,0 +1,49 @@
+from celery.utils.log import get_task_logger
+from celery_singleton import Singleton
+from django.conf import settings
+from django.core.management import call_command
+from django.db.models import Count
+
+from config.celery import app
+from corgi.core.models import ProductStream
+from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
+
+logger = get_task_logger(__name__)
+
+
+@app.task(
+    base=Singleton,
+    autoretry_for=RETRYABLE_ERRORS,
+    retry_kwargs=RETRY_KWARGS,
+)
+def update_manifests():
+    for ps in ProductStream.objects.annotate(num_components=Count("components")).filter(
+        num_components__gt=0
+    ):
+        cpu_update_ps_manifest.delay(ps.name)
+
+
+@app.task(
+    base=Singleton,
+    autoretry_for=RETRYABLE_ERRORS,
+    retry_kwargs=RETRY_KWARGS,
+)
+def cpu_update_ps_manifest(product_stream: str):
+    logger.info("Updating manifest for %s", product_stream)
+    ps = ProductStream.objects.get(name=product_stream)
+    # TODO figure out a way skip updating files where the content doesnt need updating
+    # for example we could check for the timestamp of the latest build, and only update if we
+    # have a newer build than the last run.
+    # That will allow clients to continue to be served the same content from the browser cache
+    # over the span of multiple days, until the product stream receives a new build
+    with open(f"{settings.OUTPUT_FILES_DIR}/{product_stream}-{ps.pk}.json", "w") as fh:
+        fh.write(ps.manifest)
+
+
+@app.task(
+    base=Singleton,
+    autoretry_for=RETRYABLE_ERRORS,
+    retry_kwargs=RETRY_KWARGS,
+)
+def collect_static():
+    call_command("collectstatic", verbosity=0, interactive=False, ignore_patterns=[".gitignore"])

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -64,6 +64,8 @@ def setup_periodic_tasks(sender, **kwargs):
     upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=7, minute=0)
     upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)
     upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
+    upsert_cron_task("manifest", "update_manifests", hour=10, minute=0)
+    upsert_cron_task("manifest", "collect_static", hour=11, minute=0)
     upsert_cron_task("monitoring", "email_failed_tasks", hour=11, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - .env
     environment:
       CORGI_DB_HOST: corgi-db
-    command: gunicorn config.wsgi --config gunicorn_config.py --reload
+    command: ./run_service.sh reload
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8008/api/healthy || exit 1"]
       interval: "60s"

--- a/run_service.sh
+++ b/run_service.sh
@@ -5,10 +5,14 @@
 
 # collect static files
 python3 manage.py collectstatic \
-    --ignore '*.xml' \
-    --ignore '*.bz2' \
-    --ignore 'tmp*' \
+    --ignore '.gitignore' \
+    --ignore '*.json' \
     --noinput
 
 # start gunicorn
-exec gunicorn config.wsgi --config gunicorn_config.py
+if [[ $1 == reload ]]; then
+    exec gunicorn config.wsgi --config gunicorn_config.py --reload
+else
+    exec gunicorn config.wsgi --config gunicorn_config.py
+fi
+


### PR DESCRIPTION
This generates the product streams manifests daily and services them using whitenoise in the static directory. We'll have to adjust stage/prod to set OUTPUT_FILES_DIR to a persistent volume shared by both the celery workers and the web pods.