### PR TITLE
CORGI-654: Remove whitenoise and fix Nginx bugs / ESS control violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,3 @@ Makefile
 
 # SonarQube
 .scannerwork/
-
-# Pre-generated manifests
-outputfiles/

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -155,7 +155,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
-    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "django.contrib.postgres",
@@ -178,7 +177,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -298,10 +296,10 @@ USE_L10N = False
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = f"https://{CORGI_DOMAIN}/"
+STATIC_URL = "/staticfiles/"
 STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
 STATICFILES_DIRS = [OUTPUT_FILES_DIR]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Celery config
 CELERY_BROKER_URL = os.getenv("CORGI_REDIS_URL", "redis://redis:6379")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -10,8 +10,6 @@ from corgi import __version__ as CORGI_VERSION
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
-OUTPUT_FILES_DIR = os.getenv("CORGI_OUTPUT_FILES_DIR", str(BASE_DIR / "outputfiles"))
-
 # Added
 CA_CERT = os.getenv("REQUESTS_CA_BUNDLE")
 
@@ -298,7 +296,6 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "/staticfiles/"
 STATIC_ROOT = os.getenv("CORGI_STATIC_FILES_DIR", str(BASE_DIR / "staticfiles"))
-STATICFILES_DIRS = [OUTPUT_FILES_DIR]
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
 
 # Celery config

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -18,7 +18,6 @@ SESSION_COOKIE_SECURE = False
 #      - "1025:1025"
 
 ALLOWED_HOSTS = ["*"]
-STATIC_URL = "http://localhost:8080/"
 
 # Django Debug Toolbar config; requires requirements/dev.txt deps
 INSTALLED_APPS += ["debug_toolbar"]  # noqa: F405

--- a/corgi/api/constants.py
+++ b/corgi/api/constants.py
@@ -12,5 +12,7 @@ CORGI_API_VERSION: str = "v1"
 # Generic URL prefix
 if not utils.running_dev():
     CORGI_API_URL = f"https://{settings.CORGI_DOMAIN}/api/{CORGI_API_VERSION}"
+    CORGI_STATIC_URL = f"https://{settings.CORGI_DOMAIN}{settings.STATIC_URL}"
 else:
     CORGI_API_URL = f"http://localhost:8080/api/{CORGI_API_VERSION}"
+    CORGI_STATIC_URL = f"http://localhost:8080{settings.STATIC_URL}"

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -10,9 +10,8 @@ from django.conf import settings
 from django.db.models.manager import Manager
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from whitenoise.storage import CompressedStaticFilesStorage
 
-from corgi.api.constants import CORGI_API_URL
+from corgi.api.constants import CORGI_API_URL, CORGI_STATIC_URL
 from corgi.core.constants import MODEL_FILTER_NAME_MAPPING
 from corgi.core.fixups import supported_stream_cpes
 from corgi.core.models import (
@@ -586,13 +585,7 @@ class ProductModelSerializer(ProductTaxonomySerializer):
             instance.name not in supported_stream_cpes
         ):
             return ""
-        filename = f"{instance.name}-{instance.pk}.json"
-        try:
-            manifest_link = CompressedStaticFilesStorage().url(filename)
-        except ValueError:
-            logger.error(f"Failed to find staticfiles url for {filename}")
-            return ""
-        return manifest_link
+        return f"{CORGI_STATIC_URL}{instance.name}-{instance.pk}.json"
 
     @staticmethod
     def get_relations(instance: ProductModel) -> list[dict[str, str]]:

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -56,7 +56,6 @@ def setup_periodic_tasks(sender, **kwargs):
         upsert_cron_task("yum", "load_yum_repositories", hour=3, minute=0)
         upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=4, minute=0)
         upsert_cron_task("manifest", "update_manifests", hour=5, minute=0)
-        upsert_cron_task("manifest", "collect_static", hour=6, minute=0)
         upsert_cron_task("monitoring", "email_failed_tasks", hour=6, minute=30)
     else:
         # Once a week on a Saturday fetch relations from all active CDN repos
@@ -77,7 +76,6 @@ def setup_periodic_tasks(sender, **kwargs):
         upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
         upsert_cron_task("managed_services", "refresh_service_manifests", hour=10, minute=0)
         upsert_cron_task("manifest", "update_manifests", hour=11, minute=0)
-        upsert_cron_task("manifest", "collect_static", hour=12, minute=0)
         upsert_cron_task("monitoring", "email_failed_tasks", hour=12, minute=45)
 
     # Automatic task result expiration is currently disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - "8080:8080"
     command: "nginx -g 'daemon off;'"
     volumes:
-      - ./staticfiles:/opt/app-root/src:z
+      - ./staticfiles:/opt/app-root/src/staticfiles:z
       - ./etc/nginx:/opt/app-root/etc/nginx.default.d/
 
   corgi-web:

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -5,8 +5,17 @@ access_log /dev/stdout;
 error_log stderr warn;
 
 # Settings to serve static files
-location /static/  {
+location /staticfiles/  {
+    # The staticfiles dir must be mounted inside of below folder
+    # URLs like CORGI_DOMAIN/staticfiles/spdx-22-schema.json will become
+    # filenames like /opt/app-root/src/staticfiles/spdx-22-schema.json
     root               /opt/app-root/src/;
+}
+
+# To hide 404 errors about missing favicon
+location /favicon.ico {
+    default_type        text/plain;
+    return              200;
 }
 
 # For OpenShift health checks
@@ -22,6 +31,7 @@ location / {
     # These are set by the Openshift router and must be logged as received
     # Setting them here will overwrite them with internal router IPs instead
     proxy_pass_request_headers   on;
+    proxy_read_timeout 120s;
     # Not used in production, but required in Dev to get correct links in the /api/v1 menu
     proxy_set_header   Host localhost:8080;
 }

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -1,3 +1,9 @@
+# Global settings
+# Send access and error logs to container stdout / stderr
+# So they automatically show up in "podman logs" output / "oc logs" output / Splunk
+access_log /dev/stdout;
+error_log stderr warn;
+
 # Settings to serve static files
 location /static/  {
     root               /opt/app-root/src/;
@@ -12,9 +18,10 @@ location /healthz {
 # Proxy connections to gunicorn
 location / {
     proxy_pass         http://corgi-web:8008;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Host $server_name;
+    # pass headers like X-Forwarded-For (public client IPs) through to Django
+    # These are set by the Openshift router and must be logged as received
+    # Setting them here will overwrite them with internal router IPs instead
+    proxy_pass_request_headers   on;
     # Not used in production, but required in Dev to get correct links in the /api/v1 menu
     proxy_set_header   Host localhost:8080;
 }

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -24,5 +24,4 @@ requests
 requests-gssapi
 rpm
 splitstream
-whitenoise
 mozilla-django-oidc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -577,10 +577,6 @@ wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
     --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
     # via prompt-toolkit
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via -r requirements/base.in
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1243,12 +1243,6 @@ wheel==0.40.0 \
     --hash=sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873 \
     --hash=sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247
     # via pip-tools
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -956,10 +956,6 @@ wcwidth==0.2.5 \
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
-whitenoise==6.4.0 \
-    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
-    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
-    # via -r requirements/base.txt
 zope-event==4.5.0 \
     --hash=sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42 \
     --hash=sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330

--- a/run_service.sh
+++ b/run_service.sh
@@ -3,6 +3,13 @@
 # Custom run script for starting corgi django service in corgi-stage and corgi-prod environments.
 # Note - DJANGO_SETTINGS_MODULE env var is required
 
+# collect static CSS / JS files like corgi/web/static/base.css
+# This is required to avoid breaking the app on startup
+# It does not delete any existing files in the static_output dir
+# --ignore '*.json' stops us from processing every manifest
+# Otherwise the command / web pod deployment will time out
+python3 manage.py collectstatic --ignore '*.json' --noinput
+
 # start gunicorn
 if [[ $1 == dev ]]; then
     exec gunicorn config.wsgi --config gunicorn_config.py --reload

--- a/run_service.sh
+++ b/run_service.sh
@@ -6,9 +6,7 @@
 # collect static CSS / JS files like corgi/web/static/base.css
 # This is required to avoid breaking the app on startup
 # It does not delete any existing files in the static_output dir
-# --ignore '*.json' stops us from processing every manifest
-# Otherwise the command / web pod deployment will time out
-python3 manage.py collectstatic --ignore '*.json' --noinput
+python3 manage.py collectstatic --noinput
 
 # start gunicorn
 if [[ $1 == dev ]]; then

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -57,7 +57,7 @@ def display_manifest_with_many_components() -> dict:
     name = response_json["name"]
     uuid = response_json["uuid"]
     manifest_link = response_json["manifest"]
-    assert manifest_link == f"{CORGI_API_URL.replace('/api/v1', '')}/{name}-{uuid}.json"
+    assert manifest_link == f"{CORGI_API_URL.replace('/api/v1', '/staticfiles')}/{name}-{uuid}.json"
 
     response = requests.get(manifest_link)
     response.raise_for_status()


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This will:

1. Ensure X-Forwarded-For is always set (by the OpenShift router) to the client's external IP, never overwritten (by Nginx) with the router's internal IP
2. Send Nginx logs to Splunk
3. Pass client headers in the request through to Django
4. Fix some differences between local and stage / prod config
5. Automatically collect static files on each web pod startup / avoid UI breakage due to missing dependencies
6. Write manifests directly into the staticfiles PVC / avoid file truncation due to network errors when copying files between PVCs

We also need some corresponding changes in the ops repo - I'll open a PR there in just a bit.