### PR TITLE
CORGI-508: Add a download URL for RPMs

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,7 +1,7 @@
 {# Component manifest, obj is a Component here #}{% extends "base_manifest.json" %}
 {% block packages %}{% for component in obj.provides_queryset %}{
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -2,7 +2,7 @@
 {% block packages %}{% for component in latest_components %}{# Below will eventually become component.manifest #}
     {
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from datetime import datetime
-from json import JSONDecodeError
 
 import jsonschema
 import pytest
@@ -244,7 +243,7 @@ def test_manifest_backslash():
     component = SrpmComponentFactory(version="2.8.0 \\", software_build=sb)
     component.productstreams.add(stream)
 
-    try:
-        stream.manifest
-    except JSONDecodeError:
-        assert False
+    # Raise the original JSONDecodeError if below fails
+    # Otherwise we can't see what the actual error is
+    manifest = stream.manifest
+    assert manifest

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 import pytest
 from django.apps import apps
+from django.conf import settings
 from django.db.utils import IntegrityError, ProgrammingError
 from packageurl import PackageURL
 
@@ -445,10 +446,14 @@ def test_get_upstream_container():
     ]
 
 
-def test_purl2url():
+def test_download_url():
     release = "Must_be_removed_from_every_purl_before_building_URL"
     component = ComponentFactory(type=Component.Type.RPM)
-    assert component.download_url == Component.RPM_PACKAGE_BROWSER
+    assert component.download_url == (
+        f"{settings.BREW_DOWNLOAD_ROOT_URL}/packages/"
+        f"{component.name}/{component.version}/{component.release}/{component.arch}/"
+        f"{component.name}-{component.version}-{component.release}.{component.arch}.rpm"
+    )
 
     component = ComponentFactory(type=Component.Type.CONTAINER_IMAGE)
     assert component.download_url == Component.CONTAINER_CATALOG_SEARCH


### PR DESCRIPTION
Quickly add download URLs for RPMs, using a predictable URL I found while researching other tickets.