### PR TITLE
CORGI-300 remove schema from runsql migrations

### DIFF
--- a/corgi/core/migrations/0037_custom_indexes.py
+++ b/corgi/core/migrations/0037_custom_indexes.py
@@ -12,19 +12,19 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE INDEX core_componentnode_tree_parent_lft_idx ON public.core_componentnode \
+            "CREATE INDEX core_componentnode_tree_parent_lft_idx ON core_componentnode \
              USING btree(tree_id, parent_id, lft)"
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_cn_tree_lft_purl_parent_idx ON public.core_componentnode \
+            "CREATE INDEX core_cn_tree_lft_purl_parent_idx ON core_componentnode \
              USING btree (tree_id, lft, purl, parent_id) WHERE (parent_id IS NULL)"
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_cn_lft_tree_idx ON public.core_componentnode \
+            "CREATE INDEX core_cn_lft_tree_idx ON core_componentnode \
              USING btree (lft, tree_id)"
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_cn_lft_rght_tree_idx ON public.core_componentnode \
+            "CREATE INDEX core_cn_lft_rght_tree_idx ON core_componentnode \
              USING btree (lft, rght, tree_id)"
         ),
     ]

--- a/corgi/core/migrations/0040_auto_20221020_1057.py
+++ b/corgi/core/migrations/0040_auto_20221020_1057.py
@@ -27,19 +27,19 @@ class Migration(migrations.Migration):
             index=models.Index(fields=["ofuri"], name="core_produc_ofuri_c62cf2_idx"),
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_compon_latest_name_type_idx ON public.core_component \
+            "CREATE INDEX core_compon_latest_name_type_idx ON core_component \
              USING btree (name, type) WHERE (((type)::text = 'SRPM'::text) OR \
              (((arch)::text = 'noarch'::text) AND ((type)::text = 'CONTAINER_IMAGE'::text)) \
              OR ((type)::text = 'RHEL_MODULE'::text))"
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_compon_latest_type_name_idx ON public.core_component \
+            "CREATE INDEX core_compon_latest_type_name_idx ON core_component \
              USING btree (type, name) WHERE (((type)::text = 'SRPM'::text) OR \
              (((arch)::text = 'noarch'::text) AND ((type)::text = 'CONTAINER_IMAGE'::text)) \
              OR ((type)::text = 'RHEL_MODULE'::text))"
         ),
         migrations.RunSQL(
-            "CREATE INDEX core_compon_latest_idx ON public.core_component \
+            "CREATE INDEX core_compon_latest_idx ON core_component \
             USING btree (uuid, software_build_id, type, name, product_streams) \
             WHERE (((type)::text = 'SRPM'::text) OR (((arch)::text = 'noarch'::text) \
             AND ((type)::text = 'CONTAINER_IMAGE'::text)) OR ((type)::text = 'RHEL_MODULE'::text))"

--- a/corgi/core/migrations/0042_autovacuum.py
+++ b/corgi/core/migrations/0042_autovacuum.py
@@ -11,9 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "ALTER TABLE public.core_componentnode SET (autovacuum_vacuum_scale_factor=0.001);"
+            "ALTER TABLE core_componentnode SET (autovacuum_vacuum_scale_factor=0.001);"
         ),
-        migrations.RunSQL(
-            "ALTER TABLE public.core_component SET (autovacuum_vacuum_scale_factor=0.001);"
-        ),
+        migrations.RunSQL("ALTER TABLE core_component SET (autovacuum_vacuum_scale_factor=0.001);"),
     ]


### PR DESCRIPTION
There is a single Postgres DB shared by enterprise and community. They are separated by schema. In these migrations we are including the schema 'public' in the create index commands which only works in the enterprise instance. These migrations fail in community because the schema has a different name. 

Removing the schema has no affect on enterprise, but allows community to deploy correctly.