### PR TITLE
CORGI-313: Fix missing arch and namespace

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -238,7 +238,9 @@ def save_component(
         defaults={
             "description": meta.pop("description", ""),
             "filename": find_package_file_name(meta.pop("source_files", [])),
-            "namespace": component.get("namespace", ""),
+            "namespace": Component.Namespace.REDHAT
+            if component_type == Component.Type.RPM
+            else Component.Namespace.UPSTREAM,
             "related_url": related_url,
             "software_build": softwarebuild,
         },
@@ -289,7 +291,7 @@ def save_srpm(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentNode:
             "description": build_data["meta"].get("description", ""),
             "license_declared_raw": build_data["meta"].get("license", ""),
             "meta_attr": build_data["meta"],
-            "namespace": build_data["namespace"],
+            "namespace": Component.Namespace.REDHAT,
             "related_url": related_url,
             "software_build": softwarebuild,
         },
@@ -355,7 +357,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
             "description": build_data["meta"].pop("description", ""),
             "filename": find_package_file_name(build_data["meta"].pop("source_files", [])),
             "meta_attr": build_data["meta"],
-            "namespace": build_data.get("namespace", ""),
+            "namespace": Component.Namespace.REDHAT,
             "related_url": related_url,
             "software_build": softwarebuild,
         },
@@ -402,7 +404,7 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
                 arch=image["meta"].pop("arch"),
                 defaults={
                     "meta_attr": image["meta"],
-                    "namespace": image.get("namespace", ""),
+                    "namespace": Component.Namespace.REDHAT,
                     "software_build": softwarebuild,
                 },
             )
@@ -487,7 +489,7 @@ def save_module(softwarebuild, build_data) -> ComponentNode:
             "description": build_data["meta"].get("description", ""),
             "license_declared_raw": build_data["meta"].get("license", ""),
             "meta_attr": meta_attr,
-            "namespace": build_data["namespace"],
+            "namespace": Component.Namespace.REDHAT,
             "software_build": softwarebuild,
         },
     )

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -90,7 +90,12 @@ def save_component(component: dict[str, Any], parent: ComponentNode) -> bool:
             version=meta.pop("version", ""),
             release="",
             arch="noarch",
-            defaults={"meta_attr": meta},
+            defaults={
+                "meta_attr": meta,
+                "namespace": Component.Namespace.REDHAT
+                if component["type"] == Component.Type.RPM
+                else Component.Namespace.UPSTREAM,
+            },
         )
     except django.db.IntegrityError:
         # "Get the component" fails if the name is different

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -83,12 +83,13 @@ def save_component(component: dict[str, Any], parent: ComponentNode) -> bool:
     name = meta.pop("name", "")
     try:
         # Use all fields from Component index and uniqueness constraint
+        # Don't update_or_create since Syft's metadata shouldn't override Brew's
         obj, created = Component.objects.get_or_create(
             type=component["type"],
             name=name,
             version=meta.pop("version", ""),
             release="",
-            arch="",
+            arch="noarch",
             defaults={"meta_attr": meta},
         )
     except django.db.IntegrityError:

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -799,7 +799,7 @@ def test_fetch_rpm_build(mock_sca, mock_brew):
         "pkg:rpm/redhat/cockpit-system@251-1.el8?arch=noarch",
     )
     assert srpm.provides.filter(purl__in=expected_provides).count() == 4
-    assert srpm.upstreams.values_list("purl", flat=True).get() == "pkg:rpm/cockpit@251"
+    assert srpm.upstreams.values_list("purl", flat=True).get() == "pkg:rpm/cockpit@251?arch=noarch"
     # SRPM has no sources of its own (nor is it embedded in any other component)
     assert not srpm.sources.exists()
     cockpit_system = Component.objects.get(


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This should fix some bugs where arch and namespace could be an empty string. Fixing this is required before we can constrain arch to a list of enum values, as attempted in a previous PR (don't have link handy).

I also tried to make sure we always pass enough kwargs to get_or_create() / update_or_create() to hit an index and guarantee the function is atomic. Mostly this just means passing release="" even if we know it should be an empty string / unset for some (e.g. upstream) component. I also made the kwarg ordering consistent just for readability (make it easier to see if something is missing).

Finally, I also switched to using update_or_create consistently so that all component types can be reprocessed successfully. The only case I didn't do this is in the SCA task, where the Brew metadata would get overwritten by the Syft metadata (which we don't want), and in cases where there's nothing to update (e.g. a constant value in the defaults dict that never changes).

We need a migration to fix the existing data - I can handle that here or in a follow-up PR. But I wanted to open this now so I could discuss some questions - see notes below.