### PR TITLE
CORGI-591: Add filter for released components

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,7 @@ test-performance:
     - $DNF_WITH_OPTIONS install $RPM_REQUIREMENTS
     - python3.9 -m pip install tox
     - tox -e corgi -- -m performance --no-cov
-  allow_failure: True
+  allow_failure: true
 
 mypy:
   stage: test

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -105,6 +105,7 @@ class ComponentFilter(FilterSet):
         qs: QuerySet[Component], _name: str, value: bool
     ) -> QuerySet[Component]:
         """Show only GOLANG components that are Go modules, and hide Go packages"""
+        # TODO: Probably should be added to ComponentQuerySet instead of here
         if value in EMPTY_VALUES:
             # User gave an empty ?param= so return the unfiltered queryset
             return qs

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -216,6 +216,19 @@ class StatusViewSet(GenericViewSet):
         )
 
 
+@extend_schema(
+    request=None,
+    responses={
+        200: {
+            "type": "object",
+            "properties": {
+                "oidc_enabled": {"type": "string"},
+                "user": {"type": "string"},
+                "auth": {"type": "string"},
+            },
+        }
+    },
+)
 @api_view(["GET"])
 @authentication_classes([OIDCAuthentication])
 @permission_classes([IsAuthenticated])
@@ -241,6 +254,17 @@ class ControlledAccessTestView(APIView):
     permission_classes = [RedHatRolePermission]
     roles_permitted = ["prodsec-dev"]
 
+    @extend_schema(
+        request=None,
+        responses={
+            200: {
+                "type": "object",
+                "properties": {
+                    "user": {"type": "string"},
+                },
+            }
+        },
+    )
     def get(self, request, format=None):
         content = {"user": str(request.user)}
         return Response(content)

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -19,7 +19,7 @@ from corgi.core.models import Component, SoftwareBuild
 
 logger = logging.getLogger(__name__)
 
-ADVISORY_REGEX = re.compile(r"RH\wA-[12]\d{3}:\d{4,6}")
+ADVISORY_REGEX = re.compile(r"RH[BES]A-[12]\d{3}:\d{4,6}")
 
 
 class BrewBuildTypeNotFound(Exception):
@@ -730,7 +730,8 @@ class Brew:
         return component
 
     @classmethod
-    def _extract_advisory_ids(cls, build_tags: list) -> list:
+    def _extract_advisory_ids(cls, build_tags: list[str]) -> list[str]:
+        """From a Brew build's list of tags, return any errata IDs with -released stripped"""
         advisory_ids = set()
         for tag in build_tags:
             match = ADVISORY_REGEX.match(tag)

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -3,7 +3,7 @@ import logging
 import re
 import uuid as uuid
 from abc import abstractmethod
-from typing import Any, Union
+from typing import Any, Iterator, Union
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
@@ -991,7 +991,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
     # sources is the inverse of provides. One container can provide many RPMs
     # and one RPM can have many different containers as a source (as well as modules and SRPMs)
     sources = models.ManyToManyField("Component", related_name="provides")
-    provides: models.ManyToManyField
+    provides: models.Manager["Component"]
 
     # Specify related_query_name to add e.g. component field
     # that can be used to filter from a cnode to its related component
@@ -1399,7 +1399,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         self.sources.set(self.get_sources_nodes(using="default"))
 
     @property
-    def provides_queryset(self, using: str = "read_only") -> QuerySet["Component"]:
+    def provides_queryset(self, using: str = "read_only") -> Iterator["Component"]:
         """Return the "provides" queryset using the read-only DB, for use in templates"""
         return self.provides.get_queryset().using(using).iterator()
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -922,6 +922,18 @@ def get_product_details(variant_names: tuple[str], stream_names: list[str]) -> d
 class ComponentQuerySet(models.QuerySet):
     """Helper methods to filter QuerySets of Components"""
 
+    def released_components(self, include: bool = True) -> models.QuerySet["Component"]:
+        """Show only released components by default, or unreleased components if include=False"""
+        # TODO: I could make below into separate ArrayFields on the SoftwareBuild model
+        #  like brew_tags and released_errata, but this is all Brew-specific
+        #  it doesn't make sense for other build systems
+        empty_released_errata = Q(software_build__meta_attr__released_errata_tags=())
+        if include:
+            # Truthy values return the excluded queryset (only released components)
+            return self.exclude(empty_released_errata)
+        # Falsey values return the filtered queryset (only unreleased components)
+        return self.filter(empty_released_errata)
+
     def root_components(self, include: bool = True) -> models.QuerySet["Component"]:
         """Show only root components by default, or only non-root components if include=False"""
         if include:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -920,11 +920,23 @@ def get_product_details(variant_names: tuple[str], stream_names: list[str]) -> d
 
 
 class ComponentQuerySet(models.QuerySet):
-    def srpms(self) -> models.QuerySet["Component"]:
-        return self.filter(SRPM_CONDITION)
+    """Helper methods to filter QuerySets of Components"""
 
-    def root_components(self) -> models.QuerySet["Component"]:
-        return self.filter(ROOT_COMPONENTS_CONDITION)
+    def root_components(self, include: bool = True) -> models.QuerySet["Component"]:
+        """Show only root components by default, or only non-root components if include=False"""
+        if include:
+            # Truthy values return the filtered queryset (only root components)
+            return self.filter(ROOT_COMPONENTS_CONDITION)
+        # Falsey values return the excluded queryset (only non-root components)
+        return self.exclude(ROOT_COMPONENTS_CONDITION)
+
+    def srpms(self, include: bool = True) -> models.QuerySet["Component"]:
+        """Show only source RPMs by default, or only non-SRPMs if include=False"""
+        if include:
+            # Truthy values return the filtered queryset (only SRPM components)
+            return self.filter(SRPM_CONDITION)
+        # Falsey values return the excluded queryset (only non-SRPM components)
+        return self.exclude(SRPM_CONDITION)
 
 
 class Component(TimeStampedModel, ProductTaxonomyMixin):

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -124,11 +124,8 @@ def slow_fetch_brew_build(
     if not build_meta["errata_tags"]:
         logger.info("no errata tags")
     else:
-        if isinstance(build_meta["errata_tags"], str):
-            slow_load_errata.delay(build_meta["errata_tags"], force_process=force_process)
-        else:
-            for e in build_meta["errata_tags"]:
-                slow_load_errata.delay(e, force_process=force_process)
+        for e in build_meta["errata_tags"]:
+            slow_load_errata.delay(e, force_process=force_process)
 
     build_ids = component.get("nested_builds", ())
     logger.info("Fetching brew builds for (%s, %s)", build_ids, build_type)

--- a/openapi.yml
+++ b/openapi.yml
@@ -378,6 +378,11 @@ paths:
         name: release
         schema:
           type: string
+      - in: query
+        name: root_components
+        schema:
+          type: boolean
+        description: Show only root components (source RPMs, index container images)
       - name: search
         required: false
         in: query

--- a/openapi.yml
+++ b/openapi.yml
@@ -379,6 +379,11 @@ paths:
         schema:
           type: string
       - in: query
+        name: released_components
+        schema:
+          type: boolean
+        description: Show only released components
+      - in: query
         name: root_components
         schema:
           type: boolean

--- a/openapi.yml
+++ b/openapi.yml
@@ -13,7 +13,18 @@ paths:
       - authentication_status
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  oidc_enabled:
+                    type: string
+                  user:
+                    type: string
+                  auth:
+                    type: string
+          description: ''
   /api/controlled_access_test:
     get:
       operationId: controlled_access_test_retrieve
@@ -24,7 +35,14 @@ paths:
       - controlled_access_test
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    type: string
+          description: ''
   /api/healthy:
     get:
       operationId: healthy_retrieve

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,28 @@ def test_component_detail(client, api_path):
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+def test_root_components_filter(client, api_path):
+    ComponentFactory(name="srpm", type="RPM", arch="src")
+    ComponentFactory(name="binary_rpm", type="RPM", arch="x86_64")
+
+    response = client.get(f"{api_path}/components")
+    assert response.status_code == 200
+    assert response.json()["count"] == 2
+
+    response = client.get(f"{api_path}/components?root_components=True")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+    assert response["results"][0]["name"] == "srpm"
+
+    response = client.get(f"{api_path}/components?root_components=False")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+    assert response["results"][0]["name"] == "binary_rpm"
+
+
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_detail_unscanned_filter(client, api_path):
     ComponentFactory(name="copyright", copyright_text="test")
     ComponentFactory(name="license", license_concluded_raw="test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,30 @@ def test_component_detail(client, api_path):
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+def test_released_components_filter(client, api_path):
+    released_build = SoftwareBuildFactory(meta_attr={"released_errata_tags": ["RHBA-2023:1234"]})
+    unreleased_build = SoftwareBuildFactory(meta_attr={"released_errata_tags": []})
+    ComponentFactory(name="released", software_build=released_build)
+    ComponentFactory(name="unreleased", software_build=unreleased_build)
+
+    response = client.get(f"{api_path}/components")
+    assert response.status_code == 200
+    assert response.json()["count"] == 2
+
+    response = client.get(f"{api_path}/components?released_components=True")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+    assert response["results"][0]["name"] == "released"
+
+    response = client.get(f"{api_path}/components?released_components=False")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+    assert response["results"][0]["name"] == "unreleased"
+
+
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_root_components_filter(client, api_path):
     ComponentFactory(name="srpm", type="RPM", arch="src")
     ComponentFactory(name="binary_rpm", type="RPM", arch="x86_64")

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -958,3 +958,28 @@ def test_load_unprocessed_relations_filters(mock_fetch_modular_task):
         )
         == 0
     )
+
+
+def test_extract_advisory_ids():
+    """Test that we discover only errata / advisory names from a list of Brew build tag names"""
+    brew = Brew(BUILD_TYPE)
+    tags = [
+        "stream-released",
+        "RHBA-2023:1234",
+        "RHEA-2023:12345",
+        "RHSA-2023:123456",
+        "RHSA-2023:1234567",
+        "RHXA-2023:1234",
+    ]
+    result = brew._extract_advisory_ids(tags)
+    # Only RHBA, RHEA, or RHSA is accepted, not other tags or RHXA
+    assert result == tags[1:5]
+
+
+def test_parse_advisory_ids():
+    """Test that we discover only released errata from a list of errata / advisory names"""
+    brew = Brew(BUILD_TYPE)
+    errata_tags = ["RHBA-2023:1234", "RHEA-2023:12345", "RHSA-2023:123456", "RHSA-2023:1234567"]
+    result = brew._parse_advisory_ids(errata_tags)
+    # Only 4-digit IDs like 1234 are released
+    assert result == errata_tags[:1]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,4 +1,5 @@
 import timeit
+from json import JSONDecodeError
 from urllib.parse import quote_plus
 
 import pytest
@@ -67,6 +68,7 @@ def display_manifest_with_many_components() -> dict:
     return response_json
 
 
+@pytest.mark.xfail(raises=JSONDecodeError, reason="CORGI-587 truncates generated files")
 def test_displaying_pregenerated_manifest() -> None:
     """Test that displaying a pre-generated stream manifest with many components is not slow"""
     # Slow manifests and web pod restarts (OoM) were fixed


### PR DESCRIPTION
@mprpic Quick review please. I still need to add tests, but if this looks sane I'll manually run the same logic I added to the Brew collector. That will process the list of tags on each build and figure out which are released errata IDs, then update the build's meta_attr with this list.

Once this is merged, I'll find the latest builds in some stream and update only those, then use the API filters here to confirm their components show up as "released". Once I have a few builds updated and working, I'll submit another PR for the Celery task bits and to make manifests use this filter.