### PR TITLE
CORGI-597: Fix relationship type for arch-specific children of noarch containers

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1871,7 +1871,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return (
             ComponentNode.objects.filter(pk__in=provides_set)
             .using(using)
-            .values_list("type", "object_id")
+            .values_list("purl", "type", "object_id")
             # Ensure generated manifests only change when content does
             .order_by("object_id")
             .distinct()

--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -1,29 +1,26 @@
-{# Used as the base of all manifest.json templates, obj is either a Component or a ProductModel subclass #}
-{
-    "creationInfo": {
-        "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",
-        "creators": [
-            "Organization: Red Hat Product Security (secalert@redhat.com)"
-        ],
-        "licenseListVersion": "3.8"
-    },
-    "dataLicense": "CC-BY-4.0",
-    "documentDescribes": [
-        "SPDXRef-{{obj.uuid}}"
+{# Used as the base of all manifest.json templates, obj is either a Component or a ProductModel subclass #}{
+  "creationInfo": {
+    "created": "{% now 'Y-m-d' %}T{% now 'H:i:00' %}Z",
+    "creators": [
+      "Organization: Red Hat Product Security (secalert@redhat.com)"
     ],
-    "documentNamespace": "https://access.redhat.com/security/data/sbom/beta/spdx/{{obj.name|escapejs}}-{{obj.uuid}}",
-    "name": "{{obj.name|escapejs}}",
-    "packages": [
-      {% block packages %}{% endblock %}
-    ],
-    "relationships": [
-       {% block relationships %}{% endblock %}
-       {
-          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes stream or component being manifested #}
-          "relationshipType": "DESCRIBES",
-          "spdxElementId": "SPDXRef-DOCUMENT"
-       }
-    ],
-    "SPDXID": "SPDXRef-DOCUMENT",
-    "spdxVersion": "SPDX-2.2"
+    "licenseListVersion": "3.8"
+  },
+  "dataLicense": "CC-BY-4.0",
+  "documentDescribes": [
+    "SPDXRef-{{obj.uuid}}"
+  ],
+  "documentNamespace": "https://access.redhat.com/security/data/sbom/beta/spdx/{{obj.name|escapejs}}-{{obj.uuid}}",
+  "name": "{{obj.name|escapejs}}",
+  "packages": [{% block packages %}{% endblock %}
+  ],
+  "relationships": [{% block relationships %}{% endblock %}
+    {
+      "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# Document describes stream or component being manifested #}
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    }
+  ],
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.2"
 }

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,4 +1,4 @@
-{# Component manifest, obj is a Component here #}{% extends "base_manifest.json" %}
+{# Component manifest, obj is a Component here #}{% extends "base_manifest.json" %}{% load base_extras %}
 {% block packages %}{% for component in obj.provides_queryset %}{
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
         "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
@@ -63,10 +63,10 @@
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{obj.nevra|escapejs}}"
     }
-{% endblock packages %}{% block relationships %}{% for node_type, node_id in obj.get_provides_nodes_queryset %}
+{% endblock packages %}{% block relationships %}{% for node_purl, node_type, node_id in obj.get_provides_nodes_queryset %}
     {
       "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# subcomponent is built from, or contained in, component #}
-      "relationshipType": {% if node_type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
+      "relationshipType": "{{node_purl|provided_relationship:node_type}}",
       "spdxElementId": "SPDXRef-{{node_id}}"
     },{% endfor %}{% if obj.type != obj.Type.RPM %}{% for node_id in obj.get_upstreams_pks %}{# RPM upstream data is human-generated and unreliable #}
     {{# Upstreams of the root index container. Arch-specific containers have the same upstreams, so no need to report these separately #}

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -1,69 +1,70 @@
 {# Component manifest, obj is a Component here #}{% extends "base_manifest.json" %}{% load base_extras %}
-{% block packages %}{% for component in obj.provides_queryset %}{
-        "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{component.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{component.name|escapejs}}",
-        "originator": "NOASSERTION",
-        "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{component.uuid}}",
-        "supplier": "Organization: Red Hat",
-        "versionInfo": "{{component.nevra|escapejs}}"
+{% block packages %}{% for component in obj.provides_queryset %}
+    {
+      "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{component.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{component.name|escapejs}}",
+      "originator": "NOASSERTION",
+      "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{component.uuid}}",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "{{component.nevra|escapejs}}"
     },{% endfor %}{% if obj.type != obj.Type.RPM %}{% for upstream in obj.upstreams.get_queryset.iterator %}{# RPM upstream data is human-generated and unreliable #}{
-        "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{upstream.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if upstream.related_url and upstream.type != upstream.Type.RPM %}"{{upstream.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if upstream.license_concluded %}"{{upstream.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if upstream.license_declared %}"{{upstream.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{upstream.name|escapejs}}",
-        "packageFileName": {% if upstream.filename %}"{{upstream.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{upstream.uuid}}",
-        "supplier": "NOASSERTION",
-        "versionInfo": "{{upstream.nevra|escapejs}}"
+      "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{upstream.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if upstream.related_url and upstream.type != upstream.Type.RPM %}"{{upstream.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if upstream.license_concluded %}"{{upstream.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if upstream.license_declared %}"{{upstream.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{upstream.name|escapejs}}",
+      "packageFileName": {% if upstream.filename %}"{{upstream.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{upstream.uuid}}",
+      "supplier": "NOASSERTION",
+      "versionInfo": "{{upstream.nevra|escapejs}}"
     },{% endfor %}{% endif %}
     {
-        "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if obj.download_url %}"{{obj.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{obj.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if obj.related_url and obj.type != obj.Type.RPM %}"{{obj.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{obj.name|escapejs}}",
-        "originator": "NOASSERTION",
-        "packageFileName": {% if obj.filename %}"{{obj.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{obj.uuid}}",
-        "supplier": "Organization: Red Hat",
-        "versionInfo": "{{obj.nevra|escapejs}}"
-    }
-{% endblock packages %}{% block relationships %}{% for node_purl, node_type, node_id in obj.get_provides_nodes_queryset %}
+      "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if obj.download_url %}"{{obj.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{obj.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if obj.related_url and obj.type != obj.Type.RPM %}"{{obj.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if obj.license_concluded %}"{{obj.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if obj.license_declared %}"{{obj.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{obj.name|escapejs}}",
+      "originator": "NOASSERTION",
+      "packageFileName": {% if obj.filename %}"{{obj.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{obj.uuid}}",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "{{obj.nevra|escapejs}}"
+    }{% endblock packages %}
+{% block relationships %}{% for node_purl, node_type, node_id in obj.get_provides_nodes_queryset %}
     {
       "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",{# subcomponent is built from, or contained in, component #}
       "relationshipType": "{{node_purl|provided_relationship:node_type}}",
@@ -73,5 +74,4 @@
       "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
       "relationshipType": "GENERATES",
       "spdxElementId": "SPDXRef-{{node_id}}"
-    },{% endfor %}{% endif %}
-{% endblock relationships %}
+    },{% endfor %}{% endif %}{% endblock relationships %}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,4 +1,4 @@
-{# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}
+{# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}{% load base_extras %}
 {% block packages %}{% for component in released_components %}
     {
         "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
@@ -85,10 +85,10 @@
         "supplier": "Organization: Red Hat",
         "versionInfo": "{{obj.version}}"
     }
-{% endblock packages %}{% block relationships %}{% for component in released_components %}{% for node_type, node_id in component.get_provides_nodes_queryset %}
+{% endblock packages %}{% block relationships %}{% for component in released_components %}{% for node_purl, node_type, node_id in component.get_provides_nodes_queryset %}
         {
           "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
-          "relationshipType": {% if node_type == "PROVIDES_DEV" %}"DEV_DEPENDENCY_OF"{% else %}"CONTAINED_BY"{% endif %},
+          "relationshipType": "{{node_purl|provided_relationship:node_type}}",
           "spdxElementId": "SPDXRef-{{node_id}}"
         },{% endfor %}{% if component.type != component.Type.RPM %}{% for node_id in component.get_upstreams_pks %}{# RPM upstream data is human-generated and unreliable #}
         {{# Upstreams of the root index container. Arch-specific containers have the same upstreams, so no need to report these separately #}

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,104 +1,103 @@
 {# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}{% load base_extras %}
 {% block packages %}{% for component in released_components %}
     {
-        "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{component.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{component.name|escapejs}}",
-        "originator": "NOASSERTION",
-        "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{component.uuid}}",
-        "supplier": "Organization: Red Hat",
-        "versionInfo": "{{component.nevra|escapejs}}"
+      "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{component.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if component.related_url and component.type != component.Type.RPM %}"{{component.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if component.license_concluded %}"{{component.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if component.license_declared %}"{{component.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{component.name|escapejs}}",
+      "originator": "NOASSERTION",
+      "packageFileName": {% if component.filename %}"{{component.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{component.uuid}}",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "{{component.nevra|escapejs}}"
     },{% endfor %}{% for upstream in distinct_upstreams.iterator %}{
-        "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{upstream.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if upstream.related_url and upstream.type != upstream.Type.RPM %}"{{upstream.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if upstream.license_concluded %}"{{upstream.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if upstream.license_declared %}"{{upstream.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{upstream.name|escapejs}}",
-        "packageFileName": {% if upstream.filename %}"{{upstream.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{upstream.uuid}}",
-        "supplier": "NOASSERTION",
-        "versionInfo": "{{upstream.nevra|escapejs}}"
+      "copyrightText": {% if upstream.copyright_text %}"{{upstream.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if upstream.download_url %}"{{upstream.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{upstream.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if upstream.related_url and upstream.type != upstream.Type.RPM %}"{{upstream.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if upstream.license_concluded %}"{{upstream.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if upstream.license_declared %}"{{upstream.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{upstream.name|escapejs}}",
+      "packageFileName": {% if upstream.filename %}"{{upstream.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{upstream.uuid}}",
+      "supplier": "NOASSERTION",
+      "versionInfo": "{{upstream.nevra|escapejs}}"
     },{% endfor %}{% for provided in distinct_provides.iterator %}
     {
-        "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "downloadLocation": {% if provided.download_url %}"{{provided.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "externalRefs": [
-            {
-                "referenceCategory": "PACKAGE_MANAGER",
-                "referenceLocator": "{{provided.purl|safe}}",
-                "referenceType": "purl"
-            }
-        ],
-        "filesAnalyzed": false,
-        "homepage": {% if provided.related_url and provided.type != provided.Type.RPM %}"{{provided.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
-        "licenseConcluded": {% if provided.license_concluded %}"{{provided.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
-        "licenseDeclared": {% if provided.license_declared %}"{{provided.license_declared}}"{% else %}"NOASSERTION"{% endif %},
-        "name": "{{provided.name|escapejs}}",
-        "originator": "NOASSERTION",
-        "packageFileName": {% if provided.filename %}"{{provided.filename}}"{% else %}"NOASSERTION"{% endif %},
-        "SPDXID": "SPDXRef-{{provided.uuid}}",
-        "supplier": "Organization: Red Hat",
-        "versionInfo": "{{provided.nevra|escapejs}}"
+      "copyrightText": {% if provided.copyright_text %}"{{provided.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "downloadLocation": {% if provided.download_url %}"{{provided.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "{{provided.purl|safe}}",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "homepage": {% if provided.related_url and provided.type != provided.Type.RPM %}"{{provided.related_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
+      "licenseConcluded": {% if provided.license_concluded %}"{{provided.license_concluded}}"{% else %}"NOASSERTION"{% endif %},
+      "licenseDeclared": {% if provided.license_declared %}"{{provided.license_declared}}"{% else %}"NOASSERTION"{% endif %},
+      "name": "{{provided.name|escapejs}}",
+      "originator": "NOASSERTION",
+      "packageFileName": {% if provided.filename %}"{{provided.filename}}"{% else %}"NOASSERTION"{% endif %},
+      "SPDXID": "SPDXRef-{{provided.uuid}}",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "{{provided.nevra|escapejs}}"
     },{% endfor %}
     {
-        "copyrightText": "NOASSERTION",
-        "downloadLocation": "NOASSERTION", {% if cpes %}
-        "externalRefs": [{% for cpe in cpes %}
-            {
-                "referenceCategory": "SECURITY",
-                "referenceLocator": "{{cpe}}",
-                "referenceType": "cpe22Type"
-            }{% if not forloop.last %},{% endif %}{% endfor %}
-        ],{% endif %}
-        "filesAnalyzed": false,
-        "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
-        "licenseComments": "Licensing information is provided for individual components only at this time.",
-        "licenseConcluded": "NOASSERTION",
-        "licenseDeclared": "NOASSERTION",
-        "name": "{{obj.name|escapejs}}",
-        "packageFileName": "NOASSERTION",
-        "SPDXID": "SPDXRef-{{obj.uuid}}",
-        "supplier": "Organization: Red Hat",
-        "versionInfo": "{{obj.version}}"
-    }
-{% endblock packages %}{% block relationships %}{% for component in released_components %}{% for node_purl, node_type, node_id in component.get_provides_nodes_queryset %}
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",{% if cpes %}
+      "externalRefs": [{% for cpe in cpes %}
         {
-          "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
-          "relationshipType": "{{node_purl|provided_relationship:node_type}}",
-          "spdxElementId": "SPDXRef-{{node_id}}"
-        },{% endfor %}{% if component.type != component.Type.RPM %}{% for node_id in component.get_upstreams_pks %}{# RPM upstream data is human-generated and unreliable #}
-        {{# Upstreams of the root index container. Arch-specific containers have the same upstreams, so no need to report these separately #}
-          "relatedSpdxElement": "SPDXRef-{{component.uuid}}",
-          "relationshipType": "GENERATES",
-          "spdxElementId": "SPDXRef-{{node_id}}"
-        },{% endfor %}{% endif %}
-        {
-          "relatedSpdxElement": "SPDXRef-{{obj.uuid}}",
-          "relationshipType": "PACKAGE_OF",
-          "spdxElementId": "SPDXRef-{{component.uuid}}"
-        },{% endfor %}
-{% endblock relationships %}
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "{{cpe}}",
+          "referenceType": "cpe22Type"
+        }{% if not forloop.last %},{% endif %}{% endfor %}
+      ],{% endif %}
+      "filesAnalyzed": false,
+      "homepage": {% if obj.lifecycle_url %}"{{obj.lifecycle_url}}"{% else %}"https://www.redhat.com/"{% endif %},
+      "licenseComments": "Licensing information is provided for individual components only at this time.",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "name": "{{obj.name|escapejs}}",
+      "packageFileName": "NOASSERTION",
+      "SPDXID": "SPDXRef-{{obj.uuid}}",
+      "supplier": "Organization: Red Hat",
+      "versionInfo": "{{obj.version}}"
+    }{% endblock packages %}
+{% block relationships %}{% for component in released_components %}{% for node_purl, node_type, node_id in component.get_provides_nodes_queryset %}
+    {
+      "relatedSpdxElement": "SPDXRef-{{component.uuid}}",{# subcomponent is built from, or contained in, component #}
+      "relationshipType": "{{node_purl|provided_relationship:node_type}}",
+      "spdxElementId": "SPDXRef-{{node_id}}"
+    },{% endfor %}{% if component.type != component.Type.RPM %}{% for node_id in component.get_upstreams_pks %}{# RPM upstream data is human-generated and unreliable #}
+    {{# Upstreams of the root index container. Arch-specific containers have the same upstreams, so no need to report these separately #}
+      "relatedSpdxElement": "SPDXRef-{{component.uuid}}",
+      "relationshipType": "GENERATES",
+      "spdxElementId": "SPDXRef-{{node_id}}"
+    },{% endfor %}{% endif %}
+    {
+      "relatedSpdxElement": "SPDXRef-{{obj.uuid}}", 
+      "relationshipType": "PACKAGE_OF",
+      "spdxElementId": "SPDXRef-{{component.uuid}}"
+    },{% endfor %}{% endblock relationships %}

--- a/corgi/web/templatetags/base_extras.py
+++ b/corgi/web/templatetags/base_extras.py
@@ -2,6 +2,7 @@ from django import template
 from django.conf import settings
 
 from corgi import __version__
+from corgi.core.models import Component
 
 register = template.Library()
 
@@ -30,3 +31,15 @@ def app_git_ref():
     """
     git_ref = settings.OPENSHIFT_BUILD_COMMIT
     return f" ({git_ref[:8]})" if git_ref else ""
+
+
+@register.filter
+def provided_relationship(node_purl: str, node_type: str) -> str:
+    """Relate a provided component to its parent component, based on purl and provided node type"""
+    if node_purl.startswith(f"pkg:{Component.Type.CONTAINER_IMAGE.lower()}/"):
+        # Arch-specific container is a variant of (arch-independent / noarch) index-container
+        return "VARIANT_OF"
+    elif node_type == "PROVIDES_DEV":
+        return "DEV_DEPENDENCY_OF"
+    else:
+        return "CONTAINED_BY"


### PR DESCRIPTION
@mprpic Please review (you're given as the stakeholder in the ticket). This change should give us SPDX relationships in our manifests like:

1. VARIANT_OF for containers which are child / provided components (purl starts with "pkg:oci/")
2. DEV_DEPENDENCY_OF for any non-container dev_provided component (purl does not start with "pkg:oci/", node has PROVIDES_DEV type)
3. CONTAINED_BY for all other provided components (which are not containers or dev dependencies)

The first commit is the logic for above, the second was just whitespace changes to help me debug / diff the manifests locally while testing this.