### PR TITLE
CORGI-495: Add Syft method for scanning a Git repo with a specific ref

### DIFF
--- a/corgi/collectors/prod_defs.py
+++ b/corgi/collectors/prod_defs.py
@@ -1,8 +1,11 @@
 import json
+import logging
 
 import requests
 from django.conf import settings
 from requests_gssapi import HTTPSPNEGOAuth
+
+logger = logging.getLogger(__name__)
 
 
 class ProdDefs:
@@ -50,7 +53,7 @@ class ProdDefs:
         products = cls.load_products(data)
 
         for product in products:
-            print(f"product {product}")
+            logger.debug(f"Processing product definition: {product}")
             product_versions = []
             for ps_module in product["ps_modules"]:
                 product_version = data["ps_modules"][ps_module]


### PR DESCRIPTION
This allows us to manifest sources in additional to artifacts (like images). See Jira issue for more info on how this relates to managed services.