### PR TITLE
CORGI-592 refresh build/component product taxonomy after creating a new relation

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -495,15 +495,22 @@ def load_brew_tags() -> None:
     for ps in ProductStream.objects.get_queryset():
         build_type = BUILD_TYPE
         brew = Brew(BUILD_TYPE)
+        refresh_task = slow_fetch_modular_build
         # This should really be a property in Product Definitions
         if settings.COMMUNITY_MODE_ENABLED and ps.name == "openstack-rdo":
             brew = Brew(SoftwareBuild.Type.CENTOS)
             build_type = SoftwareBuild.Type.CENTOS
+            refresh_task = slow_fetch_brew_build
         for brew_tag, inherit in ps.brew_tags.items():
             # Always load all builds in tag when saving relations
             builds = brew.get_builds_with_tag(brew_tag, inherit=inherit, latest=False)
             no_of_created = create_relations(
-                builds, build_type, brew_tag, ps.name, ProductComponentRelation.Type.BREW_TAG
+                builds,
+                build_type,
+                brew_tag,
+                ps.name,
+                ProductComponentRelation.Type.BREW_TAG,
+                refresh_task,
             )
             logger.info("Saving %s new builds for %s", no_of_created, brew_tag)
 

--- a/corgi/tasks/pulp.py
+++ b/corgi/tasks/pulp.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from config.celery import app
 from corgi.collectors.pulp import Pulp
 from corgi.core.models import Channel, ProductComponentRelation, SoftwareBuild
-from corgi.tasks.brew import fetch_unprocessed_relations
+from corgi.tasks.brew import fetch_unprocessed_relations, slow_fetch_modular_build
 from corgi.tasks.common import (
     RETRY_KWARGS,
     RETRYABLE_ERRORS,
@@ -63,6 +63,7 @@ def slow_setup_pulp_rpm_relations(channel, variant):
         channel,
         variant,
         ProductComponentRelation.Type.CDN_REPO,
+        slow_fetch_modular_build,
     )
     if no_of_relations > 0:
         logger.info("Created %s new relations for SRPMs in %s", no_of_relations, channel)
@@ -77,6 +78,7 @@ def slow_setup_pulp_module_relations(channel, variant):
         channel,
         variant,
         ProductComponentRelation.Type.CDN_REPO,
+        slow_fetch_modular_build,
     )
     if no_of_relations > 0:
         logger.info("Created %s new relations for rhel_modules in %s", no_of_relations, channel)

--- a/corgi/tasks/rhel_compose.py
+++ b/corgi/tasks/rhel_compose.py
@@ -44,6 +44,7 @@ def save_compose(stream_name) -> None:
                 compose_id,
                 stream_name,
                 ProductComponentRelation.Type.COMPOSE,
+                slow_fetch_modular_build,
             )
     logger.info("Created %s new relations for stream %s", no_of_relations, stream_name)
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,0 +1,53 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from corgi.core.models import ProductComponentRelation, SoftwareBuild
+from corgi.tasks.brew import slow_fetch_brew_build, slow_fetch_modular_build
+from corgi.tasks.common import create_relations
+
+from .factories import ProductStreamFactory, SoftwareBuildFactory
+
+logger = logging.getLogger()
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.django_db(databases=("default", "read_only"), transaction=True),
+]
+
+
+@patch("corgi.tasks.brew.slow_fetch_brew_build.delay")
+@patch("corgi.tasks.brew.slow_fetch_modular_build.delay")
+def test_update_products_after_relation_creation(fetch_modular_build_task, fetch_brew_build_task):
+    """This tests that we always call slow_fetch_*_build task after creating a relation which
+    calls save_product_taxonomy on the SoftwareBuild and it's child components to update the
+    product taxonomy based on the newly created relation"""
+    stream = ProductStreamFactory()
+    sb = SoftwareBuildFactory(build_type=SoftwareBuild.Type.BREW)
+
+    create_relations(
+        (sb.build_id,),
+        SoftwareBuild.Type.BREW,
+        "mock-brew-tag",
+        stream.name,
+        ProductComponentRelation.Type.BREW_TAG,
+        slow_fetch_modular_build,
+    )
+
+    fetch_modular_build_task.assert_called_once()
+
+    # For CENTOS builds we don't call fetch_modular_build, but slow_fetch_brew build directly
+    # because the openstack-rdo product stream doesn't use modular builds and the collector models
+    # still use build_id as a primary key, so they could overlap with Fedora builds
+    sb = SoftwareBuildFactory(build_type=SoftwareBuild.Type.CENTOS)
+
+    create_relations(
+        (sb.build_id,),
+        SoftwareBuild.Type.CENTOS,
+        "cloud8s-openstack-xena-release",
+        stream.name,
+        ProductComponentRelation.Type.BREW_TAG,
+        slow_fetch_brew_build,
+    )
+
+    fetch_brew_build_task.assert_called_once()

--- a/tests/test_rhel_compose.py
+++ b/tests/test_rhel_compose.py
@@ -142,8 +142,9 @@ def mock_fetch_rpm_data(compose_url, variants):
 
 
 @pytest.mark.django_db
+@patch("corgi.tasks.brew.slow_fetch_modular_build.delay")
 @patch("corgi.collectors.rhel_compose.RhelCompose._fetch_rpm_data", new=mock_fetch_rpm_data)
-def test_save_compose(requests_mock):
+def test_save_compose(mock_fetch_modular_build, requests_mock):
     composes = {f"{base_url}/rhel-8/rel-eng/RHEL-8/RHEL-8.4.0-RC-1.2/compose": ["AppStream"]}
     compose_url = next(iter(composes))
     for path in ["composeinfo", "rpms", "osbs", "modules"]:


### PR DESCRIPTION
In CORGI-592 it was discovered that if a SoftwareBuild was created before we created a ProductComponentRelation for that build we did not update the build and it's related components product taxonomy.

This updates the create_relation function to accept a callback function to be called when a new relation is created. The callback function then is responsible for calling SoftwareBuild.save_product_taxonomy function for that build. We call that from slow_fetch_brew_build even if a SoftwareBuild object for the build already exists.

The reason for not calling SoftwareBuild.save_product_taxonomy directly in create_relation is too allow flexibility in how we reprocess builds.  In also ensures that any modules are represented correctly as components and the component taxonomy is still up to date.