### PR TITLE
CORGI-674 remove nginx autoindex for manifests

### DIFF
--- a/corgi/web/templates/index.html
+++ b/corgi/web/templates/index.html
@@ -2,7 +2,7 @@
 {% block body %}
 <div class="container-fluid">
   <hr/>
-  <p>Corgi: <a href="/api/v1/">API</a> | <a href="/staticfiles/">Manifests</a> | <a href="api/healthy">Health</a> | <a href="/api/v1/status">Status</a></p>
+  <p>Corgi: <a href="/api/v1/">API</a> | <a href="api/healthy">Health</a> | <a href="/api/v1/status">Status</a></p>
   <p>Utils: <a href="/data">Data</a> | <a href="tasks">Available Tasks</a> | <a href="/tasks/running">Running Tasks</a></p>
   <hr/>
   <p>Docs:

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -10,7 +10,6 @@ location /staticfiles/  {
     # URLs like CORGI_DOMAIN/staticfiles/spdx-22-schema.json will become
     # filenames like /opt/app-root/src/staticfiles/spdx-22-schema.json
     root               /opt/app-root/src/;
-    autoindex on;
 }
 
 # To hide 404 errors about missing favicon


### PR DESCRIPTION
As discussed, removing NGinx autoindex because of security concerns.