### PR TITLE
Move manifest-generating tasks to CPU workers with more memory

### DIFF
--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -20,7 +20,7 @@ def update_manifests():
     for ps in ProductStream.objects.annotate(num_components=Count("components")).filter(
         num_components__gt=0
     ):
-        slow_update_ps_manifest.delay(ps.name)
+        cpu_update_ps_manifest.delay(ps.name)
 
 
 @app.task(
@@ -28,7 +28,7 @@ def update_manifests():
     autoretry_for=RETRYABLE_ERRORS,
     retry_kwargs=RETRY_KWARGS,
 )
-def slow_update_ps_manifest(product_stream: str):
+def cpu_update_ps_manifest(product_stream: str):
     logger.info("Updating manifest for %s", product_stream)
     ps = ProductStream.objects.get(name=product_stream)
     # TODO figure out a way skip updating files where the content doesnt need updating

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 2G
     image: registry.redhat.io/rhel8/postgresql-13:1
     hostname: corgi-db
     environment:
@@ -136,7 +136,7 @@ services:
       replicas: 2
       resources:
         limits:
-          memory: 2G  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 1G  # Keep in sync with OpenShift mem limits to catch OOM problems
     container_name: corgi-celery-slow
     image: corgi
     env_file:
@@ -154,7 +154,7 @@ services:
       replicas: 2
       resources:
         limits:
-          memory: 768M  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 2G  # Keep in sync with OpenShift mem limits to catch OOM problems
     container_name: corgi-celery-cpu
     image: corgi
     env_file:


### PR DESCRIPTION
@jasinner This change is the same "solution" as the WorkerLostError for the SCA task. We can't guarantee it will never happen, but we give the SCA worker pods as much memory as possible (2GB) so we can avoid it most of the time.

Better fixes for the amount of memory used are still welcome, of course.