### PR TITLE
make latest filter only return root components

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -68,7 +68,7 @@ class ProductManifestFile(ManifestFile):
 
         components = self.obj.components  # type: ignore[attr-defined]
         components = components.exclude(name__endswith="-container-source").using("read_only")
-        released_components = components.root_components().released_components().latest_components()
+        released_components = components.released_components().latest_components()
         distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -890,8 +890,10 @@ class ComponentQuerySet(models.QuerySet):
         )
 
     def filter_latest_nevra_by_name(self, component_name: str) -> str:
-        nevras = self.filter(name=component_name).values_list(
-            "nevra", "meta_attr__epoch", "version", "release"
+        nevras = (
+            self.root_components()
+            .filter(name=component_name)
+            .values_list("nevra", "meta_attr__epoch", "version", "release")
         )
         if nevras:
             # Get the latest NEVRA using python. This only works for valid RPM epoch/version/release

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -184,8 +184,8 @@ def test_component_detail(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_filter(client, api_path):
-    older_component = ComponentFactory(type=Component.Type.RPM, release="9")
-    newer_component = ComponentFactory(
+    older_component = SrpmComponentFactory(type=Component.Type.RPM, release="9")
+    newer_component = SrpmComponentFactory(
         type=older_component.type,
         name=older_component.name,
         version=older_component.version,

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -140,7 +140,6 @@ def test_slim_rpm_in_containers_manifest():
     # plus a source container which is shown in API but not in manifests
     released_components = (
         stream.components.exclude(name__endswith="-container-source")
-        .root_components()
         .released_components()
         .latest_components()
     )
@@ -212,9 +211,7 @@ def test_product_manifest_excludes_unreleased_components():
     manifest = json.loads(stream.manifest)
 
     # No released components linked to this product
-    num_components = len(
-        stream.components.root_components().released_components().latest_components()
-    )
+    num_components = len(stream.components.released_components().latest_components())
     assert num_components == 0
 
     num_provided = len(stream.provides_queryset)
@@ -249,9 +246,7 @@ def test_product_manifest_properties():
     manifest = json.loads(stream.manifest)
 
     # One component linked to this product
-    num_components = len(
-        stream.components.root_components().released_components().latest_components()
-    )
+    num_components = len(stream.components.released_components().latest_components())
     assert num_components == 1
 
     num_provided = len(stream.provides_queryset)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -806,6 +806,20 @@ def test_filter_latest_by_name():
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+def test_filter_latest_by_name_and_arch():
+    ps = ProductStreamFactory(name="rhel-7.9.z")
+    srpm_with_el = SrpmComponentFactory(name="sdb", version="1.2.1", release="21.el7")
+    srpm_with_el.productstreams.add(ps)
+    srpm = SrpmComponentFactory(name="sdb", version="1.2.1", release="21.el7", arch="x86_64")
+    srpm.productstreams.add(ps)
+    assert ps.components.filter_latest_nevra_by_name(component_name="sdb") == "sdb-1.2.1-21.el7.src"
+
+    # test no result
+    ps = ProductStreamFactory(name="rhel-7.7.z")
+    assert not ps.components.filter_latest_nevra_by_name(component_name="sdb")
+
+
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_filter_latest_by_name_modular():
     ps = ProductStreamFactory(name="certificate_system-10.2.z")
     modular_rpm_1 = SrpmComponentFactory(


### PR DESCRIPTION
This modifies the latest filter so that always filters root_component as well. Comparing components which are not root_components doesn't really makes sense for a few reasons:

- We are using RPM schematics to compare things, so comparing anything but RPM, or OCI types in the REDHAT namespace doesn't make sense.  
- All arches should be considered equivalent in terms of latest.

Leaving this in draft as I got a failing test locally:
```
>       assert manifest["relationships"][0] == provided_contained_by_component
E       AssertionError: assert {'relatedSpdx...32b765159d68'} == {'relatedSpdx...32b765159d68'}
E         Omitting 2 identical items, use -vv to show
E         Differing items:
E         {'relatedSpdxElement': 'SPDXRef-e24f6913-d568-4e9e-a359-570e53706ad3'} != {'relatedSpdxElement': 'SPDXRef-95582f58-12c8-4fdd-bf3e-86a8a72a2724'}
E         Use -v to get more diff

tests/test_manifests.py:200: AssertionError
```
Hopefully that is just a change in the order.