### PR TITLE
CORGI-414 add fedoraproject.org to allowed hosts

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -10,6 +10,7 @@ ALLOWED_HOSTS = [
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
     ".redhat.com",
+    ".fedoraproject.org",
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True

--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -5,11 +5,13 @@ from .base import *  # noqa: F401, F403
 # SECURITY WARNING: keep the secret key used in stage secret!
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")  # noqa: F405
 
+# TODO setup stage cname for community stage
 ALLOWED_HOSTS = [
     # Allow local host's IP address and hostname for health probes
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
     ".redhat.com",
+    ".fedoraproject.org",
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True


### PR DESCRIPTION
Allows stage and prod to accept request using cname *.fedoraproject.org