### PR TITLE
CORGI-300 only schedule relevant tasks in community mode

### DIFF
--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -49,25 +49,33 @@ def setup_periodic_tasks(sender, **kwargs):
     CrontabSchedule.objects.get_queryset().delete()
     IntervalSchedule.objects.get_queryset().delete()
 
-    # Once a week on a Saturday fetch relations from all active CDN repos
-    # Revisit if this is still necessary after CORGI-257 is complete
-    upsert_cron_task("pulp", "setup_pulp_relations", minute=0, hour=4, day_of_week=6)
+    if settings.COMMUNITY_MODE_ENABLED:
+        upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
+        upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=2, minute=0)
+        upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=3, minute=0)
+        upsert_cron_task("manifest", "update_manifests", hour=4, minute=0)
+        upsert_cron_task("manifest", "collect_static", hour=5, minute=0)
+        upsert_cron_task("monitoring", "email_failed_tasks", hour=6, minute=0)
+    else:
+        # Once a week on a Saturday fetch relations from all active CDN repos
+        # Revisit if this is still necessary after CORGI-257 is complete
+        upsert_cron_task("pulp", "setup_pulp_relations", minute=0, hour=4, day_of_week=6)
 
-    # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
-    # task at all: https://github.com/celery/django-celery-beat/issues/221
-    upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
-    upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
-    upsert_cron_task("pulp", "update_cdn_repo_channels", hour=2, minute=0)
-    upsert_cron_task("rhel_compose", "save_composes", hour=3, minute=0)
-    upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)
-    upsert_cron_task("brew", "load_brew_tags", hour=5, minute=0)
-    upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=6, minute=0)
-    upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=7, minute=0)
-    upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)
-    upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
-    upsert_cron_task("manifest", "update_manifests", hour=10, minute=0)
-    upsert_cron_task("manifest", "collect_static", hour=11, minute=0)
-    upsert_cron_task("monitoring", "email_failed_tasks", hour=11, minute=45)
+        # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
+        # task at all: https://github.com/celery/django-celery-beat/issues/221
+        upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
+        upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
+        upsert_cron_task("pulp", "update_cdn_repo_channels", hour=2, minute=0)
+        upsert_cron_task("rhel_compose", "save_composes", hour=3, minute=0)
+        upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)
+        upsert_cron_task("brew", "load_brew_tags", hour=5, minute=0)
+        upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=6, minute=0)
+        upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=7, minute=0)
+        upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)
+        upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
+        upsert_cron_task("manifest", "update_manifests", hour=10, minute=0)
+        upsert_cron_task("manifest", "collect_static", hour=11, minute=0)
+        upsert_cron_task("monitoring", "email_failed_tasks", hour=11, minute=45)
 
     # Automatic task result expiration is currently disabled
     # We are required to keep UMB task results


### PR DESCRIPTION
This updates the scheduled tasks in community mode to only those relevant to that environment.

Verified with:

```
$ bm.PeriodicTask.objects.all()
 <ExtendedQuerySet [<PeriodicTask: update_products: 0 1 * * * (m/h/dM/MY/d) UTC>, <PeriodicTask: fetch_unprocessed_brew_tag_relations: 0 2 * * * (m/h/dM/MY/d) UTC>, <PeriodicTask: fetch_unprocessed_yum_relations: 0 3 * * * (m/h/dM/MY/d) UTC>, <PeriodicTask: update_manifests: 0 4 * * * (m/h/dM/MY/d) UTC>, <PeriodicTask: collect_static: 0 5 * * * (m/h/dM/MY/d) UTC>, <PeriodicTask: email_failed_tasks: 0 6 * * * (m/h/dM/MY/d) UTC>]>
```