### PR TITLE
CORGI-591: Add automation to keep Brew / Corgi build tags in sync

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,8 @@ include:
   - project: 'product-security/dev/component-registry-ops'
     ref: "$CORGI_OPS_BRANCH"
     file: '/templates/gitlab/ansible-run.yml'
+  - project: 'enterprise-pipelines/gitlab-ci/includes'
+    file: 'SAST/sonarqube.yml'
 
 .common_ci_setup: &common_ci_setup
   - export LANG=en_US.UTF-8
@@ -59,6 +61,9 @@ deploy-prod:
   except:
     refs:
       - schedules
+
+sonarqube:
+  stage: test
 
 test:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,6 @@ test-performance:
     - $DNF_WITH_OPTIONS install $RPM_REQUIREMENTS
     - python3.9 -m pip install tox
     - tox -e corgi -- -m performance --no-cov
-  allow_failure: true
 
 mypy:
   stage: test

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -729,8 +729,8 @@ class Brew:
         # TODO: add more info
         return component
 
-    @classmethod
-    def _extract_advisory_ids(cls, build_tags: list[str]) -> list[str]:
+    @staticmethod
+    def extract_advisory_ids(build_tags: list[str]) -> list[str]:
         """From a Brew build's list of tags, return any errata IDs with -released stripped"""
         advisory_ids = set()
         for tag in build_tags:
@@ -740,7 +740,7 @@ class Brew:
         return sorted(advisory_ids)
 
     @staticmethod
-    def _parse_advisory_ids(errata_tags: list[str]) -> list[str]:
+    def parse_advisory_ids(errata_tags: list[str]) -> list[str]:
         """From a Brew build's list of Errata tags, return tags with released (4-digit) IDs"""
         # released errata always have 4-digit IDs, e.g. RHBA-2023:1234
         # unreleased errata have 5-digit IDs or greater
@@ -856,9 +856,9 @@ class Brew:
 
         # Add list of Brew tags for this build
         tags = self.koji_session.listTags(build_id)
-        build["tags"] = [tag["name"] for tag in tags]
-        build["errata_tags"] = self._extract_advisory_ids(build["tags"])
-        build["released_errata_tags"] = self._parse_advisory_ids(build["errata_tags"])
+        build["tags"] = sorted(set(tag["name"] for tag in tags))
+        build["errata_tags"] = self.extract_advisory_ids(build["tags"])
+        build["released_errata_tags"] = self.parse_advisory_ids(build["errata_tags"])
 
         # TODO: handle wrapper RPM builds:
         # brew buildID=1839210

--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -15,11 +15,13 @@ logger = logging.getLogger(__name__)
 class UMBReceiverHandler(MessagingHandler):
     """Handler to deal with received messages from UMB."""
 
-    def __init__(self, virtual_topic_address: str, selector: Optional[str] = None):
+    def __init__(self, virtual_topic_addresses: dict[str, str], selector: Optional[str] = None):
+        """Set up a handler that listens to many topics and processes messages from each"""
         super(UMBReceiverHandler, self).__init__()
 
-        # A virtual topic address determined by a specific listener.
-        self.virtual_topic_address = virtual_topic_address
+        # A mapping of virtual topic addresses to functions that handle topic messages
+        # as determined by a specific listener.
+        self.virtual_topic_addresses = virtual_topic_addresses
 
         # Set of URLs where UMB brokers are running. Use AMQP protocol port numbers only. See
         # specific URLs in settings; use env vars to select the appropriate broker.
@@ -48,16 +50,44 @@ class UMBReceiverHandler(MessagingHandler):
         # message that is accepted automatically (this is the default value).
         self.auto_settle = True
 
-    def on_start(self, event: Event):
+    def on_start(self, event: Event) -> None:
+        """Connect to UMB broker(s) and set up a receiver for each virtual topic address"""
         recv_opts = [self.selector] if self.selector is not None else []
         logger.info("Connecting to broker(s): %s", self.urls)
         conn = event.container.connect(urls=self.urls, ssl_domain=self.ssl_domain, heartbeat=500)
-        event.container.create_receiver(
-            conn, self.virtual_topic_address, name=None, options=recv_opts
-        )
+        for virtual_topic_address in self.virtual_topic_addresses:
+            event.container.create_receiver(
+                conn, virtual_topic_address, name=None, options=recv_opts
+            )
 
-    def on_message(self, event: Event):
-        logger.info("Received UMB event on %s: %s", self.virtual_topic_address, event.message.id)
+    def on_message(self, event: Event) -> None:
+        """Route message to a handler function, based on the virtual topic it was received on"""
+        logger.info("Received UMB event on %s: %s", event.message.address, event.message.id)
+        # Convert general topic address into specific address we listen on
+        address = event.message.address or ""
+        address = address.replace("topic://", f"Consumer.{settings.UMB_CONSUMER}.")
+
+        # Turn function name (str) into callable so we can pass event to it below
+        # We don't pass the callable itself because it needs a self arg
+        callback_name = self.virtual_topic_addresses.get(address, "")
+        callback_function = getattr(self, callback_name, None)
+
+        if not address:
+            raise ValueError(f"UMB event {event.message.id} had no address!")
+        elif callback_function:
+            callback_function(event)
+        else:
+            raise ValueError(
+                f"UMB event {event.message.id} had unrecognized address: {event.message.address}"
+            )
+
+
+class BrewUMBReceiverHandler(UMBReceiverHandler):
+    """Handle messages about completed Brew builds, tagged builds, and untagged builds"""
+
+    def handle_builds(self, event: Event) -> None:
+        """Handle messages about completed Brew builds"""
+        logger.info("Handling UMB event for completed builds: %s", event.message.id)
         message = json.loads(event.message.body)
         build_id = message["info"]["build_id"]
 
@@ -78,18 +108,29 @@ class UMBReceiverHandler(MessagingHandler):
 
 
 class UMBListener:
-    virtual_topic_address = ""
+    """Base class that listens for and handles messages on certain UMB topics"""
+
+    handler_class: Optional[MessagingHandler] = None
+    virtual_topic_addresses: dict[str, str] = {}
     selector = None
 
     @classmethod
     def consume(cls):
-        if not cls.virtual_topic_address:
-            raise NotImplementedError("Subclass must defined virtual topic address")
+        """Run a single message handler, which can listen to multiple virtual topic addresses"""
+        if not cls.handler_class or not cls.virtual_topic_addresses:
+            raise NotImplementedError(
+                "Subclass must define handler class and virtual topic address(es)"
+            )
 
-        logger.info("Starting consumer for virtual topic: %s", cls.virtual_topic_address)
-        handler = UMBReceiverHandler(virtual_topic_address=cls.virtual_topic_address)
+        logger.info("Starting consumer for virtual topic(s): %s", cls.virtual_topic_addresses)
+        handler = cls.handler_class(virtual_topic_addresses=cls.virtual_topic_addresses)
         Container(handler).run()
 
 
 class BrewUMBListener(UMBListener):
-    virtual_topic_address = f"Consumer.{settings.UMB_CONSUMER}.VirtualTopic.eng.brew.build.complete"
+    """Listen for messages about completed Brew builds, tagged builds, and untagged builds."""
+
+    handler_class = BrewUMBReceiverHandler
+    virtual_topic_addresses = {
+        f"Consumer.{settings.UMB_CONSUMER}.VirtualTopic.eng.brew.build.complete": "handle_builds",
+    }

--- a/corgi/monitor/management/commands/runmonitor.py
+++ b/corgi/monitor/management/commands/runmonitor.py
@@ -5,10 +5,11 @@ from corgi.monitor.consumer import BrewUMBListener
 
 
 class Command(BaseCommand):
+    """Run Brew UMB monitor to listen on events on configured virtual topics."""
 
-    help = "Run Brew UMB monitor to listen on events on configured virtual topics."
+    help = __doc__
 
-    def handle(self, *args, **options):
+    def handle(self, *args: str, **options: dict[str, str]) -> None:
         if settings.UMB_BREW_MONITOR_ENABLED:
             try:
                 BrewUMBListener.consume()

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -5,12 +5,13 @@ from typing import Optional
 from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.utils import dateformat, dateparse, timezone
 from django.utils.timezone import make_aware
 
 from config.celery import app
-from corgi.collectors.brew import Brew, BrewBuildTypeNotSupported
+from corgi.collectors.brew import ADVISORY_REGEX, Brew, BrewBuildTypeNotSupported
 from corgi.core.models import (
     Component,
     ComponentNode,
@@ -595,3 +596,40 @@ def fetch_unprocessed_brew_tag_relations(
         force_process=force_process,
         created_since=created_dt,
     )
+
+
+@app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
+def slow_update_brew_tags(build_id: str, tag_added: str = "", tag_removed: str = "") -> str:
+    """Update a build's list of tags in Corgi when they change in Brew"""
+    if not tag_added and not tag_removed:
+        raise ValueError("Must supply one tag to be added or removed")
+
+    with transaction.atomic():
+        build = SoftwareBuild.objects.filter(
+            build_id=build_id, build_type=SoftwareBuild.Type.BREW
+        ).first()
+        if not build:
+            logger.warning(f"Brew build with matching ID not ingested (yet?): {build_id}")
+            # Include warning message in Celery task result
+            # We don't raise an error here because there are potentially many builds
+            # that we haven't loaded, but which could have tags updated at any time
+            return f"Brew build with matching ID not ingested (yet?): {build_id}"
+
+        if tag_added:
+            tags = set(build.meta_attr["tags"])
+            tags.add(tag_added)
+            build.meta_attr["tags"] = sorted(tags)
+            errata_tag = ADVISORY_REGEX.match(tag_added)
+            if errata_tag:
+                # Below should automatically create new relations for this build / erratum
+                slow_load_errata.delay(errata_tag.group())
+        else:
+            build.meta_attr["tags"].remove(tag_removed)
+            # TODO: Clean up old relations for some build / erratum when a tag is removed
+
+        build.meta_attr["errata_tags"] = Brew.extract_advisory_ids(build.meta_attr["tags"])
+        build.meta_attr["released_errata_tags"] = Brew.parse_advisory_ids(
+            build.meta_attr["errata_tags"]
+        )
+        build.save()
+        return f"Added tag {tag_added} or removed tag {tag_removed} for build {build_id}"

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -76,8 +76,8 @@ def setup_periodic_tasks(sender, **kwargs):
         upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)
         upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
         upsert_cron_task("managed_services", "refresh_service_manifests", hour=10, minute=0)
-        upsert_cron_task("manifest", "collect_static", hour=11, minute=0)
-        upsert_cron_task("manifest", "update_manifests", hour=12, minute=0)
+        upsert_cron_task("manifest", "update_manifests", hour=11, minute=0)
+        upsert_cron_task("manifest", "collect_static", hour=12, minute=0)
         upsert_cron_task("monitoring", "email_failed_tasks", hour=12, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -38,6 +38,7 @@ The following values are populated as examples, but also allow to run in communi
 copy the URLs needed to run tests from the internal Gitlab server's CI variables:
 ```bash
 # Internal hostnames or URLs that appear in build metadata; used in tests
+export CORGI_APP_INTERFACE_URL
 export CORGI_TEST_DOWNLOAD_URL=https://download.example.com
 export CORGI_PULP_URL=https://rhsm-pulp.example.com/pulp
 # Not used in tests directly, but needed for tests to pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -182,7 +182,7 @@ def test_component_detail(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_filter(client, api_path):
-    older_component = ComponentFactory(release="9")
+    older_component = ComponentFactory(type=Component.Type.RPM, release="9")
     newer_component = ComponentFactory(
         type=older_component.type,
         name=older_component.name,

--- a/tests/test_app_interface.py
+++ b/tests/test_app_interface.py
@@ -8,7 +8,7 @@ from .factories import ProductStreamFactory
 pytestmark = pytest.mark.unit
 
 
-@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+@pytest.mark.django_db(databases=("default",))
 def test_metadata_fetch(requests_mock):
     example_response = {
         "data": {

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -962,7 +962,6 @@ def test_load_unprocessed_relations_filters(mock_fetch_modular_task):
 
 def test_extract_advisory_ids():
     """Test that we discover only errata / advisory names from a list of Brew build tag names"""
-    brew = Brew(BUILD_TYPE)
     tags = [
         "stream-released",
         "RHBA-2023:1234-released",
@@ -971,7 +970,7 @@ def test_extract_advisory_ids():
         "RHSA-2023:1234567-notarealthingyet",
         "RHXA-2023:1234-released",
     ]
-    result = brew._extract_advisory_ids(tags)
+    result = Brew.extract_advisory_ids(tags)
     # Only RHBA, RHEA, or RHSA is accepted, not other tags or RHXA
     # Suffixes like -released are stripped
     assert result == [tag.rsplit("-", maxsplit=1)[0] for tag in tags[1:5]]
@@ -979,8 +978,7 @@ def test_extract_advisory_ids():
 
 def test_parse_advisory_ids():
     """Test that we discover only released errata from a list of errata / advisory names"""
-    brew = Brew(BUILD_TYPE)
     errata_tags = ["RHBA-2023:1234", "RHEA-2023:12345", "RHSA-2023:123456", "RHSA-2023:1234567"]
-    result = brew._parse_advisory_ids(errata_tags)
+    result = Brew.parse_advisory_ids(errata_tags)
     # Only 4-digit IDs like 1234 are released
     assert result == errata_tags[:1]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,5 +1,4 @@
 import timeit
-from json import JSONDecodeError
 from urllib.parse import quote_plus
 
 import pytest
@@ -68,7 +67,6 @@ def display_manifest_with_many_components() -> dict:
     return response_json
 
 
-@pytest.mark.xfail(raises=JSONDecodeError, reason="CORGI-587 truncates generated files")
 def test_displaying_pregenerated_manifest() -> None:
     """Test that displaying a pre-generated stream manifest with many components is not slow"""
     # Slow manifests and web pod restarts (OoM) were fixed

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -12,7 +12,7 @@ from .factories import ProductStreamFactory, SoftwareBuildFactory
 logger = logging.getLogger()
 pytestmark = [
     pytest.mark.unit,
-    pytest.mark.django_db(databases=("default", "read_only"), transaction=True),
+    pytest.mark.django_db(databases=("default",)),
 ]
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+
+import pytest
+
+from corgi.collectors.brew import ADVISORY_REGEX
+from corgi.core.models import SoftwareBuild
+from corgi.tasks.brew import slow_update_brew_tags
+
+from .factories import SoftwareBuildFactory
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.django_db(databases=("default",)),
+]
+
+# Raw tags with some data quality issues - we assert these are cleaned up
+MISC_TAGS = ["stream-pending", "stream-candidate", "stream-pending", "RHXA-2023:1234-invalid"]
+ERRATA_TAGS = [
+    "RHBA-2023:1234567-pending",
+    "RHEA-2023:12345-dropped",
+    "RHBA-2023:1234567-alsopending",
+]
+RELEASED_TAGS = [
+    "RHSA-2023:12345-pending",
+    "RHEA-2023:1234-suffixignored",
+    "RHEA-2023:1234-suffixignored",
+]
+
+EXISTING_TAGS = MISC_TAGS + ERRATA_TAGS + RELEASED_TAGS
+CLEAN_TAGS = sorted(set(EXISTING_TAGS))
+CLEAN_ERRATA_TAGS = sorted(set(tag.rsplit("-", maxsplit=1)[0] for tag in EXISTING_TAGS[4:]))
+CLEAN_RELEASED_TAGS = sorted(set(tag.rsplit("-", maxsplit=1)[0] for tag in EXISTING_TAGS[8:]))
+
+# TODO: Needs much more
+# tag_added, is_errata, is_released
+test_tag_data = (
+    ("RHSA-2023:4321-released", True, True),
+    ("RHSA-2023:43210-dropped", True, False),
+    ("not_an_errata", False, False),
+)
+
+
+@pytest.mark.parametrize("tag_added,is_errata,is_released", test_tag_data)
+def test_slow_update_brew_tags_added(tag_added, is_errata, is_released):
+    """Test that builds have their tags and relations updated"""
+    build = SoftwareBuildFactory(
+        build_type=SoftwareBuild.Type.BREW, meta_attr={"tags": EXISTING_TAGS}
+    )
+
+    with patch("corgi.tasks.brew.slow_load_errata.delay") as mock_load_errata:
+        slow_update_brew_tags(build.build_id, tag_added=tag_added)
+    # Get updated build / tag data from DB after task saves it
+    build = SoftwareBuild.objects.get(build_id=build.build_id, build_type=SoftwareBuild.Type.BREW)
+
+    # Below are only modified if tag meets certain conditions
+    clean_errata_tags = CLEAN_ERRATA_TAGS
+    clean_released_tags = CLEAN_RELEASED_TAGS
+
+    if is_errata:
+        tag_without_suffix = tag_added.rsplit("-", maxsplit=1)[0]
+        assert ADVISORY_REGEX.match(tag_added).group() == tag_without_suffix
+        mock_load_errata.assert_called_once_with(tag_without_suffix)
+        clean_errata_tags = sorted(set(clean_errata_tags + [tag_without_suffix]))
+
+        if is_released:
+            tag_id = tag_without_suffix.rsplit(":", maxsplit=1)[-1]
+            assert len(tag_id) == 4 and tag_id.isdigit()
+            clean_released_tags = sorted(set(clean_released_tags + [tag_without_suffix]))
+    else:
+        mock_load_errata.assert_not_called()
+
+    # All tags end up in tags field
+    # Only tags matching ADVISORY_REGEX end up in errata_tags field (with -suffix stripped)
+    # Only released advisories (4-digit IDs) end up in released_errata_tags field
+    # All fields are automatically sorted and deduped
+    assert build.meta_attr["tags"] == sorted(set(CLEAN_TAGS + [tag_added]))
+    assert build.meta_attr["errata_tags"] == clean_errata_tags
+    assert build.meta_attr["released_errata_tags"] == clean_released_tags
+
+
+def test_slow_update_brew_tags_removed():
+    """Test that builds have their tags updated, but not relations"""
+    tag_removed = RELEASED_TAGS[-1]
+    tag_removed_without_suffix = tag_removed.rsplit("-", maxsplit=1)[0]
+    build = SoftwareBuildFactory(build_type=SoftwareBuild.Type.BREW, meta_attr={"tags": CLEAN_TAGS})
+
+    with patch("corgi.tasks.brew.slow_load_errata.delay") as mock_load_errata:
+        slow_update_brew_tags(build.build_id, tag_removed=tag_removed)
+    mock_load_errata.assert_not_called()
+
+    # Get updated build / tag data from DB after task saves it
+    build = SoftwareBuild.objects.get(build_id=build.build_id, build_type=SoftwareBuild.Type.BREW)
+
+    clean_tags = sorted(set(tag for tag in CLEAN_TAGS if tag != tag_removed))
+    clean_errata_tags = sorted(
+        set(tag for tag in CLEAN_ERRATA_TAGS if tag != tag_removed_without_suffix)
+    )
+    clean_released_tags = sorted(
+        set(tag for tag in CLEAN_RELEASED_TAGS if tag != tag_removed_without_suffix)
+    )
+
+    # All tags end up in tags field
+    # Only tags matching ADVISORY_REGEX end up in errata_tags field (with -suffix stripped)
+    # Only released advisories (4-digit IDs) end up in released_errata_tags field
+    # All fields are automatically sorted and deduped
+    assert build.meta_attr["tags"] == clean_tags
+    assert build.meta_attr["errata_tags"] == clean_errata_tags
+    assert build.meta_attr["released_errata_tags"] == clean_released_tags
+
+
+def test_slow_update_brew_tags_errors():
+    """Test that slow_update_brew_tags handles missing builds and missing tags"""
+    warning = slow_update_brew_tags("123", tag_added="123")
+    assert warning == "Brew build with matching ID not ingested (yet?): 123"
+
+    # meta_attr field for all builds always has tags key set to a list (on ingestion)
+    # no need to test missing tags key or values other than lists
+    build = SoftwareBuildFactory(build_type=SoftwareBuild.Type.BREW, meta_attr={"tags": []})
+    with pytest.raises(ValueError):
+        # Must supply either tag_added or tag_removed kwarg
+        slow_update_brew_tags(build.build_id)
+
+    with pytest.raises(ValueError):
+        # Raise an error if tag isn't found
+        # This shouldn't happen unless we failed to add the tag in the first place
+        # Probably worth reingesting at that point - explicit error reminds us to do so
+        slow_update_brew_tags(build.build_id, tag_removed="does_not_exist")

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ passenv =
     CORGI_DB_HOST_RO
     CORGI_DB_PORT
     # Internal hostnames or URLs that appear in build metadata; used in tests
+    CORGI_APP_INTERFACE_URL
     CORGI_TEST_DOWNLOAD_URL
     # Not used in tests directly, but needed for tests to pass
-    CORGI_APP_INTERFACE_URL
     CORGI_APP_STREAMS_LIFE_CYCLE_URL
     CORGI_BREW_URL
     CORGI_BREW_DOWNLOAD_ROOT_URL


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This change is needed to keep the tags up-to-date on Corgi builds whenever they change in Brew. Having up-to-date tags ensures that manifests always represent the latest released content for some stream and are never stale.

I added tests for the Celery task, but I'm not sure about the logic. Is it enough to call slow_load_errata() when errata tags get added to some build? Or is there something else I need to do, so that relations are created and the build is correctly linked to the erratum's variant?

I'm also not sure how to correctly clean up the relations, whenever some build has an errata tag removed. If someone has an easy idea for a solution, I can handle that as part of this MR. I could also file a backlog ticket, or we could avoid doing this at all if we never want to delete the relations (but that doesn't seem right).