### PR TITLE
CORGI-576: Don't report unreliable / human-provided upstream URLs for RPMs

### DIFF
--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -11,7 +11,7 @@
     "documentDescribes": [
         "SPDXRef-{{obj.uuid}}"
     ],
-    "documentNamespace": "https://access.redhat.com/security/data/manifest/spdx/{{obj.name|escapejs}}-{{obj.uuid}}",
+    "documentNamespace": "https://access.redhat.com/security/data/sbom/beta/spdx/{{obj.name|escapejs}}-{{obj.uuid}}",
     "name": "{{obj.name|escapejs}}",
     "packages": [
       {% block packages %}{% endblock %}

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -10,7 +10,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if component.related_url %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
@@ -32,7 +32,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if obj.related_url %}"{{obj.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if obj.related_url and obj.type != obj.Type.RPM %}"{{obj.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -11,7 +11,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if component.related_url %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
@@ -33,7 +33,7 @@
             }
         ],
         "filesAnalyzed": false,
-        "homepage": {% if provided.related_url %}"{{provided.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+        "homepage": {% if provided.related_url and provided.type != provided.Type.RPM %}"{{provided.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
         "licenseConcluded": {% if provided.license_concluded %}"{{provided.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
         "licenseDeclared": {% if provided.license_declared %}"{{provided.license_declared}}"{% else %}"NOASSERTION"{% endif %},


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review this fix for a few internal URLs in manifests. Manifest generation is currently broken in stage, so I can't verify where these problematic / internal URLs (mentioned in ticket) are coming from or if this PR fixes all the issues. But this should fix at least one known issue, and matches what we discussed in a previous meeting.

EDIT: The example URL mentioned in the ticket is not actaully an internal URL. I can resolve it off VPN, just was having DNS issues when I first checked it. I think we still want to exclude these RPM upstream URLs though since they can be literally anything and there's no quality control or standards here.