### PR TITLE
CORGI-634 - add OIDC_EXEMPT_URLS setting

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -384,6 +384,7 @@ OIDC_OP_USER_ENDPOINT = os.getenv("CORGI_OIDC_OP_USER_ENDPOINT", "")
 OIDC_RP_CLIENT_ID = os.getenv("CORGI_OIDC_RP_CLIENT_ID", "")
 OIDC_RP_CLIENT_SECRET = os.getenv("CORGI_OIDC_RP_CLIENT_SECRET", "")
 OIDC_DRF_AUTH_BACKEND = "corgi.core.authentication.CorgiOIDCBackend"
+OIDC_EXEMPT_URLS = ["/static"]
 
 
 # UMB -- Unified Message Bus


### PR DESCRIPTION
All files served by static are being truncated to the same size ... regardless of underlying file size. At first we thought maybe this was to do with selecting wrong variation (gz or cached version) but the same issue occurs with staticfiles.json (which only has a single version).

As this is difficult to repro locally - this is a test PR to see if the new OIDC middleware (as this is what changed in the past 1-2 weeks) is interfering with any static file processing ... albeit we would have to inject a bunch of logging statements to make middleware process chain visible .. this seemed the easiest way to verify [**problem** or **no problem**].