### PR TITLE
CORGI-609: Fix latest filter regression

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ test-migrations:
     refs:
       - schedules
 
-.test-performance:
+test-performance:
   stage: test
   # Keep in sync with Dockerfile
   image: registry.redhat.io/ubi8/ubi

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -79,9 +79,6 @@ class ComponentFilter(FilterSet):
     re_upstreams = CharFilter(field_name="upstreams", lookup_expr="purl__regex")
 
     el_match = CharFilter(label="RHEL version for layered products", lookup_expr="icontains")
-    latest_components = BooleanFilter(
-        method="filter_latest_components", label="Show only latest components"
-    )
     released_components = BooleanFilter(
         method="filter_released_components", label="Show only released components"
     )
@@ -133,19 +130,6 @@ class ComponentFilter(FilterSet):
         method = qs.exclude if value is False else qs.filter
 
         return method(**{"meta_attr__go_component_type": "gomod"})
-
-    @staticmethod
-    def filter_latest_components(
-        queryset: ComponentQuerySet, _name: str, value: bool
-    ) -> QuerySet["Component"]:
-        """Show only latest components in some queryset if user chose YES / NO"""
-        if value in EMPTY_VALUES:
-            # User gave an empty ?param= so return the unfiltered queryset
-            return queryset
-        # Else user gave a non-empty value
-        # Truthy values return the filtered queryset (only latest components)
-        # Falsey values return the excluded queryset (only older components)
-        return queryset.latest_components(include=value)
 
     @staticmethod
     def filter_ofuri_or_name(

--- a/corgi/core/constants.py
+++ b/corgi/core/constants.py
@@ -2,6 +2,7 @@
     model constants
 """
 import re
+from typing import Union
 
 from django.db.models import Q
 
@@ -45,3 +46,6 @@ ROOT_COMPONENTS_CONDITION = SRPM_CONDITION | INDEX_CONTAINER_CONDITION
 # Regex for generating version_arr, release_arr and el_match fields
 RELEASE_VERSION_DELIM_RE = re.compile("[.,\\-,_,\\+]")
 EL_MATCH_RE = re.compile(".*el(\\d+)?[.,\\-,_]?(\\d+)?[.,\\-,_]?(\\d+)?(.*)")
+
+# Epoch can be 0, "0", or missing,
+EPOCH_TYPE = Union[int, str, None]

--- a/openapi.yml
+++ b/openapi.yml
@@ -337,11 +337,6 @@ paths:
         description: 'Include only specified fields in the response. Multiple values
           may be separated by commas. Example: `include_fields=software_build.build_id,name`'
       - in: query
-        name: latest_components
-        schema:
-          type: boolean
-        description: Show only latest components
-      - in: query
         name: latest_components_by_streams
         schema:
           type: boolean

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,31 +188,120 @@ def test_component_detail(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_filter(client, api_path):
-    older_component = ComponentFactory(type=Component.Type.RPM, release="9")
-    newer_component = ComponentFactory(
-        type=older_component.type,
-        name=older_component.name,
-        version=older_component.version,
-        release="10",
-        arch=older_component.arch,
-        software_build=older_component.software_build,
-    )
+    # Create many components so we have robust test data
+    # 2 components (1 older version, 1 newer version) for each name / arch pair in REDHAT namespace
+    # 12 REDHAT components across 6 pairs
+    # plus 2 UPSTREAM components per name for src architecture only, 4 upstreams total
+    # Overall 16 components, and latest filter should show 8 (newer, when on or older, when off)
+    components = {}
+    for name in "red", "blue":
+        for arch in "aarch64", "x86_64", "src":
+            older_component = ComponentFactory(
+                type=Component.Type.RPM,
+                namespace=Component.Namespace.REDHAT,
+                name=name,
+                version="9",
+                arch=arch,
+            )
+            # Create newer components with the same type, namespace, name, release, and arch
+            # But a different version and build
+            newer_component = ComponentFactory(
+                type=older_component.type,
+                namespace=older_component.namespace,
+                name=older_component.name,
+                version="10",
+                release=older_component.release,
+                arch=older_component.arch,
+            )
+            components[(name, arch)] = (older_component, newer_component)
+        # Create UPSTREAM components for src architecture only
+        # with the same type, name, and version as REDHAT src components
+        # but no release or software_build
+        older_upstream_component = ComponentFactory(
+            type=older_component.type,
+            namespace=Component.Namespace.UPSTREAM,
+            name=older_component.name,
+            version=older_component.version,
+            release="",
+            arch="noarch",
+            software_build=None,
+        )
+        newer_upstream_component = ComponentFactory(
+            type=newer_component.type,
+            namespace=older_upstream_component.namespace,
+            name=newer_component.name,
+            version=newer_component.version,
+            release=older_upstream_component.release,
+            arch=older_upstream_component.arch,
+            software_build=older_upstream_component.software_build,
+        )
+        components[(name, older_upstream_component.arch)] = (
+            older_upstream_component,
+            newer_upstream_component,
+        )
 
     response = client.get(f"{api_path}/components")
     assert response.status_code == 200
-    assert response.json()["count"] == 2
+    assert response.json()["count"] == 16
 
     response = client.get(f"{api_path}/components?latest_components=True")
     assert response.status_code == 200
     response = response.json()
-    assert response["count"] == 1
-    assert response["results"][0]["nevra"] == newer_component.nevra
+    assert response["count"] == 8
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][1].nevra
 
     response = client.get(f"{api_path}/components?latest_components=False")
     assert response.status_code == 200
     response = response.json()
-    assert response["count"] == 1
-    assert response["results"][0]["nevra"] == older_component.nevra
+    assert response["count"] == 8
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][0].nevra
+
+    # Also test latest_components filter when combined with root_components filter
+    # Note that order doesn't matter here, e.g. before CORGI-609 both of below gave 0 results:
+    # /api/v1/components?re_name=webkitgtk&root_components=True&latest_components=True
+    # /api/v1/components?re_name=webkitgtk&latest_components=True&root_components=True
+    #
+    # There are 17 root components in the above queryset:
+    # /api/v1/components?re_name=webkitgtk&root_components=True
+    # But the latest_components filter is always applied first, and previously chose a binary RPM
+    # So the source RPMs were filtered out, and the root_components filter had no data to report
+    # This is likely due to the order the filters are defined in (see corgi/api/filters.py)
+    # Fixed by CORGI-609, and this test makes sure the bug doesn't come back
+    response = client.get(f"{api_path}/components?root_components=True&latest_components=True")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 2
+    # Red and blue components with arch "src" each have 1 latest
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][1].nevra
+
+    response = client.get(f"{api_path}/components?root_components=True&latest_components=False")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 2
+    # Red and blue components with arch "src" each have 1 non-latest
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][0].nevra
+
+    response = client.get(f"{api_path}/components?root_components=False&latest_components=True")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 6
+    # Red and blue components for 2 arches each have 1 latest
+    # Red and blue components for upstream (non-root) each have 1 latest
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][1].nevra
+
+    response = client.get(f"{api_path}/components?root_components=False&latest_components=False")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 6
+    # Red and blue components for 2 arches each have 1 non-latest
+    # Red and blue components for upstream (non-root) each have 1 non-latest
+    for result in response["results"]:
+        assert result["nevra"] == components[(result["name"], result["arch"])][0].nevra
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -791,7 +791,7 @@ def test_queryset_ordering_fails():
         len(misordered_products.distinct("description"))
 
 
-@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+@pytest.mark.django_db
 def test_filter_latest_nevra_by_distinct_component():
     ps = ProductStreamFactory(name="rhel-7.9.z")
     srpm_with_el = SrpmComponentFactory(name="sdb", version="1.2.1", release="21.el7")
@@ -812,7 +812,7 @@ def test_filter_latest_nevra_by_distinct_component():
     )
 
 
-@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+@pytest.mark.django_db
 def test_filter_latest_nevra_by_distinct_component_modular():
     ps = ProductStreamFactory(name="certificate_system-10.2.z")
     modular_rpm_1 = SrpmComponentFactory(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -792,6 +792,116 @@ def test_queryset_ordering_fails():
 
 
 @pytest.mark.django_db
+def test_latest_components_queryset(client, api_path):
+    # Create many components so we have robust test data
+    # 2 components (1 older version, 1 newer version) for each name / arch pair in REDHAT namespace
+    # 12 REDHAT components across 6 pairs
+    # plus 2 UPSTREAM components per name for src architecture only, 4 upstreams total
+    # Overall 16 components, and latest queryset should show 8 (newer, when on or older, when off)
+    components = {}
+    for name in "red", "blue":
+        for arch in "aarch64", "x86_64", "src":
+            older_component = ComponentFactory(
+                type=Component.Type.RPM,
+                namespace=Component.Namespace.REDHAT,
+                name=name,
+                version="9",
+                arch=arch,
+            )
+            # Create newer components with the same type, namespace, name, release, and arch
+            # But a different version and build
+            newer_component = ComponentFactory(
+                type=older_component.type,
+                namespace=older_component.namespace,
+                name=older_component.name,
+                version="10",
+                release=older_component.release,
+                arch=older_component.arch,
+            )
+            components[(name, arch)] = (older_component, newer_component)
+        # Create UPSTREAM components for src architecture only
+        # with the same type, name, and version as REDHAT src components
+        # but no release or software_build
+        older_upstream_component = ComponentFactory(
+            type=older_component.type,
+            namespace=Component.Namespace.UPSTREAM,
+            name=older_component.name,
+            version=older_component.version,
+            release="",
+            arch="noarch",
+            software_build=None,
+        )
+        newer_upstream_component = ComponentFactory(
+            type=newer_component.type,
+            namespace=older_upstream_component.namespace,
+            name=newer_component.name,
+            version=newer_component.version,
+            release=older_upstream_component.release,
+            arch=older_upstream_component.arch,
+            software_build=older_upstream_component.software_build,
+        )
+        components[(name, older_upstream_component.arch)] = (
+            older_upstream_component,
+            newer_upstream_component,
+        )
+
+    assert Component.objects.count() == 16
+
+    latest_components = Component.objects.latest_components()
+    assert len(latest_components) == 8
+    for component in latest_components:
+        assert component.nevra == components[(component.name, component.arch)][1].nevra
+
+    non_latest_components = Component.objects.latest_components(include=False)
+    assert len(non_latest_components) == 8
+    for component in non_latest_components:
+        assert component.nevra == components[(component.name, component.arch)][0].nevra
+
+    # Also test latest_components queryset when combined with root_components queryset
+    # Note that order doesn't matter in the API, e.g. before CORGI-609 both of below gave 0 results:
+    # /api/v1/components?re_name=webkitgtk&root_components=True&latest_components=True
+    # /api/v1/components?re_name=webkitgtk&latest_components=True&root_components=True
+    #
+    # There are 17 root components in the above queryset:
+    # /api/v1/components?re_name=webkitgtk&root_components=True
+    # But the latest_components filter eas always applied first, and previously chose a binary RPM
+    # So the source RPMs were filtered out, and the root_components filter had no data to report
+    # This was likely due to the order the filters are defined in (see corgi/api/filters.py)
+    # Fixed by CORGI-609, and this test makes sure the bug doesn't come back
+    latest_root_components = Component.objects.latest_components().root_components()
+    assert len(latest_root_components) == 2
+    # Red and blue components with arch "src" each have 1 latest
+    for component in latest_root_components:
+        assert component.nevra == components[(component.name, component.arch)][1].nevra
+
+    non_latest_root_components = Component.objects.latest_components(
+        include=False
+    ).root_components()
+    assert len(non_latest_root_components) == 2
+    # Red and blue components with arch "src" each have 1 non-latest
+    for component in non_latest_root_components:
+        assert component.nevra == components[(component.name, component.arch)][0].nevra
+
+    latest_non_root_components = Component.objects.latest_components().root_components(
+        include=False
+    )
+    assert len(latest_non_root_components) == 6
+    # Red and blue components for 2 arches each have 1 latest
+    # Red and blue components for upstream (non-root) each have 1 latest
+    for component in latest_non_root_components:
+        assert component.nevra == components[(component.name, component.arch)][1].nevra
+
+    non_latest_non_root_components = Component.objects.latest_components(
+        include=False
+    ).root_components(include=False)
+    assert len(non_latest_non_root_components) == 6
+    # Red and blue components for 2 arches each have 1 non-latest
+    # Red and blue components for upstream (non-root) each have 1 non-latest
+    for component in non_latest_non_root_components:
+        assert component.nevra == components[(component.name, component.arch)][0].nevra
+
+
+@pytest.mark.django_db
 def test_filter_latest_nevra_by_distinct_component():
     ps = ProductStreamFactory(name="rhel-7.9.z")
     srpm_with_el = SrpmComponentFactory(name="sdb", version="1.2.1", release="21.el7")

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,4 +1,5 @@
 import timeit
+from json import JSONDecodeError
 from urllib.parse import quote_plus
 
 import pytest
@@ -67,6 +68,10 @@ def display_manifest_with_many_components() -> dict:
     return response_json
 
 
+@pytest.mark.xfail(
+    raises=JSONDecodeError,
+    reason="CORGI-634 truncates generated files when transferred with Gzip compression",
+)
 def test_displaying_pregenerated_manifest() -> None:
     """Test that displaying a pre-generated stream manifest with many components is not slow"""
     # Slow manifests and web pod restarts (OoM) were fixed


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review when you have time. The latest filter refactoring we needed for manifests uncovered a bug, which only happens when we have multiple namespace / arch values for the same component name.

Previously, we always filtered for root_components() first. So the namespace was always "REDHAT", and the arch was always "src" for source RPMs or "noarch" for index containers, and the bug never occurred.

During the refactoring, we decoupled the root_components() and latest_components() filters based on user requests. This lets users see the latest versions of binary RPMs and arch-specific containers directly, without having to first find the latest root component then look at its "provides" field.

That decoupling caused us to sometimes report a binary RPM as the only "latest" component, when we had both a source RPM and a binary RPM with the same NVR. If the user wanted to filter the results further, they might end up with no results (e.g. if they applied the root_components filter, but there are only non-root results here).

The fix is to just filter on all three of (namespace, name, arch), instead of only filtering on name, to decide which component is latest. Now we'll report three results (one for an upstream component, one for a source component, one for a binary component) that the user can filter further based on their needs (show only upstream or root or non-root components).

In the future, we may also want to filter on the major RHEL version for layered products. For example, el_match[0] == "8" or "9", so that users can see the latest version when the product is running on top of RHEL8 vs. the latest version when the product is running on top of RHEL9. Since the two base products have different support lifecycles, we've been asked previously to support showing only the components that are in a particular version of the base product.