### PR TITLE
Enhance get_provides, get_sources and get_upstreams to use include/exclude fields

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -405,20 +405,51 @@ class ComponentSerializer(ProductTaxonomySerializer):
     def get_link(instance: Component) -> str:
         return get_component_purl_link(instance.purl)
 
-    @staticmethod
-    def get_provides(instance: Component) -> list[dict[str, str]]:
+    # @staticmethod
+    def get_provides(self, instance: Component):
+        if self._next_level_include_fields.get(
+            "provides", []
+        ) or self._next_level_exclude_fields.get("provides", []):
+            context = {
+                "include_fields": self._next_level_include_fields.get("provides", []),
+                "exclude_fields": self._next_level_exclude_fields.get("provides", []),
+            }
+            serializer = ComponentSerializer(
+                instance=instance.provides, many=True, read_only=True, context=context
+            )
+            return serializer.data
         return get_component_data_list(
             instance.provides.values_list("purl", flat=True).using("read_only").iterator()
         )
 
-    @staticmethod
-    def get_sources(instance: Component) -> list[dict[str, str]]:
+    def get_sources(self, instance: Component):
+        if self._next_level_include_fields.get(
+            "sources", []
+        ) or self._next_level_exclude_fields.get("sources", []):
+            context = {
+                "include_fields": self._next_level_include_fields.get("sources", []),
+                "exclude_fields": self._next_level_exclude_fields.get("sources", []),
+            }
+            serializer = ComponentSerializer(
+                instance=instance.sources, many=True, read_only=True, context=context
+            )
+            return serializer.data
         return get_component_data_list(
             instance.sources.values_list("purl", flat=True).using("read_only").iterator()
         )
 
-    @staticmethod
-    def get_upstreams(instance: Component) -> list[dict[str, str]]:
+    def get_upstreams(self, instance: Component):
+        if self._next_level_include_fields.get(
+            "upstreams", []
+        ) or self._next_level_exclude_fields.get("upstreams", []):
+            context = {
+                "include_fields": self._next_level_include_fields.get("upstreams", []),
+                "exclude_fields": self._next_level_exclude_fields.get("upstreams", []),
+            }
+            serializer = ComponentSerializer(
+                instance=instance.upstreams, many=True, read_only=True, context=context
+            )
+            return serializer.data
         return get_component_data_list(
             instance.upstreams.values_list("purl", flat=True).using("read_only").iterator()
         )

--- a/openapi.yml
+++ b/openapi.yml
@@ -1463,25 +1463,13 @@ components:
               type: string
           readOnly: true
         sources:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              type: string
+          type: string
           readOnly: true
         provides:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              type: string
+          type: string
           readOnly: true
         upstreams:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              type: string
+          type: string
           readOnly: true
         manifest:
           type: string

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1012,6 +1012,38 @@ def test_oci_component_provides_sources_upstreams(client, api_path):
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
+    response = client.get(f"{api_path}/components/{root_comp.uuid}/taxonomy")
+    assert response.status_code == 200
+    assert len(response.json()[0]["provides"]) == 3
+
+    response = client.get(
+        f"{api_path}/components/{root_comp.uuid}?include_fields=provides.name,provides.purl"
+    )
+    assert response.status_code == 200
+    assert "upstreams" not in response.json()
+    assert len(response.json()["provides"]) == 2
+    for provide in response.json()["provides"]:
+        assert "name" in provide
+        assert "purl" in provide
+    response = client.get(
+        f"{api_path}/components/{root_comp.uuid}?include_fields=upstreams.name,upstreams.purl"
+    )
+    assert response.status_code == 200
+    assert "provides" not in response.json()
+    assert len(response.json()["upstreams"]) == 1
+    for provide in response.json()["upstreams"]:
+        assert "name" in provide
+        assert "purl" in provide
+    response = client.get(
+        f"{api_path}/components/{dep_comp.uuid}?include_fields=sources.name,sources.purl"
+    )
+    assert response.status_code == 200
+    assert "provides" not in response.json()
+    assert len(response.json()["sources"]) == 1
+    for provide in response.json()["sources"]:
+        assert "name" in provide
+        assert "purl" in provide
+
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_srpm_component_provides_sources_upstreams(client, api_path):
@@ -1150,3 +1182,36 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     response = client.get(f"{api_path}/components?upstreams={quote(upstream_comp.purl)}")
     assert response.status_code == 200
     assert response.json()["count"] == 3
+
+    response = client.get(f"{api_path}/components/{root_comp.uuid}/taxonomy")
+    assert response.status_code == 200
+    print(response.json())
+    assert len(response.json()[0]["provides"]) == 2
+
+    response = client.get(
+        f"{api_path}/components/{root_comp.uuid}?include_fields=provides.name,provides.purl"
+    )
+    assert response.status_code == 200
+    assert "upstreams" not in response.json()
+    assert len(response.json()["provides"]) == 1
+    for provide in response.json()["provides"]:
+        assert "name" in provide
+        assert "purl" in provide
+    response = client.get(
+        f"{api_path}/components/{root_comp.uuid}?include_fields=upstreams.name,upstreams.purl"
+    )
+    assert response.status_code == 200
+    assert "provides" not in response.json()
+    assert len(response.json()["upstreams"]) == 1
+    for provide in response.json()["upstreams"]:
+        assert "name" in provide
+        assert "purl" in provide
+    response = client.get(
+        f"{api_path}/components/{dep_comp.uuid}?include_fields=sources.name,sources.purl"
+    )
+    assert response.status_code == 200
+    assert "provides" not in response.json()
+    assert len(response.json()["sources"]) == 1
+    for provide in response.json()["sources"]:
+        assert "name" in provide
+        assert "purl" in provide


### PR DESCRIPTION
Components return provides, sources and upstream components. Currently we only return component purls but as we use internal component names (eg. ps_component) for raising affects it is cumbersome to get this rote list of purls and then have to separately retrieve associated internal component names.

This PR (unblocks griffon) extends include_filter, exclude_filter paradigm to get_provides, get_sources and get_upstreams we are able to select them - while retaining status quo if no include/exclude filters are provided.

```
http://localhost:9000/api/v1/components?name=grafana&include_fields=purl,link,sources.purl,sources.name
```

**Note** - need to figure out the right way to annotate this construct for openapi schema and mypy and add tests.