### PR TITLE
CORGI-546 low coverage

### DIFF
--- a/corgi/tasks/management/commands/loadunprocessedrelations.py
+++ b/corgi/tasks/management/commands/loadunprocessedrelations.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.core.models import ProductComponentRelation
 from corgi.tasks.brew import fetch_unprocessed_relations
@@ -7,17 +7,41 @@ from corgi.tasks.brew import fetch_unprocessed_relations
 class Command(BaseCommand):
     help = "Fetch unprocessed builds from the relations table"
 
-    def handle(self, *args, **options):
-        self.stdout.write(
-            self.style.SUCCESS(
-                "Loading unprocessed relations",
-            )
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "-p",
+            "--product_ref",
+            dest="product_ref",
+            help="Fetch unprocessed relations for product reference",
         )
+
+    def handle(self, *args, **options):
         processed_builds = 0
-        for relation_type in ProductComponentRelation.objects.values_list(
-            "type", flat=True
-        ).distinct():
-            processed_builds += fetch_unprocessed_relations(relation_type=relation_type)
+        if options["product_ref"]:
+            if (
+                not ProductComponentRelation.objects.db_manager("read_only")
+                .filter(product_ref=options["product_ref"])
+                .exists()
+            ):
+                self.out.write(
+                    self.style.ERROR(
+                        f"Could not find relations with product ref: {options['product_ref']}"
+                    )
+                )
+                exit(1)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Loading unprocessed relations with product ref: {options['product_ref']}",
+                )
+            )
+            processed_builds = fetch_unprocessed_relations(product_ref=options["product_ref"])
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Loading unprocessed relations",
+                )
+            )
+            processed_builds = fetch_unprocessed_relations()
         self.stdout.write(
             self.style.SUCCESS(
                 f"Loaded {processed_builds} unprocessed relations",

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -130,8 +130,10 @@ def update_products() -> None:
                             "obj": product_stream,
                         },
                     )
-
-                    if len(brew_tags) > 0:
+                    # quay-3 Errata Tool product version Quay-3-RHEL-8 list too many brew tags
+                    # Linking quay streams to the 8Base-Quay-3 variant here via brew tags leads
+                    # to builds from later streams being included in earlier ones, see PROJQUAY-5312.
+                    if len(brew_tags) > 0 and product_version.name != "quay-3":
                         logger.debug(
                             "Found brew tags (%s) in product stream: %s",
                             brew_tags,

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -34,7 +34,7 @@ def fetch_unprocessed_cdn_relations(
     else:
         created_dt = get_last_success_for_task("corgi.tasks.pulp.fetch_unprocessed_cdn_relations")
     return fetch_unprocessed_relations(
-        ProductComponentRelation.Type.CDN_REPO,
+        relation_type=ProductComponentRelation.Type.CDN_REPO,
         force_process=force_process,
         created_since=created_dt,
     )

--- a/corgi/tasks/yum.py
+++ b/corgi/tasks/yum.py
@@ -35,7 +35,7 @@ def fetch_unprocessed_yum_relations(
     else:
         created_dt = get_last_success_for_task("corgi.tasks.yum.fetch_unprocessed_yum_relations")
     return fetch_unprocessed_relations(
-        ProductComponentRelation.Type.YUM_REPO,
+        relation_type=ProductComponentRelation.Type.YUM_REPO,
         force_process=force_process,
         created_since=created_dt,
     )


### PR DESCRIPTION
Fixes bad linking between product streams and variants. The variant 8Base-Quay-3 for example was reused in both the quay-3.8 and quay-3.6 product streams. We can determine what's in those stream by using brew tags only. We don't need the variant, so I removed the problem linking for that Product Version, and also 4 others as explained in CORGI-546.

This change also comes with a script which cleans up the bad data produced by this bug. I verified it worked for the 8Base-Quay-3 variant. See CORGI-546 for the script.