### PR TITLE
CORGI-536 - change sources, provides and upstreams to do exact match

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -70,10 +70,15 @@ class ComponentFilter(FilterSet):
     product_variants = CharFilter(field_name="productvariants", method="filter_ofuri_or_name")
     channels = CharFilter(lookup_expr="name")
 
+    # Normally we are interested in retrieving provides,sources or upstreams of a specific component
     sources = CharFilter(lookup_expr="purl__icontains")
     provides = CharFilter(lookup_expr="purl__icontains")
     upstreams = CharFilter(lookup_expr="purl__icontains")
-    re_upstream = CharFilter(lookup_expr="purl__regex", field_name="upstreams")
+
+    # otherwise use regex to match a range of purls
+    re_upstreams = CharFilter(lookup_expr="purl__regex", field_name="upstreams")
+    re_sources = CharFilter(lookup_expr="purl__regex", field_name="sources")
+    re_provides = CharFilter(lookup_expr="purl__regex", field_name="provides")
 
     el_match = CharFilter(label="RHEL version for layered products", lookup_expr="icontains")
 


### PR DESCRIPTION
?sources={}, ?provides={} and ?upstreams={} should perform an exact match .. this has the benefit of avoiding a LIKE in generated SQL (which is seriously slow and expensive query).

in addition we added re_ variants to enable regex matching if that is so desired.

**IMPORTANT** - when doing this I added some more tests but confused by the result of explicitly testing node creation ... needs discussion