### PR TITLE
CORGI-673: Match Nginx proxy_read_timeout to Gunicorn / OCP router timeout

### DIFF
--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -32,7 +32,7 @@ location / {
     # These are set by the Openshift router and must be logged as received
     # Setting them here will overwrite them with internal router IPs instead
     proxy_pass_request_headers   on;
-    proxy_read_timeout 120s;
+    proxy_read_timeout 300s;
     # Not used in production, but required in Dev to get correct links in the /api/v1 menu
     proxy_set_header   Host localhost:8080;
 }


### PR DESCRIPTION
Quick fix based on issue discovered by OpenLCS this morning. This change won't prevent the reported behavior from happening again, but it does simplify our setup so that troubleshooting these is easier.