### PR TITLE
CORGI-654: Switch to native Django StaticFilesStorage instead of Whitenoise

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -155,7 +155,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
-    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "django.contrib.postgres",
@@ -178,7 +177,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -298,10 +296,9 @@ USE_L10N = False
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = f"https://{CORGI_DOMAIN}/"
+STATIC_URL = "/"
 STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
 STATICFILES_DIRS = [OUTPUT_FILES_DIR]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
 # Celery config
 CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://redis:6379")

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -8,9 +8,9 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db.models.manager import Manager
+from django.templatetags.static import static
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from whitenoise.storage import CompressedStaticFilesStorage
 
 from corgi.api.constants import CORGI_API_URL
 from corgi.core.constants import MODEL_FILTER_NAME_MAPPING
@@ -591,7 +591,7 @@ class ProductModelSerializer(ProductTaxonomySerializer):
             return ""
         filename = f"{instance.name}-{instance.pk}.json"
         try:
-            manifest_link = CompressedStaticFilesStorage().url(filename)
+            manifest_link = static(filename)
         except ValueError:
             logger.error(f"Failed to find staticfiles url for {filename}")
             return ""

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -24,5 +24,4 @@ requests
 requests-gssapi
 rpm
 splitstream
-whitenoise
 mozilla-django-oidc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -577,10 +577,6 @@ wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
     --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
     # via prompt-toolkit
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via -r requirements/base.in
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1243,12 +1243,6 @@ wheel==0.40.0 \
     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873 \
     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247
     # via pip-tools
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -956,10 +956,6 @@ wcwidth==0.2.5 \
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via -r requirements/base.txt
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,10 +3,16 @@
 # Custom run script for starting corgi django service in corgi-stage and corgi-prod environments.
 # Note - DJANGO_SETTINGS_MODULE env var is required
 
+# collect static files from any app folder ending in /static/
+# (currently only corgi/web/static/base.css)
+python3 manage.py collectstatic \
+    --ignore '*.json' \
+    -v 2 \
+    --noinput
+
 # start gunicorn
 if [[ $1 == dev ]]; then
     exec gunicorn config.wsgi --config gunicorn_config.py --reload
 else
     exec gunicorn config.wsgi --config gunicorn_config.py
 fi
-


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. I'm not sure I understand the new setup, since the nginx pod's "./staticfiles" dir (at least locally / in dev's docker-compose.yml) seems to point to the main corgi folder's "/opt/app-root/src" dir instead of the "/opt/app-root/staticfiles" dir.

We also still need to collect static files on web pod startup in order to get the "base.css" file our HTML templates rely on to be displayed. Not collecting this static file after the PVC is recreated triggers server errors whenever someone tries to view the main Corgi webpage. This eventually fixes itself when the collectstatic task runs, but let's just collect the files we need at startup for safety / to avoid outages.

EDIT: Actually it looks like the current nginx setup is completely broken because the manifest links we generate in the API still rely on Whitenoise's URL-building logic, and we return an empty "" string if the URL isn't found. Have we tested with Whitenoise's ManifestStaticFilesStorage or Django's StaticFilesStorage?

These don't use Gzip compression as far as I understand, so shouldn't be affected by this Gzip bug that causes manifest truncation. That seems like a simpler change than standing up a whole new webserver just to serve the manifests.