### PR TITLE
CORGI-609: add latest_components_by_stream) view

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -89,6 +89,10 @@ class ComponentFilter(FilterSet):
         method="filter_root_components",
         label="Show only root components (source RPMs, index container images)",
     )
+    latest_components_by_streams = BooleanFilter(
+        method="filter_latest_components_by_streams",
+        label="Show only latest components across product streams",
+    )
 
     missing_copyright = EmptyStringFilter(
         field_name="copyright_text",
@@ -184,6 +188,19 @@ class ComponentFilter(FilterSet):
         # Truthy values return the filtered queryset (only root components)
         # Falsey values return the excluded queryset (only non-root components)
         return queryset.root_components(include=value)
+
+    @staticmethod
+    def filter_latest_components_by_streams(
+        queryset: ComponentQuerySet, _name: str, value: bool
+    ) -> QuerySet["Component"]:
+        """Show only latest ROOT components in some queryset if user chose YES / NO"""
+        if value in EMPTY_VALUES:
+            # User gave an empty ?param= so return the unfiltered queryset
+            return queryset
+        # Else user gave a non-empty value
+        # Truthy values return the filtered queryset (only latest components)
+        # Falsey values return the excluded queryset (only older components)
+        return queryset.latest_components_by_streams(include=value)
 
 
 class ProductDataFilter(FilterSet):

--- a/openapi.yml
+++ b/openapi.yml
@@ -341,6 +341,11 @@ paths:
         schema:
           type: boolean
         description: Show only latest components
+      - in: query
+        name: latest_components_by_streams
+        schema:
+          type: boolean
+        description: Show only latest components across product streams
       - name: limit
         required: false
         in: query


### PR DESCRIPTION
Adds **?latest_components_by_stream=True** view which is used by downstream clients (like griffon).

For example, to return latest components with 'grafana' in the component internal name, across product streams
```
/api/v1/components?re_name=grafana&latest_components_by_streams=False&include_fields=purl,product_streams,namespace,arch,nvr&limit=200&namespace=REDHAT
```

**Note** - this isolates code path from latest_components which is probably safer.