### PR TITLE
CORGI-530 oom openshift manifests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = output_files/*

--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -67,10 +67,12 @@ class ProductManifestFile(ManifestFile):
     def render_content(self) -> str:
 
         latest_components = self.obj.get_latest_components()  # type: ignore[attr-defined]
+        distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {
             "obj": self.obj,
             "latest_components": latest_components,
+            "distinct_provides": distinct_provides,
         }
         content = render_to_string(self.file_name, kwargs_for_template)
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -301,7 +301,6 @@ class SoftwareBuild(TimeStampedModel):
         )
 
         product_details = get_product_details(variant_names, stream_names)
-
         components = set()
         for component in self.components.get_queryset().iterator():
             # This is needed for container image builds which pull in components not
@@ -665,6 +664,7 @@ class ProductStream(ProductModel):
                 Component.objects.filter(
                     ROOT_COMPONENTS_CONDITION, productstreams__ofuri=self.ofuri
                 )
+                .exclude(name__endswith="-container-source")
                 .distinct("name")
                 .values_list("name", flat=True)
                 .using(using)
@@ -1466,7 +1466,6 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         self.productstreams.add(*product_pks_dict["productstreams"])
         self.productvariants.add(*product_pks_dict["productvariants"])
         self.channels.add(*product_pks_dict["channels"])
-
         return None
 
     def get_roots(self, using: str = "read_only") -> list[ComponentNode]:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -689,6 +689,7 @@ class ProductStream(ProductModel):
             .distinct()
             .order_by("provides__pk")
             .using(using)
+            .iterator()
         )
         return Component.objects.filter(pk__in=unique_provides).using(using)
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -679,6 +679,19 @@ class ProductStream(ProductModel):
                 return Component.objects.none()
             return Component.objects.filter(Q(ROOT_COMPONENTS_CONDITION & query)).using(using)
 
+    @property
+    def provides_queryset(self, using: str = "read_only") -> QuerySet["Component"]:
+        """Returns unique aggregate "provides" for the latest components in this stream,
+        for use in templates"""
+        unique_provides = (
+            self.get_latest_components()
+            .values_list("provides__pk", flat=True)
+            .distinct()
+            .order_by("provides__pk")
+            .using(using)
+        )
+        return Component.objects.filter(pk__in=unique_provides).using(using)
+
 
 class ProductStreamTag(Tag):
     tagged_model = models.ForeignKey(ProductStream, on_delete=models.CASCADE, related_name="tags")

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -43,14 +43,10 @@
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{obj.version}}"
     }
-{% endblock %}{% block relationships %}{% for node_type, node_id in obj.get_provides_nodes_queryset %}
+{% endblock packages %}{% block relationships %}{% for node_type, node_id in obj.get_provides_nodes_queryset %}
     {
       "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# subcomponent is built from, or contained in, component #}
       "relationshipType": {% if node_type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
       "spdxElementId": "SPDXRef-{{node_id}}"
-    },
-    {
-      "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
-      "relationshipType": "CONTAINS",
-      "spdxElementId": "SPDXRef-{{node_id}}"
-    },{% endfor %}{% endblock %}
+    },{% endfor %}
+{% endblock relationships %}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -80,10 +80,5 @@
           "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
           "relationshipType": "PACKAGE_OF",
           "spdxElementId": "SPDXRef-{{component.uuid}}"
-        },{% endfor %}{% for provided in distinct_provides %}
-        {
-          "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
-          "relationshipType": "CONTAINS",
-          "spdxElementId": "SPDXRef-{{provided.pk}}"
         },{% endfor %}
 {% endblock relationships %}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,5 +1,5 @@
 {# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}
-{% block packages %}{% for component in latest_components %}{# Below will eventually become component.manifest #}
+{% block packages %}{% for component in latest_components %}
     {
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if component.download_url %}"{{component.download_url}}"{% else %}"NOASSERTION"{% endif %},
@@ -21,7 +21,7 @@
         "SPDXID": "SPDXRef-{{component.uuid}}",
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{component.nevra|escapejs}}"
-    },{% for provided in component.provides_queryset %}
+    },{% endfor %}{% for provided in distinct_provides %}
     {
         "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if provided.download_url %}"{{provided.download_url}}"{% else %}"NOASSERTION"{% endif %},
@@ -43,7 +43,7 @@
         "SPDXID": "SPDXRef-{{provided.uuid}}",
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{provided.nevra|escapejs}}"
-    },{% endfor %}{% endfor %}
+    },{% endfor %}
     {
         "copyrightText": "NOASSERTION",
         "downloadLocation": "NOASSERTION",
@@ -70,21 +70,20 @@
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{obj.version}}"
     }
-{% endblock %}{% block relationships %}{% for component in latest_components %}{% for node_type, node_id in component.get_provides_nodes_queryset %}
+{% endblock packages %}{% block relationships %}{% for component in latest_components %}{% for node_type, node_id in component.get_provides_nodes_queryset %}
         {
           "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
           "relationshipType": {% if node_type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
-          "spdxElementId": "SPDXRef-{{node_id}}"
-        },
-        {
-          "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
-          "relationshipType": "CONTAINS",
           "spdxElementId": "SPDXRef-{{node_id}}"
         },{% endfor %}
         {
           "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
           "relationshipType": "PACKAGE_OF",
           "spdxElementId": "SPDXRef-{{component.uuid}}"
-        },
-    {% endfor %}
-{% endblock %}
+        },{% endfor %}{% for provided in distinct_provides %}
+        {
+          "relatedSpdxElement": "NONE",{# subcomponent is a leaf node #}
+          "relationshipType": "CONTAINS",
+          "spdxElementId": "SPDXRef-{{provided.pk}}"
+        },{% endfor %}
+{% endblock relationships %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ testpaths = "tests"
 # - Ensure pytest config here is valid, and all defined markers are specified below in `markers`
 addopts = """
 -m unit
---cov corgi --cov-report html --cov-report xml:coverage.xml
+--cov corgi --cov-report html --cov-report xml:coverage.xml --cov-config=.coveragerc
 -ra
 --durations=10
 --nomigrations

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -74,7 +74,7 @@ def test_slim_rpm_in_containers_manifest():
     # For each provided in component, one "provided contains none" indicating a leaf node
     # For each component, one "component is package of product" relationship
     # Plus one "document describes product" relationship for the whole document at the end
-    assert len(manifest["relationships"]) == num_components + ((num_provided * 2) + 1) + 1
+    assert len(manifest["relationships"]) == num_components + (num_provided + 1) + 1
 
     provided_uuid = provided.pop()
     component = containers[0]
@@ -99,15 +99,8 @@ def test_slim_rpm_in_containers_manifest():
         "spdxElementId": f"SPDXRef-{provided_uuid}",
     }
 
-    provided_contains_nothing = {
-        "relatedSpdxElement": "NONE",
-        "relationshipType": "CONTAINS",
-        "spdxElementId": f"SPDXRef-{provided_uuid}",
-    }
-
     assert manifest["relationships"][0] == provided_contained_by_component
     assert manifest["relationships"][1] == component_is_package_of_product
-    assert manifest["relationships"][-2] == provided_contains_nothing
     assert manifest["relationships"][-1] == document_describes_product
 
 
@@ -116,9 +109,7 @@ def test_product_manifest_properties():
     And that it generates valid JSON."""
     component, stream, provided, dev_provided = setup_products_and_components_provides()
 
-    manifest = stream.manifest
-    print(manifest)
-    manifest = json.loads(manifest)
+    manifest = json.loads(stream.manifest)
 
     # One component linked to this product
     num_components = len(stream.get_latest_components())
@@ -163,36 +154,18 @@ def test_product_manifest_properties():
         "spdxElementId": f"SPDXRef-{provided.uuid}",
     }
 
-    provided_contains_nothing = {
-        "relatedSpdxElement": "NONE",
-        "relationshipType": "CONTAINS",
-        "spdxElementId": f"SPDXRef-{provided.uuid}",
-    }
-
     dev_provided_dependency_of_component = {
         "relatedSpdxElement": f"SPDXRef-{component.uuid}",
         "relationshipType": "DEV_DEPENDENCY_OF",
         "spdxElementId": f"SPDXRef-{dev_provided.uuid}",
     }
 
-    dev_provided_contains_nothing = {
-        "relatedSpdxElement": "NONE",
-        "relationshipType": "CONTAINS",
-        "spdxElementId": f"SPDXRef-{dev_provided.uuid}",
-    }
-
-    print(f"stream uuid:{stream.uuid}")
-    print(f"component uuid:{component.uuid}")
-    print(f"provided: {provided.uuid}")
-    print(f"dev_provided: {dev_provided.uuid}")
-
-    print(manifest["relationships"])
-
     # For each provided in component, one "provided contained by component"
     # For each provided in component, one "provided contains none" indicating a leaf node
     # For each component, one "component is package of product" relationship
     # Plus one "document describes product" relationship for the whole document at the end
-    assert len(manifest["relationships"]) == num_components + (num_provided * 2) + 1
+    assert len(manifest["relationships"]) == num_components + num_provided + 1
+
     if dev_provided.uuid < provided.uuid:
         dev_provided_index = 0
         provided_index = 1
@@ -203,8 +176,6 @@ def test_product_manifest_properties():
     assert manifest["relationships"][provided_index] == provided_contained_by_component
     assert manifest["relationships"][dev_provided_index] == dev_provided_dependency_of_component
     assert manifest["relationships"][num_provided] == component_is_package_of_product
-    assert manifest["relationships"][provided_index - 3] == provided_contains_nothing
-    assert manifest["relationships"][dev_provided_index - 3] == dev_provided_contains_nothing
     assert manifest["relationships"][-1] == document_describes_product
 
 
@@ -231,38 +202,24 @@ def test_component_manifest_properties():
         "spdxElementId": f"SPDXRef-{provided.uuid}",
     }
 
-    provided_contains_nothing = {
-        "relatedSpdxElement": "NONE",
-        "relationshipType": "CONTAINS",
-        "spdxElementId": f"SPDXRef-{provided.uuid}",
-    }
-
     dev_provided_dependency_of_component = {
         "relatedSpdxElement": f"SPDXRef-{component.uuid}",
         "relationshipType": "DEV_DEPENDENCY_OF",
         "spdxElementId": f"SPDXRef-{dev_provided.uuid}",
     }
 
-    dev_provided_contains_nothing = {
-        "relatedSpdxElement": "NONE",
-        "relationshipType": "CONTAINS",
-        "spdxElementId": f"SPDXRef-{dev_provided.uuid}",
-    }
-
-    assert len(manifest["relationships"]) == (num_provided * 2) + 1
+    assert len(manifest["relationships"]) == num_provided + 1
     # Relationships in manifest use a constant ordering based on object UUID
     # Actual UUIDs created in the tests will vary, so make sure we assert the right thing
     if dev_provided.uuid < provided.uuid:
         dev_provided_index = 0
-        provided_index = 2
+        provided_index = 1
     else:
         provided_index = 0
-        dev_provided_index = 2
+        dev_provided_index = 1
 
     assert manifest["relationships"][provided_index] == provided_contained_by_component
-    assert manifest["relationships"][provided_index + 1] == provided_contains_nothing
     assert manifest["relationships"][dev_provided_index] == dev_provided_dependency_of_component
-    assert manifest["relationships"][dev_provided_index + 1] == dev_provided_contains_nothing
     assert manifest["relationships"][-1] == document_describes_product
 
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -14,6 +14,7 @@ from corgi.core.models import (
 
 from .factories import (
     ComponentFactory,
+    ContainerImageComponentFactory,
     ProductComponentRelationFactory,
     ProductFactory,
     ProductStreamFactory,
@@ -30,21 +31,100 @@ pytestmark = [
 ]
 
 
-def test_product_manifest_properties():
-    """Test that all models inheriting from ProductModel have a .manifest property
-    And that it generates valid JSON."""
-    component, container_component, stream, provided, dev_provided = setup_products_and_components()
+def test_latest_components_exclude_source_container():
+    """Test that container sources are excluded packages"""
+    containers, stream, _ = setup_products_and_rpm_in_containers()
+    assert len(containers) == 3
 
-    manifest = json.loads(stream.manifest)
+    components = stream.get_latest_components()
+    assert len(components) == 2
+    assert not components.first().name.endswith("-container-source")
 
-    # One component linked to this product
+
+def test_slim_rpm_in_containers_manifest():
+    containers, stream, rpm_in_container = setup_products_and_rpm_in_containers()
+
+    # Two components linked to this product
     num_components = len(stream.get_latest_components())
     assert num_components == 2
 
-    num_provided = 0
+    provided = set()
+    # Each component has 1 node each
     for latest_component in stream.get_latest_components():
-        num_provided += len(latest_component.get_provides_nodes())
+        component_nodes = latest_component.get_provides_nodes()
+        assert len(component_nodes) == 1
+        provided.update(component_nodes)
 
+    # Here we are checking that the components share a single provided component
+    num_provided = len(provided)
+    assert num_provided == 1
+
+    distinct_provides = stream.provides_queryset
+    assert len(distinct_provides) == num_provided
+
+    stream_manifest = stream.manifest
+    manifest = json.loads(stream_manifest)
+
+    # One package for each component
+    # One (and only one) package for each distinct provided
+    # Plus one package for the stream itself
+    assert len(manifest["packages"]) == num_components + num_provided + 1
+
+    # For each provided in component, one "provided contained by component"
+    # For each provided in component, one "provided contains none" indicating a leaf node
+    # For each component, one "component is package of product" relationship
+    # Plus one "document describes product" relationship for the whole document at the end
+    assert len(manifest["relationships"]) == num_components + ((num_provided * 2) + 1) + 1
+
+    provided_uuid = provided.pop()
+    component = containers[0]
+    if containers[0].uuid > containers[1].uuid:
+        component = containers[1]
+
+    document_describes_product = {
+        "relatedSpdxElement": f"SPDXRef-{stream.uuid}",
+        "relationshipType": "DESCRIBES",
+        "spdxElementId": "SPDXRef-DOCUMENT",
+    }
+
+    component_is_package_of_product = {
+        "relatedSpdxElement": f"SPDXRef-{stream.uuid}",
+        "relationshipType": "PACKAGE_OF",
+        "spdxElementId": f"SPDXRef-{component.uuid}",
+    }
+
+    provided_contained_by_component = {
+        "relatedSpdxElement": f"SPDXRef-{component.uuid}",
+        "relationshipType": "CONTAINED_BY",
+        "spdxElementId": f"SPDXRef-{provided_uuid}",
+    }
+
+    provided_contains_nothing = {
+        "relatedSpdxElement": "NONE",
+        "relationshipType": "CONTAINS",
+        "spdxElementId": f"SPDXRef-{provided_uuid}",
+    }
+
+    assert manifest["relationships"][0] == provided_contained_by_component
+    assert manifest["relationships"][1] == component_is_package_of_product
+    assert manifest["relationships"][-2] == provided_contains_nothing
+    assert manifest["relationships"][-1] == document_describes_product
+
+
+def test_product_manifest_properties():
+    """Test that all models inheriting from ProductModel have a .manifest property
+    And that it generates valid JSON."""
+    component, stream, provided, dev_provided = setup_products_and_components_provides()
+
+    manifest = stream.manifest
+    print(manifest)
+    manifest = json.loads(manifest)
+
+    # One component linked to this product
+    num_components = len(stream.get_latest_components())
+    assert num_components == 1
+
+    num_provided = len(stream.provides_queryset)
     assert num_provided == 2
 
     # Manifest contains info for all components, their provides, and the product itself
@@ -77,12 +157,6 @@ def test_product_manifest_properties():
         "spdxElementId": f"SPDXRef-{component.uuid}",
     }
 
-    container_component_is_package_of_product = {
-        "relatedSpdxElement": f"SPDXRef-{stream.uuid}",
-        "relationshipType": "PACKAGE_OF",
-        "spdxElementId": f"SPDXRef-{container_component.uuid}",
-    }
-
     provided_contained_by_component = {
         "relatedSpdxElement": f"SPDXRef-{component.uuid}",
         "relationshipType": "CONTAINED_BY",
@@ -107,6 +181,13 @@ def test_product_manifest_properties():
         "spdxElementId": f"SPDXRef-{dev_provided.uuid}",
     }
 
+    print(f"stream uuid:{stream.uuid}")
+    print(f"component uuid:{component.uuid}")
+    print(f"provided: {provided.uuid}")
+    print(f"dev_provided: {dev_provided.uuid}")
+
+    print(manifest["relationships"])
+
     # For each provided in component, one "provided contained by component"
     # For each provided in component, one "provided contains none" indicating a leaf node
     # For each component, one "component is package of product" relationship
@@ -114,24 +195,23 @@ def test_product_manifest_properties():
     assert len(manifest["relationships"]) == num_components + (num_provided * 2) + 1
     if dev_provided.uuid < provided.uuid:
         dev_provided_index = 0
-        provided_index = 2
+        provided_index = 1
     else:
         provided_index = 0
-        dev_provided_index = 2
+        dev_provided_index = 1
 
     assert manifest["relationships"][provided_index] == provided_contained_by_component
-    assert manifest["relationships"][provided_index + 1] == provided_contains_nothing
     assert manifest["relationships"][dev_provided_index] == dev_provided_dependency_of_component
-    assert manifest["relationships"][dev_provided_index + 1] == dev_provided_contains_nothing
-    assert manifest["relationships"][-3] == component_is_package_of_product
-    assert manifest["relationships"][-2] == container_component_is_package_of_product
+    assert manifest["relationships"][num_provided] == component_is_package_of_product
+    assert manifest["relationships"][provided_index - 3] == provided_contains_nothing
+    assert manifest["relationships"][dev_provided_index - 3] == dev_provided_contains_nothing
     assert manifest["relationships"][-1] == document_describes_product
 
 
 def test_component_manifest_properties():
     """Test that all Components have a .manifest property
     And that it generates valid JSON."""
-    component, _, _, provided, dev_provided = setup_products_and_components()
+    component, _, provided, dev_provided = setup_products_and_components_provides()
 
     manifest = json.loads(component.manifest)
 
@@ -186,30 +266,11 @@ def test_component_manifest_properties():
     assert manifest["relationships"][-1] == document_describes_product
 
 
-def setup_products_and_components():
-    product = ProductFactory()
-    version = ProductVersionFactory(products=product)
-    stream = ProductStreamFactory(products=product, productversions=version)
-    variant = ProductVariantFactory(
-        name="1", products=product, productversions=version, productstreams=stream
-    )
-
-    # TODO: Factory should probably create nodes for model
-    #  Move these somewhere for reuse - common.py helper method, or fixtures??
-    pnode = ProductNode.objects.create(parent=None, obj=product)
-    pvnode = ProductNode.objects.create(parent=pnode, obj=version)
-    psnode = ProductNode.objects.create(parent=pvnode, obj=stream)
-    ProductNode.objects.create(parent=psnode, obj=variant)
-
-    # This generates and saves the ProductModel properties of stream
-    # AKA we link the ProductModel instances to each other
-    stream.save_product_taxonomy()
-    assert variant in stream.productvariants.get_queryset()
+def setup_products_and_components_provides():
+    stream, variant = setup_product()
     build = SoftwareBuildFactory(
         build_id=1,
-    )
-    build2 = SoftwareBuildFactory(
-        build_id=2,
+        completion_time=datetime.strptime("2017-03-29 12:13:29 GMT+0000", "%Y-%m-%d %H:%M:%S %Z%z"),
     )
     provided = ComponentFactory(type=Component.Type.RPM, arch="x86_64")
     dev_provided = ComponentFactory(type=Component.Type.NPM)
@@ -218,31 +279,6 @@ def setup_products_and_components():
     )
     cnode = ComponentNode.objects.create(
         type=ComponentNode.ComponentNodeType.SOURCE, parent=None, purl=component.purl, obj=component
-    )
-    container_component = ComponentFactory(
-        type=Component.Type.CONTAINER_IMAGE,
-        arch="noarch",
-        software_build=build2,
-        name="some-container",
-    )
-    ComponentNode.objects.create(
-        type=ComponentNode.ComponentNodeType.SOURCE,
-        parent=None,
-        purl=container_component.purl,
-        obj=container_component,
-    )
-    # Excluded by laster filter when component_name is not used
-    source_container = ComponentFactory(
-        type=Component.Type.CONTAINER_IMAGE,
-        arch="noarch",
-        software_build=build2,
-        name="some-container-source",
-    )
-    ComponentNode.objects.create(
-        type=ComponentNode.ComponentNodeType.SOURCE,
-        parent=None,
-        purl=source_container.purl,
-        obj=source_container,
     )
     ComponentNode.objects.create(
         type=ComponentNode.ComponentNodeType.PROVIDES,
@@ -266,16 +302,76 @@ def setup_products_and_components():
         product_ref=variant.name,
         type=ProductComponentRelation.Type.ERRATA,
     )
-    ProductComponentRelationFactory(
-        build_id=str(build2.build_id),
-        product_ref=stream.name,
-        type=ProductComponentRelation.Type.BREW_TAG,
-    )
     # Link the components to the ProductModel instances
     build.save_product_taxonomy()
-    build2.save_product_taxonomy()
+    return component, stream, provided, dev_provided
 
-    return component, container_component, stream, provided, dev_provided
+
+def setup_products_and_rpm_in_containers():
+    stream, variant = setup_product()
+    rpm_in_container = ComponentFactory(type=Component.Type.RPM, arch="x86_64")
+    containers = []
+    for name in ["", "", "some-container-source"]:
+        build, container = _build_rpm_in_containers(rpm_in_container, name=name)
+
+        # The product_ref here is a variant name but below we use it's parent stream
+        # to generate the manifest
+        ProductComponentRelationFactory(
+            build_id=str(build.build_id),
+            product_ref=variant.name,
+            type=ProductComponentRelation.Type.ERRATA,
+        )
+        # Link the components to the ProductModel instances
+        build.save_product_taxonomy()
+        containers.append(container)
+    return containers, stream, rpm_in_container
+
+
+def _build_rpm_in_containers(rpm_in_container, name=""):
+    build = SoftwareBuildFactory(
+        completion_time=datetime.strptime("2017-03-29 12:13:29 GMT+0000", "%Y-%m-%d %H:%M:%S %Z%z"),
+    )
+    if not name:
+        container = ContainerImageComponentFactory(
+            software_build=build,
+        )
+    else:
+        container = ContainerImageComponentFactory(
+            name=name,
+            software_build=build,
+        )
+    cnode = ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.SOURCE, parent=None, purl=container.purl, obj=container
+    )
+    ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.PROVIDES,
+        parent=cnode,
+        purl=rpm_in_container.purl,
+        obj=rpm_in_container,
+    )
+    # Link the components to each other
+    container.save_component_taxonomy()
+    return build, container
+
+
+def setup_product():
+    product = ProductFactory()
+    version = ProductVersionFactory(products=product)
+    stream = ProductStreamFactory(products=product, productversions=version)
+    variant = ProductVariantFactory(
+        name="1", products=product, productversions=version, productstreams=stream
+    )
+    # TODO: Factory should probably create nodes for model
+    #  Move these somewhere for reuse - common.py helper method, or fixtures??
+    pnode = ProductNode.objects.create(parent=None, obj=product)
+    pvnode = ProductNode.objects.create(parent=pnode, obj=version)
+    psnode = ProductNode.objects.create(parent=pvnode, obj=stream)
+    ProductNode.objects.create(parent=psnode, obj=variant)
+    # This generates and saves the ProductModel properties of stream
+    # AKA we link the ProductModel instances to each other
+    stream.save_product_taxonomy()
+    assert variant in stream.productvariants.get_queryset()
+    return stream, variant
 
 
 def test_manifest_backslash():


### PR DESCRIPTION
This removes duplicates components from the manifest 'packages' list, and only lists provides once as leaf nodes.

The test seem to work OK, but when I compare the old openshift-4.7 manifest with the current one, there seems to be some components missing. Leaving as draft for now.

new:
```
$ cat corgi/output_files/openshift-4.7-a6b89c93-7c76-4737-984d-a0f69ac7326f.json | jq '.packages[].externalRefs[].referenceLocator' | wc -l
313
$ cat corgi/output_files/openshift-4.7-a6b89c93-7c76-4737-984d-a0f69ac7326f.json | jq '.packages[].externalRefs[].referenceLocator' | sort | uniq | wc -l
313
```

old:
```
$ cat corgi/output_files/openshift-4.7-a6b89c93-7c76-4737-984d-a0f69ac7326f.json | jq '.packages[].externalRefs[].referenceLocator' | wc -l
239537
$ cat corgi/output_files/openshift-4.7-a6b89c93-7c76-4737-984d-a0f69ac7326f.json | jq '.packages[].externalRefs[].referenceLocator' | sort | uniq | wc -l
35443
```
