### PR TITLE
CORGI-698: Fix online SPDX validator errors

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1786,17 +1786,32 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         )
         return list(erratum for erratum in errata_qs if erratum)
 
+    @staticmethod
+    def license_clean(license_str: str) -> str:
+        """Take an SPDX license expression, and remove spaces from all identifiers
+        so that PUBLIC DOMAIN becomes PUBLIC-DOMAIN, ASL 2.0 becomes ASL-2.0, etc."""
+        license_str = license_str.replace(" ", "-")
+        # Above fixed identifiers, but also the keywords "-AND-", "-OR-" and "-WITH-"
+        license_str = license_str.replace("-AND-", " AND ")
+        license_str = license_str.replace("-OR-", " OR ")
+        license_str = license_str.replace("-WITH-", " WITH ")
+        return license_str
+
     @property
     def license_concluded(self) -> str:
         """Return the OLCS scan results formatted as an SPDX license expression
-        This is almost the same as above, but operators (AND, OR) + license IDs are uppercased"""
-        return self.license_concluded_raw.upper()
+        This is almost the same as above, but operators (AND, OR) + license IDs are uppercased
+        and multi-word identifiers like ASL 2.0 are joined with - dashes, like ASL-2.0"""
+        license_str = self.license_concluded_raw.upper()
+        return self.license_clean(license_str)
 
     @property
     def license_declared(self) -> str:
         """Return the "summary license string" formatted as an SPDX license expression
-        This is almost the same as above, but operators (AND, OR) + license IDs are uppercased"""
-        return self.license_declared_raw.upper()
+        This is almost the same as above, but operators (AND, OR) + license IDs are uppercased
+        and multi-word identifiers like ASL 2.0 are joined with - dashes, like ASL-2.0"""
+        license_str = self.license_declared_raw.upper()
+        return self.license_clean(license_str)
 
     @staticmethod
     def license_list(license_expression: str) -> list[str]:

--- a/corgi/web/templates/base_manifest.json
+++ b/corgi/web/templates/base_manifest.json
@@ -6,7 +6,7 @@
     ],
     "licenseListVersion": "3.8"
   },
-  "dataLicense": "CC-BY-4.0",
+  "dataLicense": "CC0-1.0",
   "documentDescribes": [
     "SPDXRef-{{obj.uuid}}"
   ],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -176,8 +176,9 @@ class ComponentFactory(factory.django.DjangoModelFactory):
     version = ".".join(str(n) for n in random.sample(range(10), 3))
     release = str(random.randint(0, 10))
     arch = random.choice(("src", "noarch", "s390", "ppc", "x86_64"))
-    license_declared_raw = "BSD-3-Clause or (GPLv3+ and LGPLv3+)"
-    license_concluded_raw = "(MIT and (ASL-2.0 or GPLv3+)) or LGPLv3+"
+    # These values use nonstandard SPDX license identifiers to match the real data
+    license_declared_raw = "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain"
+    license_concluded_raw = "(MIT and (ASL 2.0 or GPLv3+ with exceptions)) or LGPLv3+"
 
     software_build = factory.SubFactory(SoftwareBuildFactory)
     tag = factory.RelatedFactory(ComponentTagFactory, factory_related_name="tagged_model")


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This fixes the errors seen in the official SPDX validator, and causes it to report "Success! This SPDX Document is valid." instead. See the detailed message on each commit for the exact error.

Note that the real online validator is currently offline, so I cloned their Github repo and ran a local copy instead:
https://github.com/spdx/spdx-online-tools

This may have given different results than the curent version they're running in production:
https://tools.spdx.org/app/validate

I downloaded the latest ubi9 container's manifest from Corgi prod, then ran it through the validator before and after these changes. Diffing the licenseDeclared data in the two versions:

```
cat ubi9-manifest-before.json | jq .packages[].licenseDeclared >ubi9-licenses-before.txt
cat ubi9-manifest-after.json | jq .packages[].licenseDeclared >ubi9-licenses-after.txt
diff ubi9-licenses-before.txt ubi9-licenses-after.txt
```

Shows output like below. You can see that keywords like AND, OR, and WITH aren't affected by this change, but licenses like ASL 2.0 and PUBLIC DOMAIN have spaces replaced with dashes:
```
560c560
< "LGPLV2+ AND LGPLV2+ WITH EXCEPTIONS AND GPLV2+ AND GPLV2+ WITH EXCEPTIONS AND BSD AND INNER-NET AND ISC AND PUBLIC DOMAIN AND GFDL"
---
> "LGPLV2+ AND LGPLV2+ WITH EXCEPTIONS AND GPLV2+ AND GPLV2+ WITH EXCEPTIONS AND BSD AND INNER-NET AND ISC AND PUBLIC-DOMAIN AND GFDL"
585c585
< "LGPLV2+ AND LGPLV2+ WITH EXCEPTIONS AND GPLV2+ AND GPLV2+ WITH EXCEPTIONS AND BSD AND INNER-NET AND ISC AND PUBLIC DOMAIN AND GFDL"
---
> "LGPLV2+ AND LGPLV2+ WITH EXCEPTIONS AND GPLV2+ AND GPLV2+ WITH EXCEPTIONS AND BSD AND INNER-NET AND ISC AND PUBLIC-DOMAIN AND GFDL"
593c593
< "LGPLV2+ AND BSD AND PUBLIC DOMAIN"
---
> "LGPLV2+ AND BSD AND PUBLIC-DOMAIN"
606,607c606,607
< "MIT AND (BSD OR ASL 2.0)"
< "ASL 2.0"
---
> "MIT AND (BSD OR ASL-2.0)"
> "ASL-2.0"
614c614
< "ASL 2.0"
---
> "ASL-2.0"
```

I also filed https://github.com/spdx/spdx-online-tools/issues/474 to fix this error in the SPDX validator itself.