### PR TITLE
CORGI-648 collector product variant cpe null

### DIFF
--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -92,10 +92,15 @@ class ErrataTool:
             except CollectorErrataProductVersion.DoesNotExist:
                 logger.warning("Did not find product version with id %s", product_version_id)
                 continue
+
+            cpe = variant["attributes"]["cpe"]
+            # CORGI-648 the value can be null
+            if not cpe:
+                cpe = ""
             et_product_variant, created = CollectorErrataProductVariant.objects.update_or_create(
                 et_id=variant["id"],
                 defaults={
-                    "cpe": variant["attributes"]["cpe"],
+                    "cpe": cpe,
                     "product_version": et_product_version,
                     "name": variant["attributes"]["name"],
                 },

--- a/tox.ini
+++ b/tox.ini
@@ -72,13 +72,13 @@ commands = mypy {posargs:corgi}
 
 [testenv:schema]
 deps = -r requirements/base.txt
-allowlist_externals = git
+allowlist_externals = /usr/bin/git
 commands = python3 manage.py spectacular --file openapi.yml {posargs}
     /usr/bin/git diff --quiet openapi.yml
 
 [testenv:secrets]
 deps = -r requirements/lint.txt
-allowlist_externals = bash
+allowlist_externals = /usr/bin/bash
 # Check only files in the current branch which have changed, compared to the main branch, for secrets
 # Scan all files for secrets if the first form fails, since Gitlab CI uses shallow clone and does not have a "main" ref
 commands = /usr/bin/bash -c 'detect-secrets-hook --baseline .secrets.baseline \


### PR DESCRIPTION
When ET returns null for variant CPE set it to an empty string in the Collector models.

Also fixes an issue running schema and secrets tox targets with the latest tox 4.5.1.