### PR TITLE
CORGI-650: Handle brew tag renames

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -77,7 +77,9 @@ class Brew:
     # A list of component names, for which build analysis will be skipped.
     COMPONENT_EXCLUDES = json.loads(os.getenv("CORGI_COMPONENT_EXCLUDES", "[]"))
 
-    def __init__(self, source: Optional[str] = ""):
+    koji_session: koji.ClientSession = None
+
+    def __init__(self, source: str = ""):
         if source == SoftwareBuild.Type.CENTOS:
             self.koji_session = koji.ClientSession(settings.CENTOS_URL)
         elif source == SoftwareBuild.Type.KOJI:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,9 +155,9 @@ decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
     # via gssapi
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements/base.in
     #   django-celery-beat

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -302,9 +302,9 @@ detect-secrets==1.4.0 \
     --hash=sha256:d08ecabeee8b68c0acb0e8a354fb98d822a653f6ed05e520cead4c6fc1fc02cd \
     --hash=sha256:d56787e339758cef48c9ccd6692f7a094b9963c979c9813580b0169e41132833
     # via -r requirements/lint.txt
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -237,9 +237,9 @@ decorator==5.1.0 \
     # via
     #   -r requirements/base.txt
     #   gssapi
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements/base.txt
     #   django-celery-beat


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review when you have time. If this looks good I'll deploy to stage and test the selector / message filtering logic. In the meantime I'll be writing tests, but I wanted to get review on this before I find out it's the wrong approach. Once tests are written and this is merged, I'll manually refresh tags on all builds for (hopefully) the last time.

I left the Brew tag / untag UMB logic in place, since that works correctly for 2 out of 3 cases (only fails when an existing tag is renamed), and I didn't want to do a major refactoring of this code before summit. We could switch to listening on the errata.v2.builds.changed topic instead, and then all of our tag / untag events would use data from Errata Tool.

Note that this errata.v2.builds.changed topic won't handle / report any messages for non-errata tags that get added to a build. Since we rely on Brew tags to link streams to builds, I think it's important we keep all tags in sync between Brew and Corgi, not just errata tags. But please let me know if I've misunderstood something or there's a better way.

The ET docs for all these UMB topics specifically call out "Brew build IDs" and the "Brew API". So I'm not sure this solution is future-proof / will work for PNC builds attached to errata. My preferred approach here is just to focus on fixing bugs before summit, then refactoring as part of a larger effort in the future if needed, only when we're ready to add broader support for middleware / PNC. Right now we listen for UMB messages about "completed Brew builds" but not "completed PNC builds", so there are other gaps we'll need to close anyway.