### PR TITLE
CORGI-673: Support proxying requests as this newfangled HTTP 1.1 thing

### DIFF
--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -27,6 +27,7 @@ location /healthz {
 
 # Proxy connections to gunicorn
 location / {
+    proxy_http_version 1.1;
     proxy_pass         http://corgi-web:8008;
     # pass headers like X-Forwarded-For (public client IPs) through to Django
     # These are set by the Openshift router and must be logged as received


### PR DESCRIPTION
Last PR for this ticket, based on my review of available configuration options for Nginx's proxy module:
https://nginx.org/en/docs/http/ngx_http_proxy_module.html