### PR TITLE
CORGI-536: use exact match for sources,provides, and upstreams filters

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -70,10 +70,14 @@ class ComponentFilter(FilterSet):
     product_variants = CharFilter(field_name="productvariants", method="filter_ofuri_or_name")
     channels = CharFilter(lookup_expr="name")
 
-    sources = CharFilter(lookup_expr="purl__icontains")
-    provides = CharFilter(lookup_expr="purl__icontains")
-    upstreams = CharFilter(lookup_expr="purl__icontains")
-    re_upstream = CharFilter(lookup_expr="purl__regex", field_name="upstreams")
+    # Normally we are interested in retrieving provides,sources or upstreams of a specific component
+    sources = CharFilter(field_name="sources", lookup_expr="purl")
+    provides = CharFilter(field_name="provides", lookup_expr="purl")
+    upstreams = CharFilter(field_name="upstreams", lookup_expr="purl")
+    # otherwise use regex to match provides,sources or upstreams purls
+    re_sources = CharFilter(field_name="sources", lookup_expr="purl__regex")
+    re_provides = CharFilter(field_name="provides", lookup_expr="purl__regex")
+    re_upstreams = CharFilter(field_name="upstreams", lookup_expr="purl__regex")
 
     el_match = CharFilter(label="RHEL version for layered products", lookup_expr="icontains")
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -323,11 +323,19 @@ paths:
         schema:
           type: string
       - in: query
+        name: re_provides
+        schema:
+          type: string
+      - in: query
         name: re_purl
         schema:
           type: string
       - in: query
-        name: re_upstream
+        name: re_sources
+        schema:
+          type: string
+      - in: query
+        name: re_upstreams
         schema:
           type: string
       - in: query


### PR DESCRIPTION
Previously we matched using **icontains** for sources, provides and upstreams url param filters - which resulted in very poor performance as django ORM generated SQL with **LIKE** (with %target%) - these expressions can only be indexed using trigram/full text search. 

We now have **exact** matching for the following endpoint url filter params:
```
api/v1/components?sources={purl}       # return all components provided by this purl
api/v1/components?provides={purl}      # return all sources that use this purl
api/v1/components?upstreams={purl}   # return all components with this upstream purl
```
Much quicker (as we are hitting an index to resolve) and enables reasonable performance (ex. downstream griffon).

In addition, we provide re_ variants for regex search:
```
api/v1/components?re_sources={}
api/v1/components?re_provides={}
api/v1/components?re_upstreams={}
```
which by definition will run slower (presumably by someone who knows that is what they want to do).

**Note** - discussion for this was litigated in https://github.com/RedHatProductSecurity/component-registry/pull/370 ... which I had to close due to git not playing nice.