### PR TITLE
added test for component node creation to make structure explicit

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -815,7 +815,7 @@ def test_oci_component_provides_sources_upstreams(client, api_path):
     The data model does not impose this constraint eg. provides, sources and upstream property queries enforce
     this behaviour.
 
-    """
+    """  # noqa
 
     # create a top level root source component
     root_comp = ComponentFactory(
@@ -928,35 +928,35 @@ def test_oci_component_provides_sources_upstreams(client, api_path):
     assert len(response.json()["upstreams"]) == 0
 
     # retrieve all sources of root_comp
-    response = client.get(f"{api_path}/components?provides={root_comp.purl}")
+    response = client.get(f"{api_path}/components?provides={quote(root_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["results"] == []
     assert response.json()["count"] == 0
     # retrieve all provides of root_comp
-    response = client.get(f"{api_path}/components?sources={root_comp.purl}")
+    response = client.get(f"{api_path}/components?sources={quote(root_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 2
 
     # retrieve all sources of dep_comp component
-    response = client.get(f"{api_path}/components?provides={dep_comp.purl}")
+    response = client.get(f"{api_path}/components?provides={quote(dep_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
     # retrieve all provides of dep_comp
-    response = client.get(f"{api_path}/components?sources={dep_comp.purl}")
+    response = client.get(f"{api_path}/components?sources={quote(dep_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
     # retrieve all sources of dep2_comp component
-    response = client.get(f"{api_path}/components?provides={dep2_comp.purl}")
+    response = client.get(f"{api_path}/components?provides={quote(dep2_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 2
     # retrieve all provides of dep2_comp
-    response = client.get(f"{api_path}/components?sources={dep2_comp.purl}")
+    response = client.get(f"{api_path}/components?sources={quote(dep2_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 0
 
     # retrieve all components with upstream_comp upstream
-    response = client.get(f"{api_path}/components?upstreams={upstream_comp.purl}")
+    response = client.get(f"{api_path}/components?upstreams={quote(upstream_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
@@ -977,9 +977,9 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     +--------------------+---------+----------+-----------+
     | root_component     | 0       | 1        | 1         |
     +--------------------+---------+----------+-----------+
-    | upstream_component | 0       | 0        | 0        |
+    | upstream_component | 0       | 0        | 3         |
     +--------------------+---------+----------+-----------+
-    | dep1_component     | 1       | 0        | 0         |
+    | dep1_component     | 1       | 0        | 1         |
     +--------------------+---------+----------+-----------+
 
     This behaviour is predicated on the following assumptions:
@@ -989,7 +989,7 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     The data model does not impose this constraint eg. provides, sources and upstream property queries enforce
     this behaviour.
 
-    """
+    """  # noqa
 
     # create a top level root source component
     root_comp = ComponentFactory(
@@ -1022,7 +1022,7 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     # create dep component
     dep_comp = ComponentFactory(
         name="cool_dep_component",
-        arch="src",
+        arch="s390x",
         type=Component.Type.RPM,
         namespace=Component.Namespace.REDHAT,
     )
@@ -1036,16 +1036,16 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
 
     # TODO - investigate if invoking any of the following in any order is stable
     # it is intentional to invoke these twice during the test
-    # upstream_comp.save_component_taxonomy()
-    # upstream_comp.save()
-    # dep_comp.save_component_taxonomy()
-    # dep_comp.save()
-    # root_comp.save_component_taxonomy()
-    # root_comp.save()
-    # upstream_comp.save_component_taxonomy()
-    # upstream_comp.save()
-    # # dep_comp.save_component_taxonomy()
-    # dep_comp.save()
+    upstream_comp.save_component_taxonomy()
+    upstream_comp.save()
+    dep_comp.save_component_taxonomy()
+    dep_comp.save()
+    root_comp.save_component_taxonomy()
+    root_comp.save()
+    upstream_comp.save_component_taxonomy()
+    upstream_comp.save()
+    dep_comp.save_component_taxonomy()
+    dep_comp.save()
     root_comp.save_component_taxonomy()
     root_comp.save()
 
@@ -1067,38 +1067,34 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     assert response.status_code == 200
     assert len(response.json()["sources"]) == 1
     assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 0
+    assert len(response.json()["upstreams"]) == 1
 
     response = client.get(f"{api_path}/components/{upstream_comp.uuid}")
     assert response.status_code == 200
     assert len(response.json()["sources"]) == 0
     assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 0
+    assert len(response.json()["upstreams"]) == 1
 
     # retrieve all sources of root_comp
-    response = client.get(f"{api_path}/components?provides={root_comp.purl}")
+    response = client.get(f"{api_path}/components?provides={quote(root_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["results"] == []
     assert response.json()["count"] == 0
     # retrieve all provides of root_comp
-    response = client.get(f"{api_path}/components?sources={root_comp.purl}")
+    response = client.get(f"{api_path}/components?sources={quote(root_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
     # retrieve all sources of dep_comp component
-    response = client.get(f"{api_path}/components?provides={dep_comp.purl}")
+    response = client.get(f"{api_path}/components?provides={quote(dep_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 1
     # retrieve all provides of dep_comp
-    response = client.get(f"{api_path}/components?sources={dep_comp.purl}")
+    response = client.get(f"{api_path}/components?sources={quote(dep_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 0
 
     # retrieve all components with upstream_comp upstream
-    response = client.get(f"{api_path}/components?upstreams={upstream_comp.purl}")
+    response = client.get(f"{api_path}/components?upstreams={quote(upstream_comp.purl)}")
     assert response.status_code == 200
-    assert response.json()["count"] == 1
-
-
-
-
+    assert response.json()["count"] == 3


### PR DESCRIPTION
### OCI ComponentNode creation test
Given an OCI component node structure:
```
    /
    └──(SOURCE) root_comp: top level root component
        ├──(SOURCE) upstream_comp
        └──(PROVIDES) dep1_comp
            └──(PROVIDES) dep2_comp
```
The following are expectations in terms of sources, providers and upstreams url params on each of these components.
```
    +--------------------+---------+----------+-----------+
    |                    | sources | provides | upstreams |
    +--------------------+---------+----------+-----------+
    | root_component     | 0       | 2        | 1         |
    +--------------------+---------+----------+-----------+
    | upstream_component | 0       | 0        | 0         |
    +--------------------+---------+----------+-----------+
    | dep1_component     | 1       | 1        | 0         |
    +--------------------+---------+----------+-----------+
    | dep2_component     | 2       | 0        | 0         |
    +--------------------+---------+----------+-----------+
```
-----------------------------
### SRPM ComponentNode creation test
Given a SRPM root component node structure:
```
    /
    └──(SOURCE) root_comp: top level root component
        ├──(SOURCE) upstream_comp
        └──(PROVIDES) dep1_comp
```
Then we expect the following in terms of sources, providers and upstreams url params for each of these components.
```
    +--------------------+---------+----------+-----------+
    |                    | sources | provides | upstreams |
    +--------------------+---------+----------+-----------+
    | root_component     | 0       | 1        | 1         |
    +--------------------+---------+----------+-----------+
    | upstream_component | 0       | 0        | 3         |
    +--------------------+---------+----------+-----------+
    | dep1_component     | 1       | 0        | 1         |
    +--------------------+---------+----------+-----------+
```
-----------------------------

What happens with middleware, services or C/C++ components (and/or GOLANG for that matter) ? 

**Note** - We have other tests giving us coverage in this area - the goal with these tests is to characterise _canonical_ component node creation to ensure everyone shares understanding. We also want to have a clear test to help us tease out component relationships eg.  not conflate rpm or container packaging relationships with runtime/buildtime/devtime relationships.