### PR TITLE
Community logging

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -207,11 +207,17 @@ TEMPLATES: list[dict] = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
+COMMUNITY_MODE_ENABLED = strtobool(os.getenv("CORGI_COMMUNITY_MODE_ENABLED", "false"))
+
 # Splunk friendly key/value pairs
 LOG_FORMAT_START = (
     "%(asctime)s.%(msecs)03d+00:00 thread=%(thread)d, name=%(name)s, lineno=%(lineno)d"
 )
 LOG_FORMAT_END = f'level=%(levelname)s, app=corgi, environ={get_env()}, msg="%(message)s"'
+
+if COMMUNITY_MODE_ENABLED:
+    LOG_FORMAT_END = f"community=true {LOG_FORMAT_END}"
+
 # Splunk friendly timestamp
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
@@ -396,8 +402,6 @@ UMB_BROKER_URL = os.getenv("CORGI_UMB_BROKER_URL")
 # True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0
 # https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
 UMB_BREW_MONITOR_ENABLED = strtobool(os.getenv("CORGI_UMB_BREW_MONITOR_ENABLED", "true"))
-
-COMMUNITY_MODE_ENABLED = strtobool(os.getenv("CORGI_COMMUNITY_MODE_ENABLED", "false"))
 
 if CORGI_DOMAIN.endswith(".fedoraproject.org"):
     CORGI_DOMAIN_BASE = ".fedoraproject.org"

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # ensure there are no extensions in the dump which we can't restore with non-admin permissions
-pg_restore -l "${db_dump_dir}" | grep -v "EXTENSION" > ./restore-elements
+pg_restore -l "${db_dump_dir}" | grep -v "EXTENSION pg_stat_statements" > ./restore-elements
 
 # Restore the database re-creating the tables
 pg_restore -h localhost -p 5433 -U corgi-db-user --dbname corgi-db -j 2 -v --no-privileges --no-owner -c -L ./restore-elements "${db_dump_dir}"

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -13,6 +13,6 @@ fi
 pg_restore -l "${db_dump_dir}" | grep -v "EXTENSION" > ./restore-elements
 
 # Restore the database re-creating the tables
-pg_restore -h localhost -p 5433 -U corgi-db-user --dbname corgi-db -j 2 -v --no-owner -c -L ./restore-elements "${db_dump_dir}"
+pg_restore -h localhost -p 5433 -U corgi-db-user --dbname corgi-db -j 2 -v --no-privileges --no-owner -c -L ./restore-elements "${db_dump_dir}"
 
 rm -rf ./restore-elements


### PR DESCRIPTION
This add a key/value pair `community=true`  to application logs when running in community mode so that we can search the 2 app instances separately in Splunk.

I also fixed fixed up a couple of issues with the restore_db script which I noticed when trying to restore a community db instance locally.