### PR TITLE
CORGI-657: Deduplicate upstream components before adding to manifests

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -70,11 +70,13 @@ class ProductManifestFile(ManifestFile):
         components = self.obj.components  # type: ignore[attr-defined]
         released_components = components.manifest_components()
         distinct_provides = self.obj.provides_queryset  # type: ignore[attr-defined]
+        distinct_upstreams = self.obj.upstreams_queryset  # type: ignore[attr-defined]
 
         kwargs_for_template = {
             "obj": self.obj,
             "released_components": released_components,
             "distinct_provides": distinct_provides,
+            "distinct_upstreams": distinct_upstreams,
             "cpes": cpe_lookup(self.obj.name) if cpe_mapping else self.obj.cpes,  # type: ignore[attr-defined] # noqa
         }
 

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -21,7 +21,7 @@
         "SPDXID": "SPDXRef-{{component.uuid}}",
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{component.nevra|escapejs}}"
-    },{% if component.type != component.Type.RPM %}{% for upstream in component.upstreams.get_queryset.iterator %}{# RPM upstream data is human-generated and unreliable #}{
+    },{% endfor %}{% for upstream in distinct_upstreams.iterator %}{
         "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "externalRefs": [
@@ -41,7 +41,7 @@
         "SPDXID": "SPDXRef-{{upstream.uuid}}",
         "supplier": "NOASSERTION",
         "versionInfo": "{{upstream.nevra|escapejs}}"
-    },{% endfor %}{% endif %}{% endfor %}{% for provided in distinct_provides %}
+    },{% endfor %}{% for provided in distinct_provides.iterator %}
     {
         "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if provided.download_url %}"{{provided.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
@@ -73,7 +73,7 @@
                 "referenceLocator": "{{cpe}}",
                 "referenceType": "cpe22Type"
             }{% if not forloop.last %},{% endif %}{% endfor %}
-        ], {% endif %}
+        ],{% endif %}
         "filesAnalyzed": false,
         "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
         "licenseComments": "Licensing information is provided for individual components only at this time.",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -328,6 +328,26 @@ def test_product_manifest_properties():
     assert manifest["relationships"][-1] == document_describes_product
 
 
+def test_no_duplicates_in_manifest_with_upstream():
+    stream, component, other_component, upstream = setup_products_and_components_upstreams()
+
+    assert component.upstreams.get(pk=upstream.uuid)
+    assert other_component.upstreams.get(pk=upstream.uuid)
+
+    # 1 (product) + 2 (root components) + 1 (upstream)
+    root_components = stream.components.manifest_components().order_by("software_build__build_id")
+    assert len(root_components) == 2
+    assert root_components.first() == component
+    assert root_components.last() == other_component
+
+    upstream_components = stream.upstreams_queryset
+    assert len(upstream_components) == 1
+    assert upstream_components.first() == upstream
+
+    manifest = json.loads(stream.manifest)
+    assert len(manifest["packages"]) == 4
+
+
 def test_component_manifest_properties():
     """Test that all Components have a .manifest property
     And that it generates valid JSON."""
@@ -370,6 +390,73 @@ def test_component_manifest_properties():
     assert manifest["relationships"][provided_index] == provided_contained_by_component
     assert manifest["relationships"][dev_provided_index] == dev_provided_dependency_of_component
     assert manifest["relationships"][-1] == document_describes_product
+
+
+def setup_products_and_components_upstreams():
+    stream, variant = setup_product()
+    meta_attr = {"released_errata_tags": ["RHBA-2023:1234"]}
+
+    build = SoftwareBuildFactory(
+        build_id=1,
+        meta_attr=meta_attr,
+    )
+
+    other_build = SoftwareBuildFactory(
+        build_id=2,
+        meta_attr=meta_attr,
+    )
+
+    upstream = ComponentFactory(namespace=Component.Namespace.UPSTREAM)
+    component = ComponentFactory(
+        software_build=build, type=Component.Type.CONTAINER_IMAGE, arch="noarch"
+    )
+    other_component = ComponentFactory(
+        software_build=other_build, type=Component.Type.CONTAINER_IMAGE, arch="noarch"
+    )
+    cnode = ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.SOURCE, parent=None, purl=component.purl, obj=component
+    )
+    other_cnode = ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.SOURCE,
+        parent=None,
+        purl=other_component.purl,
+        obj=other_component,
+    )
+    ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.SOURCE,
+        parent=cnode,
+        purl=upstream.purl,
+        obj=upstream,
+    )
+    ComponentNode.objects.create(
+        type=ComponentNode.ComponentNodeType.SOURCE,
+        parent=other_cnode,
+        purl=upstream.purl,
+        obj=upstream,
+    )
+    # Link the components to each other
+    component.save_component_taxonomy()
+    other_component.save_component_taxonomy()
+
+    # The product_ref here is a variant name but below we use it's parent stream
+    # to generate the manifest
+    ProductComponentRelationFactory(
+        build_id=str(build.build_id),
+        build_type=build.build_type,
+        product_ref=variant.name,
+        type=ProductComponentRelation.Type.ERRATA,
+    )
+    ProductComponentRelationFactory(
+        build_id=str(other_build.build_id),
+        build_type=other_build.build_type,
+        product_ref=variant.name,
+        type=ProductComponentRelation.Type.ERRATA,
+    )
+    # Link the components to the ProductModel instances
+    build.save_product_taxonomy()
+    other_build.save_product_taxonomy()
+
+    return stream, component, other_component, upstream
 
 
 def setup_products_and_components_provides(released=True, internal_component=False):


### PR DESCRIPTION
@jasinner This should allow us to report different information for upstream vs. Red Hat components, while still fixing the duplication you discovered. I copied the tests from your other MR, and they still pass - if this looks good I can merge as-is and do the release right after. Or please let me know if you'd like some changes here / to keep this out of the release for now. I'm happy to do another release tomorrow or Friday if we want to validate this change in stage first.