### PR TITLE
Web pod failing startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - .env
     environment:
       CORGI_DB_HOST: corgi-db
-    command: ./run_service.sh reload
+    command: ./run_service.sh dev
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8008/api/healthy || exit 1"]
       interval: "60s"

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,13 +3,13 @@
 # Custom run script for starting corgi django service in corgi-stage and corgi-prod environments.
 # Note - DJANGO_SETTINGS_MODULE env var is required
 
-# collect static files
-python3 manage.py collectstatic \
-    --ignore '.gitignore' \
-    --noinput
-
 # start gunicorn
-if [[ $1 == reload ]]; then
+if [[ $1 == dev ]]; then
+    # collect static files
+    python3 manage.py collectstatic \
+    --ignore '.gitignore' \
+    -v 2 \
+    --noinput
     exec gunicorn config.wsgi --config gunicorn_config.py --reload
 else
     exec gunicorn config.wsgi --config gunicorn_config.py


### PR DESCRIPTION
This disables collect static command on web pod startup to avoid crash backoff loop from that pod in OpenShift.

If the static-files directory is every cleaned the css/javascript will not work until the collect static command is ran.