### PR TITLE
Fix unneeded related object lookups

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1778,7 +1778,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
     def get_upstreams_pks(self, using: str = "read_only") -> tuple[str, ...]:
         """Return only the primary keys from the set of all upstream nodes"""
-        linked_pks = set(node.obj.pk for node in self.get_upstreams_nodes(using=using) if node.obj)
+        linked_pks = set(str(node.object_id) for node in self.get_upstreams_nodes(using=using))
         return tuple(linked_pks)
 
     def get_upstreams_purls(self, using: str = "read_only") -> set[str]:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs While reviewing some other code, I saw we fetch every upstream ComponentNode's related Component to get only its primary key, which requires one extra query per node.

We can get this Component UUID value directly from the upstream ComponentNode's object_id field without any extra queries. We also don't need to check "if node.obj" or "if node.object_id" since nodes are never created without a linked object, and deleting the linked object also deletes the node.