### PR TITLE
CORGI-558, CORGI-559: Add missing filters

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class EmptyStringFilter(BooleanFilter):
     """Filter or exclude an arbitrary field against an empty string value"""
 
-    def filter(self, qs, value):
+    def filter(self, qs: QuerySet[Component], value: bool) -> QuerySet[Component]:
         if value in EMPTY_VALUES:
             # User gave an empty ?param= so return the unfiltered queryset
             return qs
@@ -28,7 +28,7 @@ class EmptyStringFilter(BooleanFilter):
 
 
 class TagFilter(Filter):
-    def filter(self, queryset, value):
+    def filter(self, queryset: QuerySet, value: str) -> QuerySet:
         # TODO: currently defaults to AND condition, we should make this configurable for both
         # OR and AND conditions.
         if not value:
@@ -52,10 +52,9 @@ class ComponentFilter(FilterSet):
         model = Component
         # Fields that are matched to a filter using their Django model field type and default
         # __exact lookups.
-        fields = ("type", "namespace", "version", "release", "arch", "nvr", "nevra")
+        fields = ("type", "namespace", "name", "version", "release", "arch", "nvr", "nevra")
 
     # Custom filters
-    name = CharFilter()
     re_name = CharFilter(lookup_expr="regex", field_name="name")
     re_purl = CharFilter(lookup_expr="regex", field_name="purl")
     description = CharFilter(lookup_expr="icontains")
@@ -71,9 +70,9 @@ class ComponentFilter(FilterSet):
     channels = CharFilter(lookup_expr="name")
 
     # Normally we are interested in retrieving provides,sources or upstreams of a specific component
-    sources = CharFilter(field_name="sources", lookup_expr="purl")
-    provides = CharFilter(field_name="provides", lookup_expr="purl")
-    upstreams = CharFilter(field_name="upstreams", lookup_expr="purl")
+    sources = CharFilter(lookup_expr="purl")
+    provides = CharFilter(lookup_expr="purl")
+    upstreams = CharFilter(lookup_expr="purl")
     # otherwise use regex to match provides,sources or upstreams purls
     re_sources = CharFilter(field_name="sources", lookup_expr="purl__regex")
     re_provides = CharFilter(field_name="provides", lookup_expr="purl__regex")
@@ -93,8 +92,8 @@ class ComponentFilter(FilterSet):
 
     @staticmethod
     def filter_ofuri_or_name(
-        queryset: QuerySet["Component"], name: str, value: str
-    ) -> QuerySet["Component"]:
+        queryset: QuerySet[Component], name: str, value: str
+    ) -> QuerySet[Component]:
         """Filter some field by a ProductModel subclass's ofuri
         Or else by a name, depending on the user's input"""
         if value.startswith("o:redhat:"):

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -90,6 +90,11 @@ class ComponentFilter(FilterSet):
         label="Show only unscanned components (where license concluded is empty)",
     )
 
+    missing_scan_url = EmptyStringFilter(
+        field_name="openlcs_scan_url",
+        label="Show only unscanned components (where OpenLCS scan URL is empty)",
+    )
+
     @staticmethod
     def filter_ofuri_or_name(
         queryset: QuerySet[Component], name: str, value: str

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -398,7 +398,10 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
                 version="",
                 release="",
                 arch="noarch",
-                defaults={"namespace": Component.Namespace.UPSTREAM},
+                defaults={
+                    "mets_attr": {"go_component_type": "gomod"},
+                    "namespace": Component.Namespace.UPSTREAM,
+                },
             )
             ComponentNode.objects.get_or_create(
                 type=ComponentNode.ComponentNodeType.SOURCE,
@@ -453,6 +456,9 @@ def save_container(softwarebuild: SoftwareBuild, build_data: dict) -> ComponentN
                 # The public repo we want is just github.com/openshift/cluster-api
                 related_url = related_url.replace("openshift-priv", "openshift")
 
+            if source["type"] == Component.Type.GOLANG:
+                # Assume upstream container sources are always go modules, never go-packages
+                source["meta"]["go_component_type"] = "gomod"
             new_upstream, created = Component.objects.update_or_create(
                 type=source["type"],
                 name=component_name,

--- a/openapi.yml
+++ b/openapi.yml
@@ -242,6 +242,11 @@ paths:
         description: 'Exclude only specified fields in the response. Multiple values
           may be separated by commas. Example: `exclude_fields=software_build.build_id,name`'
       - in: query
+        name: gomod_components
+        schema:
+          type: boolean
+        description: Show only gomod components, hide go-packages
+      - in: query
         name: include_fields
         schema:
           type: array

--- a/openapi.yml
+++ b/openapi.yml
@@ -266,6 +266,11 @@ paths:
           type: boolean
         description: Show only unscanned components (where license concluded is empty)
       - in: query
+        name: missing_scan_url
+        schema:
+          type: boolean
+        description: Show only unscanned components (where OpenLCS scan URL is empty)
+      - in: query
         name: name
         schema:
           type: string


### PR DESCRIPTION
@jasinner Let's discuss the approach since I'm not sure this is possible. We want to filter for only go-package or gomod type components, using the go_component_type key we set in the meta_attr. But it looks like this key isn't present if:

1) We're creating a golang component as a source of some container
2) We're creating a golang component discovered by Syft
3) Maybe other cases as well

As a side-effect of how I implemented the filter, setting the filter to "YES" means only showing gomod components. go-packages and golang components with an unknown type will be hidden.

Setting the filter to "NO" means only showing go-package components. gomod components and golang components with an unknown type will be hidden.

The golang components with an unknown type will only be shown when the user doesn't click anything in the filters box, or when the user gives a URI like ```?type=GOLANG&gomod_components=``` with an empty gomod_components parameter.

I could adjust this to always treat a golang component with unknown type as a gomod component (or a go-package). Is this worth pursuing further, or should we close this as CANTDO? Or maybe you know of some way to determine whether these unknown golang components are really gomod components or go-packages.