### PR TITLE
CORGI-658 Remove provided components with internal urls from manifest

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -582,12 +582,9 @@ class ProductModelSerializer(ProductTaxonomySerializer):
 
     @staticmethod
     def get_manifest(instance: ProductStream) -> str:
-        if (
-            not instance.components.root_components()
-            .released_components()
-            .latest_components()
-            .exists()
-        ) or (instance.name not in supported_stream_cpes):
+        if (not instance.components.manifest_components(quick=True).exists()) or (
+            instance.name not in supported_stream_cpes
+        ):
             return ""
         filename = f"{instance.name}-{instance.pk}.json"
         try:

--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -68,8 +68,7 @@ class ProductManifestFile(ManifestFile):
     def render_content(self, cpe_mapping=True) -> str:
 
         components = self.obj.components  # type: ignore[attr-defined]
-        components = components.exclude(name__endswith="-container-source").using("read_only")
-        released_components = components.root_components().released_components().latest_components()
+        released_components = components.manifest_components()
         distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -36,12 +36,14 @@ def update_manifests(fixup=True):
 def cpu_update_ps_manifest(product_stream: str, fixup=True):
     logger.info("Updating manifest for %s", product_stream)
     ps = ProductStream.objects.get(name=product_stream)
-    # TODO figure out a way skip updating files where the content doesnt need updating
-    # for example we could check for the timestamp of the latest build, and only update if we
-    # have a newer build than the last run.
-    # That will allow clients to continue to be served the same content from the browser cache
-    # over the span of multiple days, until the product stream receives a new build
-    if ps.components.root_components().released_components().latest_components().exists():
+    # TODO figure out a way to skip updating files where the content doesnt need updating
+    # for example we could render the manifest in a temp file, remove the created_at line and diff
+    # the contents only if there is a difference we can overwrite the file.
+    # This would could save a lot of resource downstream, because clients could just check if the
+    # file has been modified before obtaining the updated copy.
+    # We'd have to check that collectstatic does not modify a file in staticfiles directory if it
+    # hasn't been updated in outputfiles though.
+    if ps.components.manifest_components(quick=True).exists():
         logger.info(f"Generating manifest for {product_stream}")
         with open(f"{settings.OUTPUT_FILES_DIR}/{product_stream}-{ps.pk}.json", "w") as fh:
             if fixup:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -49,7 +49,7 @@ def test_displaying_component_with_many_sources() -> None:
 
 def display_manifest_with_many_components() -> dict:
     """Helper method for timeit to display a manifest with many components"""
-    large_stream_ofuri = "o:redhat:rhel:9.1.0.z"
+    large_stream_ofuri = "o:redhat:rhel:9.2.0"
     response = requests.get(f"{CORGI_API_URL}/product_streams?ofuri={large_stream_ofuri}")
     response.raise_for_status()
     response_json = response.json()


### PR DESCRIPTION
This consolidates use of manifest query to a single queryset call `manifest_components' used when checking which manifest to generate in the cpu_update_ps_manifest task, and them again when actually generating them using the template.

It also remove any internal (redhat.com in name) provided components from the manifests.