### PR TITLE
Fix community corgi checks

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -28,7 +28,7 @@ DOCS_URL = os.getenv("CORGI_DOCS_URL")
 OPENSHIFT_BUILD_COMMIT = os.getenv("OPENSHIFT_BUILD_COMMIT")
 PRODSEC_EMAIL = os.getenv("PRODSEC_EMAIL", "dev@example.com")
 
-CORGI_DOMAIN = os.getenv("CORGI_DOMAIN")
+CORGI_DOMAIN = os.getenv("CORGI_DOMAIN", "")
 if CORGI_DOMAIN:
     CSRF_COOKIE_DOMAIN = CORGI_DOMAIN
     LANGUAGE_COOKIE_DOMAIN = CORGI_DOMAIN
@@ -383,8 +383,12 @@ UMB_BROKER_URL = os.getenv("CORGI_UMB_BROKER_URL")
 # https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
 UMB_BREW_MONITOR_ENABLED = strtobool(os.getenv("CORGI_UMB_BREW_MONITOR_ENABLED", "true"))
 
-# Set to True to turn on loading of community products from product-definitions.
 COMMUNITY_MODE_ENABLED = strtobool(os.getenv("CORGI_COMMUNITY_MODE_ENABLED", "false"))
+
+if CORGI_DOMAIN.endswith(".fedoraproject.org"):
+    CORGI_DOMAIN_BASE = ".fedoraproject.org"
+else:
+    CORGI_DOMAIN_BASE = ".prodsec.redhat.com"
 
 # Brew
 BREW_URL = os.getenv("CORGI_BREW_URL")

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -9,8 +9,7 @@ ALLOWED_HOSTS = [
     # Allow local host's IP address and hostname for health probes
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
-    ".redhat.com",
-    ".fedoraproject.org",
+    CORGI_DOMAIN_BASE,  # noqa: F405
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True

--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -10,8 +10,7 @@ ALLOWED_HOSTS = [
     # Allow local host's IP address and hostname for health probes
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
-    ".redhat.com",
-    ".fedoraproject.org",
+    CORGI_DOMAIN_BASE,  # noqa: F405
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -31,7 +31,6 @@ from corgi.core.models import (
 logger = logging.getLogger(__name__)
 
 # Generic URL prefix
-# TODO remove running_community check once domain is established
 if not utils.running_dev():
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
     CORGI_STATIC_URL = f"https://{settings.CORGI_DOMAIN}{settings.STATIC_URL}"

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -3,6 +3,7 @@ import logging
 from typing import Type, Union
 
 import django_filters.rest_framework
+from django.conf import settings
 from django.db import connections
 from django.db.models import QuerySet, Value
 from django.http import Http404
@@ -596,7 +597,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         """Allow OpenLCS to upload copyright text / license scan results for a component"""
         # In the future these could be separate endpoints
         # For testing we'll just keep it under one endpoint
-        if utils.running_prod():
+        if utils.running_prod() or settings.COMMUNITY_MODE_ENABLED:
             # This is only temporary for OpenLCS testing
             # Do not enable in production until we add OIDC authentication
             return Response(status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Quick review please, this should fix a writable API endpoint on the stage community version. Both community and enterprise use the same DJANGO_SETTINGS_MODULE (whether stage or prod), so our existing running_prod() check isn't enough and we also need to check for COMMUNITY_MODE_ENABLED.

I also tweaked some settings to avoid a too-permissive Host: header check and avoid duplicating some logic. The enterprise version should only allow connections that specify an enterprise Host: header, and vice-versa for the community version.

I'm not sure if this is exploitable or not, but the Django docs say this is needed to prevent CSRF attacks and other manipulations of the Host: header:
https://docs.djangoproject.com/en/4.1/ref/settings/#allowed-hosts

I'm not sure how to actually deploy this - manually into the community namespace? Maybe we should add a step to the CI pipeline to deploy the community resources, to keep everything in sync with the enterprise resources.

We should also make sure that CORGI_DOMAIN is set correctly for the community version. Currently it's set to an internal URL. This makes the web pod generate API links with that internal URL.