### PR TITLE
CORGI-667: Fix ValueError when tag to be removed not found

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -490,9 +490,9 @@ redis==3.5.3 \
     # via
     #   celery
     #   celery-singleton
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements/base.in
     #   koji

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1032,9 +1032,9 @@ redis==3.5.3 \
     #   -r requirements/test.txt
     #   celery
     #   celery-singleton
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements/base.txt
     #   -r requirements/lint.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -129,9 +129,9 @@ pyyaml==6.0 \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via detect-secrets
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via detect-secrets
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -794,9 +794,9 @@ redis==3.5.3 \
     #   -r requirements/base.txt
     #   celery
     #   celery-singleton
-requests==2.26.0 \
-    --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
-    --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
+    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-stubs


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review this fix for an error seen in recent daily monitoring emails. We fail with an error if some tag to be removed from a build is not actually present in that build's list of tags. This is probably due to a tag rename from X to Y, and then trying to remove Y. We receive no UMB events for the rename, so the build's list of tags still has only X and is missing Y.

We handle this case for errata that were just recently released / entered the SHIPPED_LIVE state (by refreshing all tags), so that tags like "stream-candidate" or "stream-pending" are properly stored in Corgi with their final "stream-released" values.

For errata which aren't released / enter the DROPPED_NO_SHIP state, "stream-candidate" is probably renamed to "stream-dropped" (or similar). The solution is the same as above - if removing the tag fails, just refresh all tags on the build so we have the latest values and the Corgi data matches the Brew data.
