### PR TITLE
CORGI-587: Fix timeouts when collecting static files

### DIFF
--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -44,6 +44,7 @@ def cpu_update_ps_manifest(product_stream: str):
     base=Singleton,
     autoretry_for=RETRYABLE_ERRORS,
     retry_kwargs=RETRY_KWARGS,
+    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
 def collect_static():
     call_command("collectstatic", verbosity=1, interactive=False)


### PR DESCRIPTION
This is a pretty simple change, but I'm also not sure it will actually fix this bug. So I'm going to merge this now, then check again tomorrow to see if we still have any pre-generated manifests with truncated data.