### PR TITLE
CORGI-591: Make manifests use filter for released components

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -748,7 +748,11 @@ class Brew:
         # tags in Brew also have a -released, -dropped, or -pending suffix
         # but our ADVISORY_REGEX strips this to get just the friendly advisory name
 
-        return [errata_tag for errata_tag in errata_tags if len(errata_tag.split(":")[-1]) == 4]
+        return sorted(
+            errata_tag
+            for errata_tag in errata_tags
+            if len(errata_tag.split(":", maxsplit=1)[-1]) == 4
+        )
 
     @staticmethod
     def get_module_build_data(build_info: dict) -> dict:

--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -67,11 +67,12 @@ class ProductManifestFile(ManifestFile):
     def render_content(self) -> str:
 
         latest_components = self.obj.get_latest_components()  # type: ignore[attr-defined]
+        released_components = latest_components.released_components()
         distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {
             "obj": self.obj,
-            "latest_components": latest_components,
+            "released_components": released_components,
             "distinct_provides": distinct_provides,
         }
         content = render_to_string(self.file_name, kwargs_for_template)

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -645,7 +645,7 @@ class ProductStream(ProductModel):
         component_name: str = "",
         strict_search: bool = False,
         using: str = "read_only",
-    ) -> QuerySet["Component"]:
+    ) -> "ComponentQuerySet":
         """Return root components from latest builds, using specified DB (read-only by default."""
         if component_name:
             cond = {}
@@ -696,6 +696,7 @@ class ProductStream(ProductModel):
         for use in templates"""
         unique_provides = (
             self.get_latest_components()
+            .released_components()
             .values_list("provides__pk", flat=True)
             .distinct()
             .order_by("provides__pk")

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,5 +1,5 @@
 {# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}
-{% block packages %}{% for component in latest_components %}
+{% block packages %}{% for component in released_components %}
     {
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
@@ -85,7 +85,7 @@
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{obj.version}}"
     }
-{% endblock packages %}{% block relationships %}{% for component in latest_components %}{% for node_type, node_id in component.get_provides_nodes_queryset %}
+{% endblock packages %}{% block relationships %}{% for component in released_components %}{% for node_type, node_id in component.get_provides_nodes_queryset %}
         {
           "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
           "relationshipType": {% if node_type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -965,15 +965,16 @@ def test_extract_advisory_ids():
     brew = Brew(BUILD_TYPE)
     tags = [
         "stream-released",
-        "RHBA-2023:1234",
-        "RHEA-2023:12345",
-        "RHSA-2023:123456",
-        "RHSA-2023:1234567",
-        "RHXA-2023:1234",
+        "RHBA-2023:1234-released",
+        "RHEA-2023:12345-pending",
+        "RHSA-2023:123456-dropped",
+        "RHSA-2023:1234567-notarealthingyet",
+        "RHXA-2023:1234-released",
     ]
     result = brew._extract_advisory_ids(tags)
     # Only RHBA, RHEA, or RHSA is accepted, not other tags or RHXA
-    assert result == tags[1:5]
+    # Suffixes like -released are stripped
+    assert result == [tag.rsplit("-", maxsplit=1)[0] for tag in tags[1:5]]
 
 
 def test_parse_advisory_ids():


### PR DESCRIPTION
@mprpic No rush to look at this. I checked some OpenShift data in the API and saw the filter appeared to be working properly, so I've added the same filtering to our ProductStream manifest templates. 