### PR TITLE
CORGI_657 duplicate product stream manifest packages

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -69,12 +69,12 @@ class ProductManifestFile(ManifestFile):
 
         components = self.obj.components  # type: ignore[attr-defined]
         released_components = components.manifest_components()
-        distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
+        related_components = self.obj.related_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {
             "obj": self.obj,
             "released_components": released_components,
-            "distinct_provides": distinct_provides,
+            "distinct_related": related_components,
             "cpes": cpe_lookup(self.obj.name) if cpe_mapping else self.obj.cpes,  # type: ignore[attr-defined] # noqa
         }
 

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -21,27 +21,7 @@
         "SPDXID": "SPDXRef-{{component.uuid}}",
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{component.nevra|escapejs}}"
-    },{% if component.type != component.Type.RPM %}{% for upstream in component.upstreams.get_queryset.iterator %}{# RPM upstream data is human-generated and unreliable #}{
-        "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{upstream.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if upstream.related_url and upstream.type != upstream.Type.RPM %}"{{upstream.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if upstream.license_concluded %}"{{upstream.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if upstream.license_declared %}"{{upstream.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{upstream.name|escapejs}}",
-        "packageFileName": {% if upstream.filename %}"{{upstream.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{upstream.uuid}}",
-        "supplier": "NOASSERTION",
-        "versionInfo": "{{upstream.nevra|escapejs}}"
-    },{% endfor %}{% endif %}{% endfor %}{% for provided in distinct_provides %}
+    },{% endfor %}{% for provided in distinct_related %}
     {
         "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if provided.download_url %}"{{provided.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},


### PR DESCRIPTION
Combine all upstream and provides components into a single distinct 'packages' list for de-duplication in product stream manifest.