### PR TITLE
CORGI-655: Limit stream manifests to supported

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -14,6 +14,7 @@ from whitenoise.storage import CompressedStaticFilesStorage
 
 from corgi.api.constants import CORGI_API_URL
 from corgi.core.constants import MODEL_FILTER_NAME_MAPPING
+from corgi.core.fixups import supported_stream_cpes
 from corgi.core.models import (
     AppStreamLifeCycle,
     Channel,
@@ -274,7 +275,6 @@ class IncludeExcludeFieldsSerializer(serializers.ModelSerializer):
         if self._next_level_include_fields.get(
             fieldname, []
         ) or self._next_level_exclude_fields.get(fieldname, []):
-
             context = {
                 "include_fields": self._next_level_include_fields.get(fieldname, []),
                 "exclude_fields": self._next_level_exclude_fields.get(fieldname, []),
@@ -587,7 +587,7 @@ class ProductModelSerializer(ProductTaxonomySerializer):
             .released_components()
             .latest_components()
             .exists()
-        ):
+        ) or (instance.name not in supported_stream_cpes):
             return ""
         filename = f"{instance.name}-{instance.pk}.json"
         try:

--- a/corgi/core/fixups.py
+++ b/corgi/core/fixups.py
@@ -1,6 +1,6 @@
-from typing import List
-
-cpes = {
+# This is a temporary mapping of Product Streams, for which we can generate and publish SBOMs.
+# This data should be moved to an appropriate object in product definitions as soon as possible.
+supported_stream_cpes = {
     "3amp-2": ["cpe:/a:redhat:3scale_amp:2.12::el7", "cpe:/a:redhat:3scale_amp:2.12::el8"],
     "amq-ic-1": [
         "cpe:/a:redhat:amq_interconnect:1::el7",
@@ -328,6 +328,6 @@ cpes = {
 }
 
 
-def cpe_lookup(product_stream_name: str) -> List[str]:
+def cpe_lookup(product_stream_name: str) -> list[str]:
     """Temporary cpe fixup"""
-    return cpes.get(product_stream_name, [])
+    return supported_stream_cpes.get(product_stream_name, [])


### PR DESCRIPTION
This is a quick and simple way to limit our manifests to those that can be published. SDEngine queries for streams by looking at those that have a manifest link and will automatically publish all manifests that have a link. This ensures only those that are supported (are included in our manually curated list) are published.

Long-term, CPEs should be defined on product streams in prod-defs (or w/e other equivalent exists) and then this method can use the metadata of the ProductStream object directly.