### PR TITLE
CORGI-685: Fix missing cachito dependencies

### DIFF
--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -394,7 +394,7 @@ def test_extract_remote_sources(requests_mock):
     remote_sources = {"28637": (json_url, "tar.gz")}
     with open("tests/data/remote-source-quay-clair-container.json") as remote_source_data:
         requests_mock.get(json_url, text=remote_source_data.read())
-    source_components = Brew(BUILD_TYPE)._extract_remote_sources("", remote_sources)
+    source_components = Brew._extract_remote_sources("", remote_sources)
     assert len(source_components) == 1
     assert source_components[0]["meta"]["name"] == "thomasmckay/clair"
     assert source_components[0]["type"] == Component.Type.GITHUB
@@ -429,7 +429,7 @@ def test_extract_multiple_remote_sources(requests_mock):
                 text=remote_source_data.read(),
             )
     go_version = "v1.16.0"
-    source_components = Brew(BUILD_TYPE)._extract_remote_sources(go_version, remote_sources)
+    source_components = Brew._extract_remote_sources(go_version, remote_sources)
     assert len(source_components) == 4
     components = [len(s["components"]) for s in source_components]
     # TODO FAIL: what do these numbers mean?!?
@@ -674,11 +674,10 @@ extract_golang_test_data = [
 
 @pytest.mark.parametrize("test_data_file,expected_component", extract_golang_test_data)
 def test_extract_golang(test_data_file, expected_component):
-    brew = Brew(BUILD_TYPE)
     with open(test_data_file) as testdata:
         testdata = testdata.read()
         testdata = json.loads(testdata, object_hook=lambda d: SimpleNamespace(**d))
-    components, remaining = brew._extract_golang(testdata.dependencies, "1.15.0")
+    components, remaining = Brew._extract_golang(testdata.dependencies, "1.15.0")
     assert expected_component in components
     assert len(remaining) == 0
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Quick review please. There will be at least 2 follow-up PRs for this issue, so I'm splitting this change out to make it easier to review. The first commit is general cleanup and the second is the actual bugfix, where we would sometimes overwrite the non-Golang results (pypi, npm, yarn, etc.) with the Golang results.
```
  # This assignment overwrites anything already in source_component["components"]
  # If we process the Golang components first, that's OK
  # But if we already processed pypi / npm / yarn components, they are overwritten
  (
      source_component["components"],
      remote_source.dependencies,
  ) = self._extract_golang(remote_source.dependencies, go_stdlib_version)```
```

Tests still pass after this without changes / never caught this bug to begin with, but I'm going to add new tests in a separate PR. The other bugs I'm trying to fix basically require a complete rewrite of these tests.