### PR TITLE
CORGI-336: Stop reporting internal ofuris that don't map to other IDs

### DIFF
--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -46,19 +46,14 @@
     },{% endfor %}
     {
         "copyrightText": "NOASSERTION",
-        "downloadLocation": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",{% if obj.cpes %}
         "externalRefs": [{% for cpe in obj.cpes %}
             {
                 "referenceCategory": "SECURITY",
                 "referenceLocator": "{{cpe}}",
                 "referenceType": "cpe22Type"
-            },{% endfor %}
-            {{# We report ofuri since it can be used to link and compare two manifests for the same product, like CPE #}
-                "referenceCategory": "SECURITY",
-                "referenceLocator": "cpe:/{{obj.ofuri}}",
-                "referenceType": "cpe22Type"
-            }
-        ],
+            }{% if not forloop.last %},{% endif %}{% endfor %}
+        ],{% endif %}
         "filesAnalyzed": false,
         "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
         "licenseComments": "Licensing information is provided for individual components only at this time.",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -194,9 +194,8 @@ def test_product_manifest_properties():
 
     assert product_data["SPDXID"] == f"SPDXRef-{stream.uuid}"
     assert product_data["name"] == stream.name
-    if stream.cpes:
-        assert product_data["externalRefs"][0]["referenceLocator"] == stream.cpes[0]
-    assert product_data["externalRefs"][-1]["referenceLocator"] == f"cpe:/{stream.ofuri}"
+    for index, cpe in enumerate(stream.cpes):
+        assert product_data["externalRefs"][index]["referenceLocator"] == cpe
 
     document_describes_product = {
         "relatedSpdxElement": f"SPDXRef-{stream.uuid}",


### PR DESCRIPTION
@mprpic Quick thumbs-up please, or let me know if you think we should continue to report the ofuri for internal customers. The CPE is already reported in the manifest when present, we just have some other bug that causes it to never be loaded.

Since you'll add the CPEs manually, I'll investigate + fix that later. Next up is the filter to report only released components instead of all components.