### PR TITLE
Fix miscellaneous small errors in local dev environments

### DIFF
--- a/corgi/web/templates/base.html
+++ b/corgi/web/templates/base.html
@@ -4,6 +4,7 @@
 <html lang="en" class="layout-pf layout-pf-fixed-with-footer">
   <head>
     <meta charset="utf-8">
+    <link rel="icon" href="data:," />
     <link rel="stylesheet" type="text/css" crossorigin="anonymous"
           href="https://cdnjs.cloudflare.com/ajax/libs/patternfly/3.59.5/css/patternfly.min.css"
           integrity="sha512-6UpU9AcZHviFiYbPBQSNtdLnWsTo8Y/1bnfc/OM2Hh4jEeQZEa9TfmOVGzLHE90YV44V/u5I0cnQr4uwMW2P6w==">

--- a/corgi/web/templates/rest_framework/api.html
+++ b/corgi/web/templates/rest_framework/api.html
@@ -1,5 +1,10 @@
 {% extends "rest_framework/base.html" %}
 
+{% block style %}
+{{ block.super }}
+  <link rel="icon" href="data:," />
+{% endblock %}
+
 {% block branding %}
   <a class="navbar-brand" href="/">Component Registry</a>
 {% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   corgi-nginx:
     container_name: corgi-nginx
-    image: registry.access.redhat.com/ubi9/nginx-122:1-12
+    image: registry.redhat.io/ubi9/nginx-122:1
     depends_on: ["corgi-web"]
     ports:
       - "8080:8080"
@@ -62,6 +62,23 @@ services:
     volumes:
       - ./staticfiles:/opt/app-root/src/staticfiles:z
       - ./etc/nginx:/opt/app-root/etc/nginx.default.d/
+    deploy:
+      resources:
+        limits:
+          memory: 1.5G   # Keep in sync with OpenShift mem limits to catch OOM problems
+
+  corgi-nginx-exporter:
+    container_name: corgi-nginx-exporter
+    depends_on: ["corgi-nginx"]
+    image: quay.io/nginx/nginx-prometheus-exporter@sha256:131c2c2963296bbae7e9fcb52f77a1202f1d87d5d85e8e6cd7bcbccad799bc01
+    environment:
+      SCRAPE_URI: "http://corgi-nginx:8080/stub_status"
+    ports:
+      - "9113:9113"
+    deploy:
+      resources:
+        limits:
+          memory: 128M   # Keep in sync with OpenShift mem limits to catch OOM problems
 
   corgi-web:
     container_name: corgi-web
@@ -165,7 +182,7 @@ services:
       replicas: 2
       resources:
         limits:
-          memory: 2G  # Keep in sync with OpenShift mem limits to catch OOM problems
+          memory: 5G  # Keep in sync with OpenShift mem limits to catch OOM problems
     container_name: corgi-celery-cpu
     image: corgi
     env_file:

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -12,6 +12,11 @@ location /staticfiles/  {
     root               /opt/app-root/src/;
 }
 
+# Export Prometheus metrics
+location /stub_status {
+    stub_status;
+}
+
 # To hide 404 errors about missing favicon
 location /favicon.ico {
     default_type        text/plain;

--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -17,12 +17,6 @@ location /stub_status {
     stub_status;
 }
 
-# To hide 404 errors about missing favicon
-location /favicon.ico {
-    default_type        text/plain;
-    return              200;
-}
-
 # For OpenShift health checks
 location /healthz {
     default_type        text/plain;

--- a/tests/data/image_archive_data.py
+++ b/tests/data/image_archive_data.py
@@ -9,15 +9,18 @@ TEST_IMAGE_ARCHIVE = {
         "docker": {
             "layer_sizes": [
                 {
-                    "diff_id": "sha256:744c86b543903d171c69633d70aef72a25ce73da0a3be609e46db08e72978810",
+                    "diff_id": "sha256:"
+                    "744c86b543903d171c69633d70aef72a25ce73da0a3be609e46db08e72978810",
                     "size": 102428737,
                 },
                 {
-                    "diff_id": "sha256:1323ffbff4ddc4ec19320352186f090abf00c9c5a22b94f1057ae7ca4cb89f52",
+                    "diff_id": "sha256:"
+                    "1323ffbff4ddc4ec19320352186f090abf00c9c5a22b94f1057ae7ca4cb89f52",
                     "size": 4654,
                 },
                 {
-                    "diff_id": "sha256:99058f5b1a1f25e0c17575931b4263224778e1004344dd0db0d9f7359ccbd6da",
+                    "diff_id": "sha256:"
+                    "99058f5b1a1f25e0c17575931b4263224778e1004344dd0db0d9f7359ccbd6da",
                     "size": 290182191,
                 },
             ],
@@ -49,7 +52,8 @@ TEST_IMAGE_ARCHIVE = {
                         "architecture": "x86_64",
                         "build-date": "2021-11-03T07:56:17.022725",
                         "com.github.commit": "d77102aaefce8b513f034a9937e7e8789ef984c7",
-                        "com.github.url": "https://github.com/submariner-io/submariner-operator.git",
+                        "com.github.url": "https://github.com/submariner-io/"
+                        "submariner-operator.git",
                         "description": "subctl",
                         "distribution-scope": "public",
                         "io.k8s.description": "subctl",
@@ -89,12 +93,14 @@ TEST_IMAGE_ARCHIVE = {
                 },
             },
             "digests": {
-                "application/vnd.docker.distribution.manifest.v2+json": "sha256:e9690a156789266402d21ca4ce498c6392125b458fa537e172dfa2509229c4bb"
+                "application/vnd.docker.distribution.manifest.v2+json": "sha256"
+                ":e9690a156789266402d21ca4ce498c6392125b458fa537e172dfa2509229c4bb"
             },
             "parent_id": "sha256:e7685639f55280ffe8da3724cb1d342091a1ceea79af5eb91a07ce97cd32f221",
         },
     },
-    "filename": "docker-image-sha256:9b0a454a2b9d00f8f7b4a8b1188f0b70ead186b906261b1c13e5e6d75837db7d.x86_64.tar.gz",
+    "filename": "docker-image-sha256:"
+    "9b0a454a2b9d00f8f7b4a8b1188f0b70ead186b906261b1c13e5e6d75837db7d.x86_64.tar.gz",
     "id": 5620578,
     "metadata_only": False,
     "size": 138507819,
@@ -1824,6 +1830,10 @@ KOJI_LIST_RPMS = [
     },
 ]
 
+# Comment describes how to get magic values used in tests
+# Don't change data, or below will be invalidated
+# RPM_IDS_IN_SUBCTL_CONTAINER = [rpm["build_id"] for rpm in KOJI_LIST_RPMS]
+# RPM_BUILD_IDS = list(set(RPM_IDS_IN_SUBCTL_CONTAINER))
 RPM_BUILD_IDS = [
     1207296,
     1724416,
@@ -1916,6 +1926,8 @@ RPM_BUILD_IDS = [
     745979,
 ]
 
+# Different than above - uses rpm["id"] instead of rpm["build_id"]
+# list(set(rpm["id"] for rpm in KOJI_LIST_RPMS))
 NOARCH_RPM_IDS = [
     8215425,
     9859973,
@@ -1929,4 +1941,5 @@ NOARCH_RPM_IDS = [
     6156542,
 ]
 
+# len(RPM_IDS_IN_SUBCTL_CONTAINER)
 NO_RPMS_IN_SUBCTL_CONTAINER = 101

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 extend-ignore = E203
 # Keep in sync with black.line-length in pyproject.toml
 max-line-length = 100
-exclude = .git/,venv/,.tox/,tests/data/
+exclude = .git/,venv/,.tox/
 
 [testenv:flake8]
 deps = -r requirements/lint.txt


### PR DESCRIPTION
Small PR that fixes:

1. Wrong Nginx image and missing limits / corgi-nginx-exporter config compared to OpenShift.
2. 404 errors / request spam due to missing favicon. We used to hide the failed requests with Nginx config, but the right way is to stop the requests from happening at all.
3. Some flake8 errors on certain lines of one test data file, and a flake8 config that would hide any errors in any test data file.

Most of this is local dev stuff I've already tested, so going to merge as-is.