### PR TITLE
CORGI-341: Fix empty manifest properties

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -562,6 +562,7 @@ class Brew:
             build_id, build_nvr, arch=archive["extra"]["image"]["arch"], name_label=name_label
         )
         child_component["meta"]["docker_config"] = docker_config
+        child_component["meta"]["filename"] = archive["filename"]
         child_component["meta"]["brew_archive_id"] = archive["id"]
         child_component["meta"]["digests"] = archive["extra"]["docker"]["digests"]
         child_component["meta"]["source"] = ["koji.listArchives"]

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -466,14 +466,15 @@ class Brew:
         component["components"] = list(noarch_rpms_by_id.values())
 
         # During collection we are only able to inspect docker config labels on
-        # attached arch specific archives. We do this loop here to save the
+        # attached arch specific archives. We do this loop here to save the description, license,
         # name label, and repository url also on the index container object at the root of the tree.
-        for attr in ("name_from_label", "repository_url"):
+        for attr in ("description", "license", "name_from_label", "repository_url"):
             self._get_child_meta(component, attr)
 
         return component
 
-    def _get_child_meta(self, component, meta_attr):
+    @staticmethod
+    def _get_child_meta(component: dict, meta_attr: str) -> None:
         for image in component["image_components"]:
             meta_attr_value = image["meta"].get(meta_attr)
             if meta_attr_value:
@@ -557,12 +558,15 @@ class Brew:
     ) -> Tuple[dict[int, dict[str, Any]], dict[str, Any]]:
         logger.info("Processing image archive %s", archive["filename"])
         docker_config = archive["extra"]["docker"]["config"]
-        name_label = self._get_name_label(docker_config)
+        labels = self._get_labels(docker_config)
+        name_label = labels.get("name", "")
         child_component = self._create_image_component(
             build_id, build_nvr, arch=archive["extra"]["image"]["arch"], name_label=name_label
         )
+        child_component["meta"]["description"] = labels.get("description", "")
         child_component["meta"]["docker_config"] = docker_config
         child_component["meta"]["filename"] = archive["filename"]
+        child_component["meta"]["license"] = labels.get("License", "")
         child_component["meta"]["brew_archive_id"] = archive["id"]
         child_component["meta"]["digests"] = archive["extra"]["docker"]["digests"]
         child_component["meta"]["source"] = ["koji.listArchives"]
@@ -591,10 +595,10 @@ class Brew:
         child_component["rpm_components"] = arch_specific_rpms
         return noarch_rpms_by_id, child_component
 
-    def _get_name_label(self, docker_config):
+    @staticmethod
+    def _get_labels(docker_config: dict) -> dict[str, str]:
         config = docker_config.get("config", {})
-        labels = config.get("Labels", {})
-        return labels.get("name", "")
+        return config.get("Labels", {})
 
     def _extract_provides(
         self, packages: list[SimpleNamespace], pkg_type: str

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1640,19 +1640,20 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # /software/containers/container-native-virtualization/hco-bundle-registry/5ccae1925a13467289f2475b
         # /software/containers/openshift/ose-local-storage-diskmaker/
         # 5d9347b8dd19c70159f2f6e4?architecture=s390x&tag=v4.4.0-202007171809.p0
-        # We can't build URLs like above because the hash is required,
+        # We can't build Container Catalog URLs like above because the hash is required,
         # but doesn't match any hash in the meta_attr / other properties.
-        # repository_url is the customer-facing download location, but per OpenLCS
-        # they want to see the internal registry-proxy URL from Brew.
+        # repository_url / related_URL is the customer-facing location,
+        # so for now we just build a pull URL from that instead.
 
         # TODO: self.filename, AKA the filename of the image archive a container is included in,
         #  is always unset. This is not the digest SHA but the config layer SHA.
         elif self.type == Component.Type.CONTAINER_IMAGE:
-            pull_url = self.meta_attr.get("pull", [])
-            # First pull URL is based on hash, others are based on tags
-            # if we have an empty list, just return a generic URL
-            pull_url = pull_url[0] if pull_url else self.CONTAINER_CATALOG_SEARCH
-            return pull_url
+            if not self.related_url:
+                return self.CONTAINER_CATALOG_SEARCH
+
+            # registry.redhat.io/repo/name:version-release
+            release = f"-{self.release}" if self.release else ""
+            return f"{self.related_url}:{self.version}{release}"
 
         else:
             # Usually a remote-source component

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1645,8 +1645,6 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # repository_url / related_URL is the customer-facing location,
         # so for now we just build a pull URL from that instead.
 
-        # TODO: self.filename, AKA the filename of the image archive a container is included in,
-        #  is always unset. This is not the digest SHA but the config layer SHA.
         elif self.type == Component.Type.CONTAINER_IMAGE:
             if not self.related_url:
                 return self.CONTAINER_CATALOG_SEARCH

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -461,11 +461,12 @@ def test_purl2url():
 
     component = ComponentFactory(type=Component.Type.CONTAINER_IMAGE)
     assert component.download_url == Component.CONTAINER_CATALOG_SEARCH
-    assert "pull" not in component.meta_attr
-    component.meta_attr["pull"] = ["registry.redhat.io/openshift3/grafana"]
-    assert component.download_url == component.meta_attr["pull"][0]
-    component.meta_attr["pull"] = []
-    assert component.download_url == Component.CONTAINER_CATALOG_SEARCH
+    assert not component.related_url
+    component.related_url = "registry.redhat.io/openshift3/grafana"
+    component.save()
+    assert (
+        component.download_url == f"{component.related_url}:{component.version}-{component.release}"
+    )
 
     component = ComponentFactory(
         namespace=Component.Namespace.REDHAT, type=Component.Type.GEM, release=release


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review a fix for some empty manifest properties, as well as removing internal URLs from our manifests. OpenLCS confirmed they don't need the internal download_url for containers anymore (after some process changes), so we can use a public URL instead now.