### PR TITLE
CORGI-608 increase timeout of load_brew_tags task

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -487,7 +487,12 @@ def save_node(
     return node
 
 
-@app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
+@app.task(
+    base=Singleton,
+    autoretry_for=RETRYABLE_ERRORS,
+    retry_kwargs=RETRY_KWARGS,
+    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
+)
 def load_brew_tags() -> None:
     for ps in ProductStream.objects.get_queryset():
         build_type = BUILD_TYPE


### PR DESCRIPTION
Let's see if this allows the job to complete, it hasn't completed in at least the last 5 days, and it's causing reconciliation results to drop over time for brew_tag based streams.