### PR TITLE
CORGI-542 escapejs on download and related urls

### DIFF
--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,7 +1,7 @@
 {# Component manifest, obj is a Component here #}{% extends "base_manifest.json" %}
 {% block packages %}{% for component in obj.provides_queryset %}{
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",
@@ -10,7 +10,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if component.related_url %}"{{component.related_url}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if component.related_url %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
@@ -23,7 +23,7 @@
     },{% endfor %}
     {
         "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if obj.download_url %}"{{obj.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if obj.download_url %}"{{obj.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",
@@ -32,7 +32,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if obj.related_url %}"{{obj.related_url}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if obj.related_url %}"{{obj.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -2,7 +2,7 @@
 {% block packages %}{% for component in latest_components %}
     {
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",
@@ -11,7 +11,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if component.related_url %}"{{component.related_url}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if component.related_url %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
@@ -24,7 +24,7 @@
     },{% endfor %}{% for provided in distinct_provides %}
     {
         "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if provided.download_url %}"{{provided.download_url}}"{% else %}"NOASSERTION"{% endif %},
+        "downloadLocation": {% if provided.download_url %}"{{provided.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
             {
                 "referenceCategory": "PACKAGE_MANAGER",
@@ -33,7 +33,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if provided.related_url %}"{{provided.related_url}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if provided.related_url %}"{{provided.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if provided.license_concluded %}"{{provided.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if provided.license_declared %}"{{provided.license_declared}}"{% else %}"NOASSERTION"{% endif %},

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -73,7 +73,7 @@ def test_latest_components_exclude_source_container():
     assert not components.first().name.endswith("-container-source")
 
 
-def test_manifest_backslash():
+def test_stream_manifest_backslash():
     """Test that a tailing backslash in a purl doesn't break rendering"""
 
     stream = ProductStreamFactory()
@@ -85,6 +85,20 @@ def test_manifest_backslash():
 
     try:
         stream.manifest
+    except JSONDecodeError:
+        assert False
+
+
+def test_component_manifest_backslash():
+    """Test that a backslash in a version doesn't break rendering via download_url or related_url"""
+    component = ComponentFactory(
+        version="\\9.0.6.v20130930",
+        type=Component.Type.MAVEN,
+        name="org.eclipse.jetty/jetty-webapp",
+    )
+    assert component.download_url
+    try:
+        component.manifest
     except JSONDecodeError:
         assert False
 


### PR DESCRIPTION
This adds escapejs on Django templates used to generate product stream and component manifests so that special characters in JSON do not break validation of manifests.