### PR TITLE
CORGI-551 always run collectstatic as startup

### DIFF
--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -46,4 +46,4 @@ def cpu_update_ps_manifest(product_stream: str):
     retry_kwargs=RETRY_KWARGS,
 )
 def collect_static():
-    call_command("collectstatic", verbosity=0, interactive=False, ignore_patterns=[".gitignore"])
+    call_command("collectstatic", verbosity=1, interactive=False)

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,13 +3,14 @@
 # Custom run script for starting corgi django service in corgi-stage and corgi-prod environments.
 # Note - DJANGO_SETTINGS_MODULE env var is required
 
+# collect static files
+python3 manage.py collectstatic \
+--ignore '*.json' \
+-v 2 \
+--noinput
+
 # start gunicorn
 if [[ $1 == dev ]]; then
-    # collect static files
-    python3 manage.py collectstatic \
-    --ignore '.gitignore' \
-    -v 2 \
-    --noinput
     exec gunicorn config.wsgi --config gunicorn_config.py --reload
 else
     exec gunicorn config.wsgi --config gunicorn_config.py


### PR DESCRIPTION
This updates the start_server script so that collectstatic is always run on startup. This prevents a 500 error when restarting the web application after all the files in the staticfiles directory have been deleted. The 500 error is caused by missing css and javascript files places in staticfiles for Django apps that we include such as drf_spectacular.

We now exclude *.json files as those take a long time to collect and process, which delays the startup of the web application on every restart. Those will be collected by the scheduled task.