### PR TITLE
CORGI-508: Fix container ingest code so that reloading with more data works

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -342,7 +342,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
     if not related_url:
         # Handle case when key is present but value is None
         related_url = ""
-    obj, created = Component.objects.get_or_create(
+    obj, created = Component.objects.update_or_create(
         name=build_data["meta"]["name"],
         type=build_data["type"],
         arch="noarch",
@@ -387,7 +387,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
 
     if "image_components" in build_data:
         for image in build_data["image_components"]:
-            obj, created = Component.objects.get_or_create(
+            obj, created = Component.objects.update_or_create(
                 name=image["meta"].pop("name"),
                 type=image["type"],
                 arch=image["meta"].pop("arch"),


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Fixes an issue where container metadata from Brew is never updated after the component is first created.

Once this is merged, I'll quickly reprocess all the container builds again. It went very fast on Friday so I'm hopeful this won't take too much time. Or if not, I'll be working on some follow-up MRs here to fix a few other lower-priority bugs in this code (missing namespace, arch, etc.) so the reload going slowly won't really be a problem.