### PR TITLE
temporarily skip broken performance test job because of CORGI-624

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ test-migrations:
     refs:
       - schedules
 
-test-performance:
+.test-performance:
   stage: test
   # Keep in sync with Dockerfile
   image: registry.redhat.io/ubi8/ubi


### PR DESCRIPTION
This hides the test-performance job in CI. We should re-enabled it once CORGI-624 is fixed.