### PR TITLE
CORGI-616 brew tag relation timeliness

### DIFF
--- a/corgi/tasks/management/commands/loadproductdata.py
+++ b/corgi/tasks/management/commands/loadproductdata.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from corgi.tasks.brew import load_brew_tags
+from corgi.tasks.brew import load_stream_brew_tags
 from corgi.tasks.errata_tool import load_et_products
 from corgi.tasks.prod_defs import update_products
 from corgi.tasks.pulp import setup_pulp_relations, update_cdn_repo_channels
@@ -41,7 +41,7 @@ class Command(BaseCommand):
                 "Loading Brew Tags",
             )
         )
-        load_brew_tags()
+        load_stream_brew_tags()
 
     def do_save_composes(self):
         self.stdout.write(

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -51,7 +51,7 @@ def setup_periodic_tasks(sender, **kwargs):
 
     if settings.COMMUNITY_MODE_ENABLED:
         upsert_cron_task("prod_defs", "update_products", hour=0, minute=0)
-        upsert_cron_task("brew", "load_brew_tags", hour=1, minute=0)
+        upsert_cron_task("brew", "load_stream_brew_tags", hour=1, minute=0)
         upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=2, minute=0)
         upsert_cron_task("yum", "load_yum_repositories", hour=3, minute=0)
         upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=4, minute=0)
@@ -69,7 +69,7 @@ def setup_periodic_tasks(sender, **kwargs):
         upsert_cron_task("pulp", "update_cdn_repo_channels", hour=2, minute=0)
         upsert_cron_task("rhel_compose", "save_composes", hour=3, minute=0)
         upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)
-        upsert_cron_task("brew", "load_brew_tags", hour=5, minute=0)
+        upsert_cron_task("brew", "load_stream_brew_tags", hour=5, minute=0)
         upsert_cron_task("brew", "fetch_unprocessed_brew_tag_relations", hour=6, minute=0)
         upsert_cron_task("pulp", "fetch_unprocessed_cdn_relations", hour=7, minute=0)
         upsert_cron_task("yum", "load_yum_repositories", hour=8, minute=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ import pytest
 from rest_framework.test import APIClient
 
 from corgi.api.constants import CORGI_API_VERSION
+from corgi.core.models import ProductNode
+from tests.factories import (
+    ProductFactory,
+    ProductStreamFactory,
+    ProductVariantFactory,
+    ProductVersionFactory,
+)
 
 
 @pytest.fixture
@@ -17,6 +24,24 @@ def api_version():
 @pytest.fixture
 def api_path(api_version):
     return f"/api/{api_version}"
+
+
+def setup_product():
+    product = ProductFactory()
+    version = ProductVersionFactory(products=product)
+    stream = ProductStreamFactory(products=product, productversions=version)
+    variant = ProductVariantFactory(
+        name="1", products=product, productversions=version, productstreams=stream
+    )
+    pnode = ProductNode.objects.create(parent=None, obj=product)
+    pvnode = ProductNode.objects.create(parent=pnode, obj=version)
+    psnode = ProductNode.objects.create(parent=pvnode, obj=stream)
+    ProductNode.objects.create(parent=psnode, obj=variant)
+    # This generates and saves the ProductModel properties of stream
+    # AKA we link the ProductModel instances to each other
+    stream.save_product_taxonomy()
+    assert variant in stream.productvariants.get_queryset()
+    return stream, variant
 
 
 def filter_response(response):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1318,7 +1318,6 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     this behaviour.
 
     """  # noqa
-
     # create a top level root source component
     root_comp = ComponentFactory(
         name="root_comp",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -5,21 +5,14 @@ from json import JSONDecodeError
 import pytest
 
 from corgi.core.files import ProductManifestFile
-from corgi.core.models import (
-    Component,
-    ComponentNode,
-    ProductComponentRelation,
-    ProductNode,
-)
+from corgi.core.models import Component, ComponentNode, ProductComponentRelation
 
+from .conftest import setup_product
 from .factories import (
     ComponentFactory,
     ContainerImageComponentFactory,
     ProductComponentRelationFactory,
-    ProductFactory,
     ProductStreamFactory,
-    ProductVariantFactory,
-    ProductVersionFactory,
     SoftwareBuildFactory,
     SrpmComponentFactory,
 )
@@ -554,23 +547,3 @@ def _build_rpm_in_containers(rpm_in_container, name=""):
     # Link the components to each other
     container.save_component_taxonomy()
     return build, container
-
-
-def setup_product():
-    product = ProductFactory()
-    version = ProductVersionFactory(products=product)
-    stream = ProductStreamFactory(products=product, productversions=version)
-    variant = ProductVariantFactory(
-        name="1", products=product, productversions=version, productstreams=stream
-    )
-    # TODO: Factory should probably create nodes for model
-    #  Move these somewhere for reuse - common.py helper method, or fixtures??
-    pnode = ProductNode.objects.create(parent=None, obj=product)
-    pvnode = ProductNode.objects.create(parent=pnode, obj=version)
-    psnode = ProductNode.objects.create(parent=pvnode, obj=stream)
-    ProductNode.objects.create(parent=psnode, obj=variant)
-    # This generates and saves the ProductModel properties of stream
-    # AKA we link the ProductModel instances to each other
-    stream.save_product_taxonomy()
-    assert variant in stream.productvariants.get_queryset()
-    return stream, variant


### PR DESCRIPTION
This saves brew_tag relations everytime we ingest a new build. It's done before save_product_taxonomy so that the new build's components are instantly related to any product streams via it's brew_tags.

I wanted to make use of the existing save_product test function from test_manifest.py so I made it a test fixture. Since that function is called by multiple other functions in test_manifests, I also made all those fixtures as well. One of the fixtures (setup_products_and_components_provides) originally took arguments so I updated it to use pytest.markers instead.