### PR TITLE
Fix Syft purl that uses nonstandard casing

### DIFF
--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -37,6 +37,10 @@ def find_duplicate_component(meta_name: str, syft_purl: str) -> Component:
     logger.warning(
         f"Duplicate component {meta_name} detected by Syft, trying to find purl: {syft_purl}"
     )
+    # Syft generates some purls like pkg:pypi/PyYAML@6.0
+    # Happens for packages like PyYAML or PySocks with uppercase names
+    # This isn't a bug in Syft, but we need lowercase names to match Brew
+    syft_purl = syft_purl.lower()
     possible_dupe = Component.objects.get(purl=syft_purl)
 
     # Check if the dupe component fits one of our known edge cases


### PR DESCRIPTION
Quick fix for errors in recent monitoring emails. I'm manually rerunning all the failed SCA tasks in stage, and I see this fix is needed to properly dedupe component names / purls between Syft and Brew.

EDIT: After rereading the spec, it does not clearly state that the entire purl should be lowercased, only certain parts like the type and the key names in the qualifiers. So we still need to lowercase Syft purls to match data from Brew, but this is not technically a bug in Syft.