### PR TITLE
CORGI-652 reverse proxy via nginx

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,11 +298,10 @@ USE_L10N = False
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = f"https://{CORGI_DOMAIN}/static/"
+STATIC_URL = f"https://{CORGI_DOMAIN}/"
 STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
 STATICFILES_DIRS = [OUTPUT_FILES_DIR]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-WHITENOISE_KEEP_ONLY_HASHED_FILES = True
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
 # Celery config
 CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://redis:6379")

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -18,7 +18,7 @@ SESSION_COOKIE_SECURE = False
 #      - "1025:1025"
 
 ALLOWED_HOSTS = ["*"]
-STATIC_URL = "http://localhost:8008/static/"
+STATIC_URL = "http://localhost:8080/"
 
 # Django Debug Toolbar config; requires requirements/dev.txt deps
 INSTALLED_APPS += ["debug_toolbar"]  # noqa: F405

--- a/corgi/api/constants.py
+++ b/corgi/api/constants.py
@@ -13,4 +13,4 @@ CORGI_API_VERSION: str = "v1"
 if not utils.running_dev():
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
 else:
-    CORGI_API_URL = f"http://localhost:8008/api/{CORGI_API_VERSION}"
+    CORGI_API_URL = f"http://localhost:8080/api/{CORGI_API_VERSION}"

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db.models.manager import Manager
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from whitenoise.storage import CompressedManifestStaticFilesStorage
+from whitenoise.storage import CompressedStaticFilesStorage
 
 from corgi.api.constants import CORGI_API_URL
 from corgi.core.constants import MODEL_FILTER_NAME_MAPPING
@@ -591,7 +591,7 @@ class ProductModelSerializer(ProductTaxonomySerializer):
             return ""
         filename = f"{instance.name}-{instance.pk}.json"
         try:
-            manifest_link = CompressedManifestStaticFilesStorage().url(filename)
+            manifest_link = CompressedStaticFilesStorage().url(filename)
         except ValueError:
             logger.error(f"Failed to find staticfiles url for {filename}")
             return ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,17 @@ services:
         limits:
           memory: 300M   # Keep in sync with OpenShift mem limits to catch OOM problems
 
+  corgi-nginx:
+    container_name: corgi-nginx
+    image: registry.access.redhat.com/ubi9/nginx-122:1-12
+    depends_on: ["corgi-web"]
+    ports:
+      - "8080:8080"
+    command: "nginx -g 'daemon off;'"
+    volumes:
+      - ./staticfiles:/opt/app-root/src:z
+      - ./etc/nginx:/opt/app-root/etc/nginx.default.d/
+
   corgi-web:
     container_name: corgi-web
     build:

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -111,7 +111,7 @@ To start system locally
 podman-compose up -d
 ```
 
-The application should be available on http://localhost:8008.
+The application should be available on http://localhost:8080.
 
 To shut down and clean up:
 ```bash

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -1,0 +1,20 @@
+# Settings to serve static files
+location /static/  {
+    root               /opt/app-root/src/;
+}
+
+# For OpenShift health checks
+location /healthz {
+    default_type        text/plain;
+    return              200;
+}
+
+# Proxy connections to gunicorn
+location / {
+    proxy_pass         http://corgi-web:8008;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Host $server_name;
+    # Not used in production, but required in Dev to get correct links in the /api/v1 menu
+    proxy_set_header   Host localhost:8080;
+}

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -13,7 +13,7 @@ from corgi.api.constants import CORGI_API_VERSION
 if settings.CORGI_DOMAIN:
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
 else:
-    CORGI_API_URL = f"http://localhost:8008/api/{CORGI_API_VERSION}"
+    CORGI_API_URL = f"http://localhost:8080/api/{CORGI_API_VERSION}"
 
 pytestmark = [pytest.mark.performance]
 
@@ -57,7 +57,7 @@ def display_manifest_with_many_components() -> dict:
     name = response_json["name"]
     uuid = response_json["uuid"]
     manifest_link = response_json["manifest"]
-    assert manifest_link.startswith(f"{CORGI_API_URL.replace('api/v1', 'static')}/{name}-{uuid}")
+    assert manifest_link == f"{CORGI_API_URL.replace('/api/v1', '')}/{name}-{uuid}.json"
 
     response = requests.get(manifest_link)
     response.raise_for_status()
@@ -78,7 +78,7 @@ def test_displaying_pregenerated_manifest() -> None:
     test_results = sorted(timer.repeat(repeat=3, number=1))
     assert len(test_results) == 3
     median_time_taken = test_results[1]
-    assert median_time_taken < 10.0
+    assert median_time_taken < 12.0
 
 
 def generate_manifest_with_many_components() -> dict:


### PR DESCRIPTION
Yet another iteration of the file truncation issue solution. I finally decided to give up on serving static files via gunicorn in favour of NGinx. In this iteration using NGinx as a reverse proxy.

Not that to use NGinx as a reverse proxy in dev you'll need to update the url you access Corgi on from port 8008 to 8080