### PR TITLE
CORGI-590: Fix manifesting for variants

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": "config/settings/dev.py",
         "hashed_secret": "6adfb183a4a2c94a2f92dab5ade762a47889a5a1",
         "is_verified": true,
-        "line_number": 30,
+        "line_number": 5,
         "is_secret": false
       }
     ],
@@ -282,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-14T20:10:12Z"
+  "generated_at": "2023-05-17T18:41:13Z"
 }

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -473,6 +473,7 @@ class ComponentSerializer(ProductTaxonomySerializer):
 
     @staticmethod
     def get_manifest(instance: Component) -> str:
+        """Get a manifest for a Component on demand / not pre-generated"""
         return get_model_id_link("components", instance.uuid, manifest=True)
 
     class Meta:
@@ -580,7 +581,9 @@ class ProductModelSerializer(ProductTaxonomySerializer):
         return instance.builds.count()
 
     @staticmethod
-    def get_manifest(instance: ProductStream) -> str:
+    def get_manifest(instance: ProductModel) -> str:
+        """Serve a pre-generated ProductStream manifest from the staticfiles directory
+        Override this for any non-ProductStream manifests"""
         if not instance.components.exists():
             return ""
         return f"{CORGI_STATIC_URL}{instance.name}-{instance.pk}.json"
@@ -755,10 +758,18 @@ class ProductVariantSerializer(ProductModelSerializer):
     product_streams = serializers.SerializerMethodField()
 
     relations = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField()
 
     @staticmethod
     def get_link(instance: ProductVariant) -> str:
         return get_model_ofuri_link("product_variants", instance.ofuri)
+
+    @staticmethod
+    def get_manifest(instance: ProductModel) -> str:
+        """Get a manifest for a ProductVariant on demand / not pre-generated"""
+        if not instance.components.exists():
+            return ""
+        return get_model_id_link("product_variants", instance.uuid, manifest=True)
 
     class Meta(ProductModelSerializer.Meta):
         model = ProductVariant
@@ -769,6 +780,7 @@ class ProductVariantSerializer(ProductModelSerializer):
             "product_versions",
             "product_streams",
             "channels",
+            "manifest",
         ]
         read_only_fields = fields
 

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -108,7 +108,7 @@ def get_upstream_link(
 
 
 def get_model_id_link(
-    model_name: str, uuid_or_build_id: Union[int, str, UUID], manifest=False
+    model_name: str, uuid_or_build_id: Union[int, str, UUID], manifest: bool = False
 ) -> str:
     """Generic method to get an ID-based link for an arbitrary Model subclass."""
     link = f"{CORGI_API_URL}/{model_name}/{uuid_or_build_id}"

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -496,7 +496,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        manifest = json.loads(obj.manifest)
+        manifest = json.loads(obj.manifest())
         return Response(manifest)
 
 
@@ -535,7 +535,8 @@ class ProductVariantViewSetSet(ProductDataViewSet):
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        manifest = json.loads(obj.manifest)
+        errata_ids = request.query_params.get("errata_ids", "")
+        manifest = json.loads(obj.manifest(errata_ids=errata_ids))
         return Response(manifest)
 
 

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -530,6 +530,14 @@ class ProductVariantViewSetSet(ProductDataViewSet):
         except ProductVariant.DoesNotExist:
             raise Http404
 
+    @action(methods=["get"], detail=True)
+    def manifest(self, request: Request, uuid: str = "") -> Response:
+        obj = self.queryset.filter(uuid=uuid).first()
+        if not obj:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        manifest = json.loads(obj.manifest)
+        return Response(manifest)
+
 
 @INCLUDE_EXCLUDE_FIELDS_SCHEMA
 class ChannelViewSet(ReadOnlyModelViewSet):

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -492,7 +492,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
             raise Http404
 
     @action(methods=["get"], detail=True)
-    def manifest(self, request: Request, uuid: Union[str, None] = None) -> Response:
+    def manifest(self, request: Request, uuid: str = "") -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
@@ -659,7 +659,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         authentication_classes=[TokenAuthentication],
         permission_classes=[IsAuthenticatedOrReadOnly],
     )
-    def update_license(self, request: Request, uuid: Union[str, None] = None) -> Response:
+    def update_license(self, request: Request, uuid: str = "") -> Response:
         """Allow OpenLCS to upload copyright text / license scan results for a component"""
         # In the future these could be separate endpoints
         # For testing we'll just keep it under one endpoint
@@ -703,7 +703,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         return response
 
     @action(methods=["get"], detail=True)
-    def provides(self, request: Request, uuid: Union[str, None] = None) -> Response:
+    def provides(self, request: Request, uuid: str = "") -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
@@ -714,7 +714,7 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         return Response(dicts)
 
     @action(methods=["get"], detail=True)
-    def taxonomy(self, request: Request, uuid: Union[str, None] = None) -> Response:
+    def taxonomy(self, request: Request, uuid: str = "") -> Response:
         obj = self.queryset.filter(uuid=uuid).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -440,10 +440,9 @@ class ProductModel(TimeStampedModel):
     def get_ofuri(self) -> str:
         pass
 
-    @property
-    def manifest(self) -> str:
+    def manifest(self, errata_ids: str = "") -> str:
         """Return an SPDX-style manifest in JSON format."""
-        return ProductManifestFile(self).render_content()
+        return ProductManifestFile(self, errata_ids).render_content()
 
     @property
     def provides_queryset(self, using: str = "read_only") -> QuerySet["Component"]:

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -441,6 +441,11 @@ class ProductModel(TimeStampedModel):
         pass
 
     @property
+    def manifest(self) -> str:
+        """Return an SPDX-style manifest in JSON format."""
+        return ProductManifestFile(self).render_content()
+
+    @property
     def provides_queryset(self, using: str = "read_only") -> QuerySet["Component"]:
         """Returns unique aggregate "provides" for the latest components in this ProductModel instance,
         for use in templates"""
@@ -644,11 +649,6 @@ class ProductStream(ProductModel):
         """
         stream_name = re.sub(r"(-|_|)" + self.version + "$", "", self.name)
         return f"o:redhat:{stream_name}:{self.version}"
-
-    @property
-    def manifest(self) -> str:
-        """Return an SPDX-style manifest in JSON format."""
-        return ProductManifestFile(self).render_content()
 
 
 class ProductStreamTag(Tag):

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -41,7 +41,7 @@ def cpu_update_ps_manifest(product_stream: str):
     # That will allow clients to continue to be served the same content from the browser cache
     # over the span of multiple days, until the product stream receives a new build
     with open(f"{settings.OUTPUT_FILES_DIR}/{product_stream}-{ps.pk}.json", "w") as fh:
-        fh.write(ps.manifest)
+        fh.write(ps.manifest())
 
 
 @app.task(

--- a/openapi.yml
+++ b/openapi.yml
@@ -906,6 +906,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductVariant'
           description: ''
+  /api/v1/product_variants/{uuid}/manifest:
+    get:
+      operationId: v1_product_variants_manifest_retrieve
+      description: View for api/v1/product_variants
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this product variant.
+        required: true
+      tags:
+      - v1
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductVariant'
+          description: ''
   /api/v1/product_versions:
     get:
       operationId: v1_product_versions_list
@@ -1999,6 +2020,9 @@ components:
             additionalProperties:
               type: string
           readOnly: true
+        manifest:
+          type: string
+          readOnly: true
       required:
       - build_count
       - builds
@@ -2006,6 +2030,7 @@ components:
       - components
       - description
       - link
+      - manifest
       - name
       - ofuri
       - product_streams

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -161,7 +161,7 @@ def test_slim_rpm_in_containers_manifest():
     distinct_provides = stream.provides_queryset
     assert len(distinct_provides) == num_provided
 
-    stream_manifest = stream.manifest
+    stream_manifest = stream.manifest()
     manifest = json.loads(stream_manifest)
 
     # One package for each component
@@ -209,7 +209,7 @@ def test_product_manifest_excludes_unreleased_components():
         released=False
     )
 
-    manifest = json.loads(stream.manifest)
+    manifest = json.loads(stream.manifest())
 
     # No released components linked to this product
     num_components = len(
@@ -246,7 +246,7 @@ def test_product_manifest_properties():
     And that it generates valid JSON."""
     component, stream, provided, dev_provided = setup_products_and_components_provides()
 
-    manifest = json.loads(stream.manifest)
+    manifest = json.loads(stream.manifest())
 
     # One component linked to this product
     num_components = len(


### PR DESCRIPTION
Just a draft / PoC for now. I started on this while waiting for the Nexus outage to resolve, but the same outage is blocking me from testing locally (my dependencies are out of date) and I know there are some TODOs left here.

We need to be able to manifest particular releases of products, like OpenShift 4.12.10, which is neither the latest 4.12.12 release in the z-stream nor the very first 4.12.0 release as tracked in the base stream. I haven't thought about this much, but we relate errata only to variants and never to streams. Each build also has a list of released errata tags.

So we should be able to identify "which errata we want" in the API, then pass that list of errata names to the manifest-generating logic when creating a manifest for some variant. We can then filter "which components we want" based on whether or not that component's linked build has a matching released_errata_tag.

This also fixes some other minor issues related to manifesting, mainly CORGI-599. Note that Rogue says "GENERATED_FROM" in that ticket, but the correct relationship is "GENERATES". You must read the SPDX relationships section from bottom to top, e.g. the spdxElement "for an UPSTREAM component" -> relationshipType "GENERATES" -> relatedSpdxElement "a REDHAT component".

Finally, I tried to figure out why we have duplicates in the SPDX relationships section, but the queryset we're using already has .distinct() and I don't see any obvious reason why this happens. Given the time it will take to dig into our data and find the bug's root cause, I'll have to pick this up after PTO.