### PR TITLE
CORGI-685: Ensure go_component_type is set when possible, and fix migration

### DIFF
--- a/corgi/core/migrations/0069_fix_vendor_in_go_package_names.py
+++ b/corgi/core/migrations/0069_fix_vendor_in_go_package_names.py
@@ -1,4 +1,5 @@
 from django.db import migrations, transaction
+from django.db.utils import IntegrityError
 
 
 def fix_vendor_in_go_package_names(apps, schema_editor):
@@ -9,19 +10,32 @@ def fix_vendor_in_go_package_names(apps, schema_editor):
     # 628 go-packages were saved with "vendor/" in their name, due to a typo
     # We strip this value for Go packages that are linked to modules
     # We should, but didn't, strip it for Go packages that are direct dependents
-    # not linked to any module (usually stdlib packages)
+    # not linked to any module (all stdlib packages)
     with transaction.atomic():
         for component in Component.objects.filter(
             type="GOLANG", name__startswith="vendor/"
         ).iterator():
-            component.name = component.name.replace("vendor/", "", 1)
-            # We can't rely on custom .save() code to update the purl
-            component.purl = component.purl.replace("vendor/", "", 1)
-            component.save()
+            try:
+                component.name = component.name.replace("vendor/", "", 1)
+                # We can't rely on custom .save() code to update the nevra / purl??
+                component.nevra = component.nevra.replace("vendor/", "", 1)
+                component.purl = component.purl.replace("vendor/", "", 1)
+                component.save()
+            except IntegrityError:
+                # The Component is a duplicate and can't be updated
+                # Relinking all the cnodes to the other Component also fails
+                # Fixing the duplicate nodes without losing data is non-trivial
+                # Punt for now, clean all this mess up in CORGI-566
+                pass
         # We also can't access GenericForeignKeys / component.cnodes in a migration
         for node in ComponentNode.objects.filter(purl__startswith="pkg:golang/vendor/").iterator():
-            node.purl = node.purl.replace("vendor/", "", 1)
-            node.save()
+            try:
+                new_purl = node.purl.replace("vendor/", "", 1)
+                node.obj = Component.objects.get(purl=new_purl)
+                node.purl = new_purl
+                node.save()
+            except IntegrityError:
+                pass
 
 
 class Migration(migrations.Migration):

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -217,7 +217,10 @@ def save_component(
         node_type = ComponentNode.ComponentNodeType.PROVIDES_DEV
 
     # Map Cachito (lowercase) type to Corgi TYPE, or use existing Corgi TYPE, or raise error
-    if component_type in Brew.CACHITO_PKG_TYPE_MAPPING:
+    if component_type in ("go-package", "gomod"):
+        meta["go_component_type"] = component_type
+        component_type = Component.Type.GOLANG
+    elif component_type in Brew.CACHITO_PKG_TYPE_MAPPING:
         component_type = Brew.CACHITO_PKG_TYPE_MAPPING[component_type]
     elif component_type.upper() in Component.Type.values:
         component_type = component_type.upper()


### PR DESCRIPTION
Quick fix for bad migration in previous MR. Some of this data cleanup is not simple (both duplicate components and duplicate nodes), so I've added notes to the migration and CORGI-566 about how we might do the full cleanup.