### PR TITLE
Add a UMB dispatcher which routes messages to many handlers

### DIFF
--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional
+from collections.abc import Callable
 
 from django.conf import settings
 from proton import Event, SSLDomain
@@ -12,17 +12,33 @@ from corgi.tasks.errata_tool import slow_handle_shipped_errata
 
 logger = logging.getLogger(__name__)
 
+# A method which receives an event, and returns true if the message was accepted,
+# or false if it should be released back into the queue.
+HandleMethod = Callable[[Event], bool]
 
-class UMBReceiverHandler(MessagingHandler):
-    """Handler to deal with received messages from UMB."""
+VIRTUAL_TOPIC_PREFIX = f"Consumer.{settings.UMB_CONSUMER}.VirtualTopic.eng"
 
-    def __init__(self, virtual_topic_addresses: dict[str, str], selectors: dict[str, str]):
-        """Set up a handler that listens to many topics and processes messages from each"""
-        super(UMBReceiverHandler, self).__init__()
 
+class UMBHandler:
+    """Handler to deal with received messages from UMB. Defines topics to listen to and
+    methods to invoke for handle messages in those topics."""
+
+    def __init__(self, addresses: dict[str, HandleMethod], selectors: dict[str, str]):
         # A mapping of virtual topic addresses to functions that handle topic messages
         # as determined by a specific listener.
-        self.virtual_topic_addresses = virtual_topic_addresses
+        self.virtual_topic_addresses = addresses
+
+        # A set of filters used to narrow down the received messages from UMB for this handler, if
+        # none, handle all messages
+        self.selectors = selectors
+
+
+class UMBDispatcher(MessagingHandler):
+    """Maintains a collection of UMBHandlers and dispatches messages to them"""
+
+    def __init__(self):
+        """Set up a handler that listens to many topics and processes messages from each"""
+        super(UMBDispatcher, self).__init__()
 
         # Set of URLs where UMB brokers are running. Use AMQP protocol port numbers only. See
         # specific URLs in settings; use env vars to select the appropriate broker.
@@ -38,10 +54,8 @@ class UMBReceiverHandler(MessagingHandler):
         self.ssl_domain.set_trusted_ca_db(settings.CA_CERT)
         self.ssl_domain.set_peer_authentication(SSLDomain.VERIFY_PEER)
 
-        # A set of filters used to narrow down the received messages from UMB; see individual
-        # listeners to see if they define any selectors or consume all messages without any
-        # filtering.
-        self.selectors = selectors
+        # A list of UMBHandlers to which messages will be dispatched
+        self.handlers: list[UMBHandler]
 
         # Ack messages manually so that we can ensure we successfully acted upon a message when
         # it was received. See accept condition logic in the on_message() method.
@@ -50,6 +64,33 @@ class UMBReceiverHandler(MessagingHandler):
         # Each message that is accepted also needs to be settled locally. Auto-settle each
         # message that is accepted automatically (this is the default value).
         self.auto_settle = True
+
+        # Handlers must be registered before the listener is started
+        self.started = False
+
+    def register_handler(self, handler: UMBHandler):
+        """Register an additional handler. Handlers should be registered before the dispatcher
+        is started."""
+        if self.started:
+            raise RuntimeError("Handlers must be added before UMBDispatcher is started")
+        elif not handler.virtual_topic_addresses:
+            raise ValueError("Handler has no addresses")
+        else:
+            self.handlers.append(handler)
+
+    @property
+    def virtual_topic_addresses(self) -> dict[str, HandleMethod]:
+        return {
+            addr: handler.virtual_topic_addresses[addr]
+            for handler in self.handlers
+            for addr in handler.virtual_topic_addresses
+        }
+
+    @property
+    def selectors(self) -> dict[str, str]:
+        return {
+            addr: handler.selectors[addr] for handler in self.handlers for addr in handler.selectors
+        }
 
     def on_start(self, event: Event) -> None:
         """Connect to UMB broker(s) and set up a receiver for each virtual topic address"""
@@ -69,25 +110,55 @@ class UMBReceiverHandler(MessagingHandler):
         address = event.message.address or ""
         address = address.replace("topic://", f"Consumer.{settings.UMB_CONSUMER}.")
 
-        # Turn function name (str) into callable so we can pass event to it below
-        # We don't pass the callable itself because it needs a self arg
-        callback_name = self.virtual_topic_addresses.get(address, "")
-        callback_function = getattr(self, callback_name, None)
+        # Look up the function registered for this address
+        callback = self.virtual_topic_addresses.get(address)
 
         if not address:
             raise ValueError(f"UMB event {event.message.id} had no address!")
-        elif callback_function:
-            callback_function(event)
+        elif callback:
+            accepted = callback(event)
+            if accepted:
+                # Accept the delivered message to remove it from the queue.
+                self.accept(event.delivery)
+            else:
+                # Release message back to the queue but report back that it was delivered. The
+                # message will be re-delivered to any available client again.
+                self.release(event.delivery, delivered=True)
         else:
             raise ValueError(
                 f"UMB event {event.message.id} had unrecognized address: {event.message.address}"
             )
 
+    def consume(self):
+        """Run a single message handler, which can listen to multiple virtual topic addresses"""
+        if not self.handlers:
+            raise ValueError("Dispatcher must have handler(s) registered before consuming")
 
-class BrewUMBReceiverHandler(UMBReceiverHandler):
-    """Handle messages about completed Brew builds, tagged builds, and untagged builds"""
+        logger.info("Starting consumer for virtual topic(s): %s", self.virtual_topic_addresses)
+        Container(self).run()
 
-    def handle_builds(self, event: Event) -> None:
+
+class BrewUMBHandler(UMBHandler):
+    """Handle messages about completed Brew builds, tagged builds, and untagged builds, listen
+    for messages about shipped ET advisories, only to update released tags on Brew builds."""
+
+    def __init__(self):
+        addresses = {
+            f"{VIRTUAL_TOPIC_PREFIX}.brew.build.complete": self.handle_builds,
+            f"{VIRTUAL_TOPIC_PREFIX}.brew.build.tag": self.handle_tags,
+            f"{VIRTUAL_TOPIC_PREFIX}.brew.build.untag": self.handle_tags,
+            f"{VIRTUAL_TOPIC_PREFIX}.errata.activity.status": self.handle_shipped_errata,
+        }
+        # By default, listen for all messages on a topic
+        selectors = {key: "" for key in addresses}
+        # Only listen for messages about SHIPPED_LIVE errata
+        selectors[
+            f"{VIRTUAL_TOPIC_PREFIX}.errata.activity.status"
+        ] = "errata_status = 'SHIPPED_LIVE'"
+
+        super(UMBHandler, self).__init__(addresses=addresses, selectors=selectors)
+
+    def handle_builds(self, event: Event) -> bool:
         """Handle messages about completed Brew builds"""
         logger.info("Handling UMB event for completed builds: %s", event.message.id)
         message = json.loads(event.message.body)
@@ -101,14 +172,11 @@ class BrewUMBReceiverHandler(UMBReceiverHandler):
                 build_id,
                 str(exc),
             )
-            # Release message back to the queue but report back that it was delivered. The
-            # message will be re-delivered to any available client again.
-            self.release(event.delivery, delivered=True)
+            return False
         else:
-            # Accept the delivered message to remove it from the queue.
-            self.accept(event.delivery)
+            return True
 
-    def handle_shipped_errata(self, event: Event) -> None:
+    def handle_shipped_errata(self, event: Event) -> bool:
         """Handle messages about ET advisories that enter the SHIPPED_LIVE state"""
         logger.info("Handling UMB event for shipped erratum: %s", event.message.id)
         message = json.loads(event.message.body)
@@ -129,14 +197,11 @@ class BrewUMBReceiverHandler(UMBReceiverHandler):
                 errata_id,
                 str(exc),
             )
-            # Release message back to the queue but report back that it was delivered. The
-            # message will be re-delivered to any available client again.
-            self.release(event.delivery, delivered=True)
+            return False
         else:
-            # Accept the delivered message to remove it from the queue.
-            self.accept(event.delivery)
+            return True
 
-    def handle_tags(self, event: Event) -> None:
+    def handle_tags(self, event: Event) -> bool:
         """Handle messages about Brew builds that have tags added or removed"""
         logger.info("Handling UMB event for added or removed tags: %s", event.message.id)
         message = json.loads(event.message.body)
@@ -156,52 +221,6 @@ class BrewUMBReceiverHandler(UMBReceiverHandler):
                 build_id,
                 str(exc),
             )
-            # Release message back to the queue but report back that it was delivered. The
-            # message will be re-delivered to any available client again.
-            self.release(event.delivery, delivered=True)
+            return False
         else:
-            # Accept the delivered message to remove it from the queue.
-            self.accept(event.delivery)
-
-
-class UMBListener:
-    """Base class that listens for and handles messages on certain UMB topics"""
-
-    VIRTUAL_TOPIC_PREFIX = f"Consumer.{settings.UMB_CONSUMER}.VirtualTopic.eng"
-    handler_class: Optional[MessagingHandler] = None
-    virtual_topic_addresses: dict[str, str] = {}
-    # By default, listen for all messages on a topic
-    selectors: dict[str, str] = {}
-
-    @classmethod
-    def consume(cls):
-        """Run a single message handler, which can listen to multiple virtual topic addresses"""
-        if not cls.handler_class or not cls.virtual_topic_addresses:
-            raise NotImplementedError(
-                "Subclass must define handler class and virtual topic address(es)"
-            )
-
-        logger.info("Starting consumer for virtual topic(s): %s", cls.virtual_topic_addresses)
-        handler = cls.handler_class(
-            virtual_topic_addresses=cls.virtual_topic_addresses, selectors=cls.selectors
-        )
-        Container(handler).run()
-
-
-class BrewUMBListener(UMBListener):
-    """Listen for messages about completed Brew builds, tagged builds, and untagged builds.
-    Listen for messages about shipped ET advisories, only to update released tags on Brew builds."""
-
-    handler_class = BrewUMBReceiverHandler
-    virtual_topic_addresses = {
-        f"{UMBListener.VIRTUAL_TOPIC_PREFIX}.brew.build.complete": "handle_builds",
-        f"{UMBListener.VIRTUAL_TOPIC_PREFIX}.brew.build.tag": "handle_tags",
-        f"{UMBListener.VIRTUAL_TOPIC_PREFIX}.brew.build.untag": "handle_tags",
-        f"{UMBListener.VIRTUAL_TOPIC_PREFIX}.errata.activity.status": "handle_shipped_errata",
-    }
-    # By default, listen for all messages on a topic
-    selectors = {key: "" for key in virtual_topic_addresses}
-    # Only listen for messages about SHIPPED_LIVE errata
-    selectors[
-        f"{UMBListener.VIRTUAL_TOPIC_PREFIX}.errata.activity.status"
-    ] = "errata_status = 'SHIPPED_LIVE'"
+            return True

--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -26,6 +26,8 @@ class UMBHandler:
     def __init__(self, addresses: dict[str, HandleMethod], selectors: dict[str, str]):
         if not addresses:
             raise ValueError("UMBHandler has no addresses")
+        if not all(callable(handler) for handler in addresses.values()):
+            raise ValueError("UMBHandler is missing handler function(s)")
         # A mapping of virtual topic addresses to functions that handle topic messages
         # as determined by a specific listener.
         self.virtual_topic_addresses = addresses
@@ -55,7 +57,8 @@ class BrewUMBHandler(UMBHandler):
 
         super(BrewUMBHandler, self).__init__(addresses=addresses, selectors=selectors)
 
-    def handle_builds(self, event: Event) -> bool:
+    @staticmethod
+    def handle_builds(event: Event) -> bool:
         """Handle messages about completed Brew builds"""
         logger.info("Handling UMB event for completed builds: %s", event.message.id)
         message = json.loads(event.message.body)
@@ -73,7 +76,8 @@ class BrewUMBHandler(UMBHandler):
         else:
             return True
 
-    def handle_shipped_errata(self, event: Event) -> bool:
+    @staticmethod
+    def handle_shipped_errata(event: Event) -> bool:
         """Handle messages about ET advisories that enter the SHIPPED_LIVE state"""
         logger.info("Handling UMB event for shipped erratum: %s", event.message.id)
         message = json.loads(event.message.body)
@@ -98,7 +102,8 @@ class BrewUMBHandler(UMBHandler):
         else:
             return True
 
-    def handle_tags(self, event: Event) -> bool:
+    @staticmethod
+    def handle_tags(event: Event) -> bool:
         """Handle messages about Brew builds that have tags added or removed"""
         logger.info("Handling UMB event for added or removed tags: %s", event.message.id)
         message = json.loads(event.message.body)

--- a/corgi/monitor/management/commands/runmonitor.py
+++ b/corgi/monitor/management/commands/runmonitor.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from corgi.monitor.consumer import BrewUMBHandler, UMBDispatcher
+from corgi.monitor.consumer import UMBDispatcher
 
 
 class Command(BaseCommand):
@@ -13,7 +13,6 @@ class Command(BaseCommand):
         if settings.UMB_BREW_MONITOR_ENABLED:
             try:
                 dispatcher = UMBDispatcher()
-                dispatcher.register_handler(BrewUMBHandler())
                 dispatcher.consume()
             except KeyboardInterrupt:
                 pass

--- a/corgi/monitor/management/commands/runmonitor.py
+++ b/corgi/monitor/management/commands/runmonitor.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from corgi.monitor.consumer import BrewUMBListener
+from corgi.monitor.consumer import BrewUMBHandler, UMBDispatcher
 
 
 class Command(BaseCommand):
@@ -12,6 +12,8 @@ class Command(BaseCommand):
     def handle(self, *args: str, **options: dict[str, str]) -> None:
         if settings.UMB_BREW_MONITOR_ENABLED:
             try:
-                BrewUMBListener.consume()
+                dispatcher = UMBDispatcher()
+                dispatcher.register_handler(BrewUMBHandler())
+                dispatcher.consume()
             except KeyboardInterrupt:
                 pass

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -31,8 +31,22 @@ def test_dispatcher_requires_addresses():
 
     class NoAddressHandler(UMBHandler):
         def __init__(self):
-            with pytest.raises(ValueError):
-                super(UMBHandler, self).__init__(None, None)
+            super(NoAddressHandler, self).__init__(None, None)
+
+    with pytest.raises(ValueError):
+        NoAddressHandler()
+
+
+def test_dispatcher_requires_handlers():
+    """Test UMBHandler raises ValueError for missing handler functions"""
+
+    class BadHandler(UMBHandler):
+        def __init__(self):
+            addresses = {"UMB_Topic": None}
+            super(BadHandler, self).__init__(addresses, {})
+
+    with pytest.raises(ValueError):
+        BadHandler()
 
 
 def test_brew_umb_handler_defines_settings():

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -3,94 +3,73 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from django.conf import settings
 
-from corgi.monitor.consumer import BrewUMBListener, BrewUMBReceiverHandler, UMBListener
+from corgi.monitor.consumer import BrewUMBHandler, UMBDispatcher, UMBHandler
 
 pytestmark = pytest.mark.unit
 
-VIRTUAL_TOPIC_ADDRESS_PREFIX = f"Consumer.{settings.UMB_CONSUMER}."
+ADDRESS_PREFIX = f"Consumer.{settings.UMB_CONSUMER}."
 
 
-def test_umb_listener_requires_settings():
-    """Test UMBListener base class raises NotImplementedError
-    for missing address or missing handler class"""
-    listener = UMBListener()
-    with patch.object(listener, "handler_class", BrewUMBReceiverHandler):
-        assert listener.virtual_topic_addresses == {}
-        with pytest.raises(NotImplementedError):
-            listener.consume()
-
-    with patch.object(listener, "virtual_topic_addresses", {"1": "1"}):
-        assert listener.handler_class is None
-        with pytest.raises(NotImplementedError):
-            listener.consume()
-
-
-def test_brew_umb_listener_defines_settings():
-    """Test BrewUMBListener subclass listens for messages on defined address
-    and handles them with correct class"""
-    listener = BrewUMBListener()
-    assert listener.virtual_topic_addresses == {
-        f"{VIRTUAL_TOPIC_ADDRESS_PREFIX}VirtualTopic.eng.brew.build.complete": "handle_builds",
-        f"{VIRTUAL_TOPIC_ADDRESS_PREFIX}VirtualTopic.eng.brew.build.tag": "handle_tags",
-        f"{VIRTUAL_TOPIC_ADDRESS_PREFIX}VirtualTopic.eng.brew.build.untag": "handle_tags",
-        f"{VIRTUAL_TOPIC_ADDRESS_PREFIX}VirtualTopic.eng."
-        f"errata.activity.status": "handle_shipped_errata",
-    }
-    assert listener.handler_class == BrewUMBReceiverHandler
-
-    # Stub out the real Container class with a mock we can assert on
-    with patch("corgi.monitor.consumer.Container") as mock_container_constructor:
-        # Stub out a different class that we don't want to test here
-        with patch.object(BrewUMBListener, "handler_class") as mock_receiver_constructor:
-            listener.consume()
-
-    # We call the BrewUMBReceiverHandler() constructor with the class's virtual topic addresses
-    # and a dict of selectors for each address
-    mock_receiver_constructor.assert_called_once_with(
-        virtual_topic_addresses=listener.virtual_topic_addresses, selectors=listener.selectors
-    )
-
-    # We call the Container() constructor with an instance of BrewUMBReceiverHandler()
-    # returned by mock_receiver_constructor above so we don't need real UMB certs in tests
-    mock_receiver_instance = mock_receiver_constructor.return_value
-    mock_container_constructor.assert_called_once_with(mock_receiver_instance)
-
-    # We call run() on the Container() instance returned by mock_container_constructor
-    mock_container_instance = mock_container_constructor.return_value
-    mock_container_instance.run.assert_called_once_with()
-
-
-def test_brew_umb_receiver_setup():
-    """Test that the BrewUMBReceiverHandler class is set up correctly"""
-    listener = BrewUMBListener()
-    addresses = listener.virtual_topic_addresses
-    selectors = listener.selectors
+def test_dispatcher_setup():
+    """Test UMBDispatcher's configuration"""
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain") as mock_ssl_domain_constructor:
-        handler = BrewUMBReceiverHandler(virtual_topic_addresses=addresses, selectors=selectors)
+        dispatcher = UMBDispatcher()
 
     # We listen (in client mode) to the address passed in, and connect to the UMB URL from settings
     mock_ssl_domain_constructor.assert_called_once_with(mock_ssl_domain_constructor.MODE_CLIENT)
-    mock_ssl_domain_instance = mock_ssl_domain_constructor.return_value
-    assert handler.virtual_topic_addresses == addresses
-    assert handler.selectors == selectors
-    assert handler.urls == [settings.UMB_BROKER_URL]
+    assert dispatcher.urls == [settings.UMB_BROKER_URL]
 
     # Messages should be accepted manually (only if no exception)
-    assert handler.auto_accept is False
+    assert dispatcher.auto_accept is False
     # Accepted messages should be automatically settled (this is the default)
-    assert handler.auto_settle is True
+    assert dispatcher.auto_settle is True
+
+
+def test_dispatcher_requires_addresses():
+    """Test UMBHandler raises ValueError for missing addresses"""
+
+    class NoAddressHandler(UMBHandler):
+        def __init__(self):
+            with pytest.raises(ValueError):
+                super(UMBHandler, self).__init__(None, None)
+
+
+def test_brew_umb_handler_defines_settings():
+    """Test BrewUMBHandler subclass listens for messages on defined address
+    and handles them with correct methods"""
+    handler = BrewUMBHandler()
+    assert handler.virtual_topic_addresses == {
+        f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.complete": handler.handle_builds,
+        f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.tag": handler.handle_tags,
+        f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.untag": handler.handle_tags,
+        f"{ADDRESS_PREFIX}VirtualTopic.eng."
+        f"errata.activity.status": handler.handle_shipped_errata,
+    }
+
+
+def test_brew_umb_handler_setup():
+    """Test that the BrewUMBHandler class is set up correctly by the UMBDispatcher"""
+    # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
+    with patch("corgi.monitor.consumer.SSLDomain") as mock_ssl_domain_constructor:
+        dispatcher = UMBDispatcher()
+
+    # The addresses and selectors of the dispatcher should match those of a handler
+    handler = BrewUMBHandler()
+    assert dispatcher.virtual_topic_addresses.keys() == handler.virtual_topic_addresses.keys()
+    assert dispatcher.selectors == handler.selectors
 
     mock_umb_event = MagicMock()
     mock_connection_constructor = mock_umb_event.container.connect
     mock_connection_instance = mock_connection_constructor.return_value
+    mock_ssl_domain_instance = mock_ssl_domain_constructor.return_value
     with patch("corgi.monitor.consumer.Selector") as mock_selector:
-        handler.on_start(mock_umb_event)
+        dispatcher.on_start(mock_umb_event)
         mock_selector.assert_called_once_with("errata_status = 'SHIPPED_LIVE'")
         shipped_errata_selector = mock_selector.return_value
 
     mock_connection_constructor.assert_called_once_with(
-        urls=handler.urls, ssl_domain=mock_ssl_domain_instance, heartbeat=500
+        urls=dispatcher.urls, ssl_domain=mock_ssl_domain_instance, heartbeat=500
     )
 
     # One receiver per virtual topic address should be created
@@ -99,55 +78,49 @@ def test_brew_umb_receiver_setup():
             mock_connection_instance,
             address,
             name=None,
-            options=[shipped_errata_selector] if handler.selectors.get(address) else [],
+            options=[shipped_errata_selector] if dispatcher.selectors.get(address) else [],
         )
-        for address in handler.virtual_topic_addresses
+        for address in dispatcher.virtual_topic_addresses
     ]
     assert len(handler.virtual_topic_addresses) == 4
     mock_umb_event.container.create_receiver.assert_has_calls(create_receiver_calls)
 
 
-def test_brew_umb_receiver_():
-    """Test that the BrewUMBReceiverHandler class raises an error
+def test_bad_addresses():
+    """Test that the UMBDispatcher class raises an error
     when a message is missing its address or is for an unknown topic"""
-    listener = BrewUMBListener()
-    addresses = listener.virtual_topic_addresses
-    selectors = listener.selectors
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain"):
-        handler = BrewUMBReceiverHandler(virtual_topic_addresses=addresses, selectors=selectors)
+        dispatcher = UMBDispatcher()
 
     mock_umb_event = MagicMock()
     mock_id = "1"
     mock_umb_event.message.address = "invalid_virtual_topic_address"
-    assert mock_umb_event.message.address not in addresses
+    assert mock_umb_event.message.address not in dispatcher.virtual_topic_addresses
 
     mock_umb_event.message.body = '{"info": {"build_id": MOCK_ID}}'.replace("MOCK_ID", mock_id)
     with pytest.raises(ValueError):
-        handler.on_message(mock_umb_event)
+        dispatcher.on_message(mock_umb_event)
 
     mock_umb_event.message.address = None
     with pytest.raises(ValueError):
-        handler.on_message(mock_umb_event)
+        dispatcher.on_message(mock_umb_event)
 
 
-def test_brew_umb_receiver_handles_builds():
-    """Test that the BrewUMBReceiverHandler class either
+def test_brew_umb_handler_handles_builds():
+    """Test that the BrewUMBHandler class either
     accepts a "build complete" message, when no exception is raised
     OR rejects the message if any exception is raised"""
-    listener = BrewUMBListener()
-    addresses = listener.virtual_topic_addresses
-    selectors = listener.selectors
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain"):
-        handler = BrewUMBReceiverHandler(virtual_topic_addresses=addresses, selectors=selectors)
+        dispatcher = UMBDispatcher()
 
     mock_umb_event = MagicMock()
     mock_id = "1"
     mock_umb_event.message.address = "topic://VirtualTopic.eng.brew.build.complete"
     assert (
-        mock_umb_event.message.address.replace("topic://", VIRTUAL_TOPIC_ADDRESS_PREFIX)
-        in addresses
+        mock_umb_event.message.address.replace("topic://", ADDRESS_PREFIX)
+        in dispatcher.virtual_topic_addresses
     )
 
     mock_umb_event.message.body = '{"info": {"build_id": MOCK_ID}}'.replace("MOCK_ID", mock_id)
@@ -162,13 +135,13 @@ def test_brew_umb_receiver_handles_builds():
         side_effect=umb_message_exceptions,
     ) as slow_fetch_brew_build_mock:
         # First call raises no exception, message should be accepted
-        with patch.object(handler, "accept") as mock_accept:
-            handler.on_message(mock_umb_event)
+        with patch.object(dispatcher, "accept") as mock_accept:
+            dispatcher.on_message(mock_umb_event)
             mock_accept.assert_called_once_with(mock_umb_event.delivery)
 
         # Second call raises exception given above, message should be rejected
-        with patch.object(handler, "release") as mock_release:
-            handler.on_message(mock_umb_event)
+        with patch.object(dispatcher, "release") as mock_release:
+            dispatcher.on_message(mock_umb_event)
             mock_release.assert_called_once_with(mock_umb_event.delivery, delivered=True)
 
     # slow_fetch_brew_build.apply_async is called once per message with a build_id arg
@@ -176,23 +149,21 @@ def test_brew_umb_receiver_handles_builds():
 
 
 def test_handle_tag_and_untag_messages():
-    """Test that the BrewUMBReceiverHandler class either
+    """Test that the BrewUMBHandler class either
     accepts tag / untag messages, when no exceptions are raised
     OR rejects tag / untag messages if any exception is raised"""
-    listener = BrewUMBListener()
-    addresses = listener.virtual_topic_addresses
-    selectors = listener.selectors
-    _, tag_address, untag_address, _ = addresses.keys()
-    assert VIRTUAL_TOPIC_ADDRESS_PREFIX in tag_address
-    assert VIRTUAL_TOPIC_ADDRESS_PREFIX in untag_address
-    assert ".tag" in tag_address
-    assert ".untag" in untag_address
-    tag_address = tag_address.replace(VIRTUAL_TOPIC_ADDRESS_PREFIX, "topic://")
-    untag_address = untag_address.replace(VIRTUAL_TOPIC_ADDRESS_PREFIX, "topic://")
-
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain"):
-        handler = BrewUMBReceiverHandler(virtual_topic_addresses=addresses, selectors=selectors)
+        dispatcher = UMBDispatcher()
+
+    addresses = dispatcher.virtual_topic_addresses
+    _, tag_address, untag_address, _ = addresses.keys()
+    assert ADDRESS_PREFIX in tag_address
+    assert ADDRESS_PREFIX in untag_address
+    assert ".tag" in tag_address
+    assert ".untag" in untag_address
+    tag_address = tag_address.replace(ADDRESS_PREFIX, "topic://")
+    untag_address = untag_address.replace(ADDRESS_PREFIX, "topic://")
 
     mock_umb_event = MagicMock()
     mock_id = "1"
@@ -213,28 +184,28 @@ def test_handle_tag_and_untag_messages():
         "corgi.monitor.consumer.slow_update_brew_tags.apply_async",
         side_effect=umb_message_exceptions,
     ) as slow_update_brew_tags_mock:
-        with patch.object(handler, "accept") as mock_accept:
+        with patch.object(dispatcher, "accept") as mock_accept:
             # First tag call raises no exception, message should be accepted
             mock_umb_event.message.address = tag_address
-            handler.on_message(mock_umb_event)
+            dispatcher.on_message(mock_umb_event)
             mock_accept.assert_called_once_with(mock_umb_event.delivery)
             mock_accept.reset_mock()
 
             # First untag call raises no exception, message should be accepted
             mock_umb_event.message.address = untag_address
-            handler.on_message(mock_umb_event)
+            dispatcher.on_message(mock_umb_event)
             mock_accept.assert_called_once_with(mock_umb_event.delivery)
 
-        with patch.object(handler, "release") as mock_release:
+        with patch.object(dispatcher, "release") as mock_release:
             # Second tag call raises exception given above, message should be rejected
             mock_umb_event.message.address = tag_address
-            handler.on_message(mock_umb_event)
+            dispatcher.on_message(mock_umb_event)
             mock_release.assert_called_once_with(mock_umb_event.delivery, delivered=True)
             mock_release.reset_mock()
 
             # Second untag call raises exception given above, message should be rejected
             mock_umb_event.message.address = untag_address
-            handler.on_message(mock_umb_event)
+            dispatcher.on_message(mock_umb_event)
             mock_release.assert_called_once_with(mock_umb_event.delivery, delivered=True)
 
     # slow_update_brew_tags.apply_async is called once per message with a build_id arg
@@ -247,16 +218,15 @@ def test_handle_tag_and_untag_messages():
     slow_update_brew_tags_mock.assert_has_calls(call_list)
 
 
-def test_brew_umb_receiver_handles_shipped_errata():
-    """Test that the BrewUMBReceiverHandler class either
+def test_brew_umb_handler_handles_shipped_errata():
+    """Test that the BrewUMBHandler class either
     accepts a shipped errata message, when no exception is raised
     OR rejects the message if any exception is raised"""
-    listener = BrewUMBListener()
-    addresses = listener.virtual_topic_addresses
-    selectors = listener.selectors
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain"):
-        handler = BrewUMBReceiverHandler(virtual_topic_addresses=addresses, selectors=selectors)
+        dispatcher = UMBDispatcher()
+
+    addresses = dispatcher.virtual_topic_addresses
 
     mock_umb_event = MagicMock()
     mock_invalid_event = MagicMock()
@@ -264,7 +234,7 @@ def test_brew_umb_receiver_handles_shipped_errata():
     address = "topic://VirtualTopic.eng.errata.activity.status"
     mock_umb_event.message.address = address
     mock_invalid_event.message.address = address
-    assert address.replace("topic://", VIRTUAL_TOPIC_ADDRESS_PREFIX) in addresses
+    assert address.replace("topic://", ADDRESS_PREFIX) in addresses
 
     mock_umb_event.message.body = '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID}'.replace(
         "MOCK_ID", mock_id
@@ -284,8 +254,8 @@ def test_brew_umb_receiver_handles_shipped_errata():
         side_effect=umb_message_exceptions,
     ) as slow_handle_shipped_errata_mock:
         # First call raises no exception, message should be accepted
-        with patch.object(handler, "accept") as mock_accept:
-            handler.on_message(mock_umb_event)
+        with patch.object(dispatcher, "accept") as mock_accept:
+            dispatcher.on_message(mock_umb_event)
             mock_accept.assert_called_once_with(mock_umb_event.delivery)
             mock_accept.reset_mock()
 
@@ -293,12 +263,12 @@ def test_brew_umb_receiver_handles_shipped_errata():
             # The task will raise an exception for the invalid status (should never happen)
             # This will log the invalid message status and ID in our Celery task results
             # Raising an exception in the listener would block processing other messages
-            handler.on_message(mock_invalid_event)
+            dispatcher.on_message(mock_invalid_event)
             mock_accept.assert_called_once_with(mock_invalid_event.delivery)
 
         # Third call raises exception given above, message should be rejected
-        with patch.object(handler, "release") as mock_release:
-            handler.on_message(mock_umb_event)
+        with patch.object(dispatcher, "release") as mock_release:
+            dispatcher.on_message(mock_umb_event)
             mock_release.assert_called_once_with(mock_umb_event.delivery, delivered=True)
 
     # slow_handle_shipped_errata.apply_async is called once per message


### PR DESCRIPTION
Refactor UMB handling by creating a dispatcher class which maintains a registry of handlers which each specify the topics they're listening for and methods to handle messages on those topics.