### PR TITLE
CORGI-634 generate links to manifests with hash

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": "config/settings/dev.py",
         "hashed_secret": "6adfb183a4a2c94a2f92dab5ade762a47889a5a1",
         "is_verified": true,
-        "line_number": 30,
+        "line_number": 5,
         "is_secret": false
       }
     ],
@@ -282,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-14T20:10:12Z"
+  "generated_at": "2023-05-10T20:29:38Z"
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,10 +298,11 @@ USE_L10N = False
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = "/static/"
+STATIC_URL = f"https://{CORGI_DOMAIN}/static/"
 STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
 STATICFILES_DIRS = [OUTPUT_FILES_DIR]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+WHITENOISE_KEEP_ONLY_HASHED_FILES = True
 
 # Celery config
 CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://redis:6379")

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -18,6 +18,7 @@ SESSION_COOKIE_SECURE = False
 #      - "1025:1025"
 
 ALLOWED_HOSTS = ["*"]
+STATIC_URL = "http://localhost:8008/static/"
 
 # Django Debug Toolbar config; requires requirements/dev.txt deps
 INSTALLED_APPS += ["debug_toolbar"]  # noqa: F405

--- a/corgi/api/constants.py
+++ b/corgi/api/constants.py
@@ -12,7 +12,5 @@ CORGI_API_VERSION: str = "v1"
 # Generic URL prefix
 if not utils.running_dev():
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
-    CORGI_STATIC_URL = f"https://{settings.CORGI_DOMAIN}{settings.STATIC_URL}"
 else:
     CORGI_API_URL = f"http://localhost:8008/api/{CORGI_API_VERSION}"
-    CORGI_STATIC_URL = f"http://localhost:8008{settings.STATIC_URL}"

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -10,8 +10,9 @@ from django.conf import settings
 from django.db.models.manager import Manager
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+from whitenoise.storage import CompressedManifestStaticFilesStorage
 
-from corgi.api.constants import CORGI_API_URL, CORGI_STATIC_URL
+from corgi.api.constants import CORGI_API_URL
 from corgi.core.constants import MODEL_FILTER_NAME_MAPPING
 from corgi.core.models import (
     AppStreamLifeCycle,
@@ -583,7 +584,13 @@ class ProductModelSerializer(ProductTaxonomySerializer):
     def get_manifest(instance: ProductStream) -> str:
         if not instance.components.exists():
             return ""
-        return f"{CORGI_STATIC_URL}{instance.name}-{instance.pk}.json"
+        filename = f"{instance.name}-{instance.pk}.json"
+        try:
+            manifest_link = CompressedManifestStaticFilesStorage().url(filename)
+        except ValueError:
+            logger.error(f"Failed to find staticfiles url for {filename}")
+            return ""
+        return manifest_link
 
     @staticmethod
     def get_relations(instance: ProductModel) -> list[dict[str, str]]:

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -582,7 +582,12 @@ class ProductModelSerializer(ProductTaxonomySerializer):
 
     @staticmethod
     def get_manifest(instance: ProductStream) -> str:
-        if not instance.components.exists():
+        if (
+            not instance.components.root_components()
+            .released_components()
+            .latest_components()
+            .exists()
+        ):
             return ""
         filename = f"{instance.name}-{instance.pk}.json"
         try:

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -40,8 +40,15 @@ def cpu_update_ps_manifest(product_stream: str):
     # have a newer build than the last run.
     # That will allow clients to continue to be served the same content from the browser cache
     # over the span of multiple days, until the product stream receives a new build
-    with open(f"{settings.OUTPUT_FILES_DIR}/{product_stream}-{ps.pk}.json", "w") as fh:
-        fh.write(ps.manifest)
+    if ps.components.root_components().released_components().latest_components().exists():
+        logger.info(f"Generating manifest for {product_stream}")
+        with open(f"{settings.OUTPUT_FILES_DIR}/{product_stream}-{ps.pk}.json", "w") as fh:
+            fh.write(ps.manifest)
+    else:
+        logger.info(
+            f"Didn't find any released components for {product_stream}, "
+            f"skipping manifest generation"
+        )
 
 
 @app.task(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       timeout: "3s"
       retries: 3
     volumes:
-      - .:/opt/app-root/src:Z
+      - .:/opt/app-root/src:z
 
   corgi-monitor:
     container_name: corgi-monitor

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -118,6 +118,17 @@ To shut down and clean up:
 podman-compose down -v  # Also removes data volume
 ```
 
+### On first run
+The first time the application is run it's expected that the web pod will return an HTTP 500 error when trying render 
+requests. To fix it run:
+
+```bash
+python3 manage.py collectstatic
+```
+
+That will populate staticfiles required by the installed Django plugins and place them in the staticfiles directory. 
+On subsequent runs, as long as those files exist in the staticfiles directory, the web pod should return 200 responses.
+
 ### Running the Development Shell
 
 Ensure you have environment variables defined as noted in "Project Setup"; then run:

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,12 +3,6 @@
 # Custom run script for starting corgi django service in corgi-stage and corgi-prod environments.
 # Note - DJANGO_SETTINGS_MODULE env var is required
 
-# collect static files
-python3 manage.py collectstatic \
---ignore '*.json' \
--v 2 \
---noinput
-
 # start gunicorn
 if [[ $1 == dev ]]; then
     exec gunicorn config.wsgi --config gunicorn_config.py --reload

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,5 +1,4 @@
 import timeit
-from json import JSONDecodeError
 from urllib.parse import quote_plus
 
 import pytest
@@ -58,7 +57,7 @@ def display_manifest_with_many_components() -> dict:
     name = response_json["name"]
     uuid = response_json["uuid"]
     manifest_link = response_json["manifest"]
-    assert manifest_link == f"{CORGI_API_URL.replace('api/v1', 'static')}/{name}-{uuid}.json"
+    assert manifest_link.startswith(f"{CORGI_API_URL.replace('api/v1', 'static')}/{name}-{uuid}")
 
     response = requests.get(manifest_link)
     response.raise_for_status()
@@ -68,10 +67,6 @@ def display_manifest_with_many_components() -> dict:
     return response_json
 
 
-@pytest.mark.xfail(
-    raises=JSONDecodeError,
-    reason="CORGI-634 truncates generated files when transferred with Gzip compression",
-)
 def test_displaying_pregenerated_manifest() -> None:
     """Test that displaying a pre-generated stream manifest with many components is not slow"""
     # Slow manifests and web pod restarts (OoM) were fixed
@@ -83,7 +78,7 @@ def test_displaying_pregenerated_manifest() -> None:
     test_results = sorted(timer.repeat(repeat=3, number=1))
     assert len(test_results) == 3
     median_time_taken = test_results[1]
-    assert median_time_taken < 8.0
+    assert median_time_taken < 10.0
 
 
 def generate_manifest_with_many_components() -> dict:


### PR DESCRIPTION
I think CORGI-634 file truncation is because we overwrite the file, but django doesn't re-read the file metadata from disk on every request unless you have [WHITENOISE_AUTOREFRESH](https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_AUTOREFRESH) set. An alternative approach might be to add a [WHITENOISE_IMMUTABLE_FILE_TEST](https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_IMMUTABLE_FILE_TEST)  for the json files.

This switches back to `whitenoise.storage.CompressedManifestStaticFilesStorage` and generates manifest links like this:
such as `openshift-4.13-efe620b4-e61d-4862-a632-81e320bdf6a4.a1f4f6010cda.json`, notice the `a1f4f6010cda` hash in the filename. The next time we run `collectstatic `we'll get a new file and won't overwrite any files. Which should mean no mismatch between file metadata (content-length) and file contents. Those files can be cached forever by clients in the browsers, or anywhere in between the server and browser as the content won't change.

We'll have to keep an eye on the size of our staticfiles PVC and clean it up when it's getting close to capacity. I'll increase the size in an ops repo MR soon. All also see if I can find a metric to monitor the PVC disk usage.