### PR TITLE
tailor the streams we manifest so we can remove support_stream_cpe map

### DIFF
--- a/corgi/core/migrations/0070_add_skip_manifest_streams.py
+++ b/corgi/core/migrations/0070_add_skip_manifest_streams.py
@@ -1,0 +1,44 @@
+from django.db import migrations
+
+
+def add_skip_manifest_tags_to_streams(apps, schema_editor):
+    """Add skip manifest tags to some streams"""
+    ProductStream = apps.get_model("core", "ProductStream")
+    ProductStreamTag = apps.get_model("core", "ProductStreamTag")
+
+    # Other streams are also skipped, see corgi.tasks.manifests.update_rhel_manifests
+    # These are mostly middleware streams where we get a more accurate SBOM from Deptopia until PNC
+    # is on-boarded, all stream are using SBOMMER feature of PNC
+    # The cost-management stream should be excluded by the managed-services filter but it is missed.
+    # See also
+    # https://docs.google.com/spreadsheets/d/1dci4mxCi1hlWbmE9drRyjclsTJHV9ySKedKU3_j9paE/edit#gid=0
+    for stream in (
+        "amq-st-2",
+        "cost-management",
+        "eap-6.4.23",
+        "fsw-6",
+        "fuse-6.3.0",
+        "jdg-8",
+        "jbcs-httpd-2.4",
+        "jws-5",
+        "nmo-4.10",
+        "openjdk-1.8",
+        "openjdk-11",
+        "openjdk-17",
+        "rhai-1",
+        "red_hat_discovery-1.0",
+        "rhivos-test",
+    ):
+        ps = ProductStream.objects.get(name=stream)
+        ProductStreamTag.objects.create(name="skip_manifest", tagged_model=ps)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0069_auto_20230606_1542"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_skip_manifest_tags_to_streams),
+    ]

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -77,6 +77,7 @@ def setup_periodic_tasks(sender, **kwargs):
         upsert_cron_task("yum", "fetch_unprocessed_yum_relations", hour=9, minute=0)
         upsert_cron_task("managed_services", "refresh_service_manifests", hour=10, minute=0)
         upsert_cron_task("manifest", "update_manifests", hour=11, minute=0)
+        upsert_cron_task("manifest", "update_rhel_manifests", hour=11, minute=10)
         upsert_cron_task("monitoring", "email_failed_tasks", hour=12, minute=45)
 
     # Automatic task result expiration is currently disabled


### PR DESCRIPTION
Define the stream we manifest without the supported_stream_cpes map in corgi/core/fixups.py.

If I run the migration locally and compare the streams generated by the new filter with the one from the supported_stream_cpes map I get this list:

Generated filtered_streams using filter from manifest.py::update_manifests function:
```
In [80]: filtered_streams = set(m.ProductStream.objects.annotate(num_components=Count("components"))
    ...:         .filter(num_components__gt=0, active=True)
    ...:         .exclude(name__startswith="rhel")
    ...:         .exclude(meta_attr__managed_service_components__isnull=False)
    ...:         .exclude(tags__name="skip_manifest").values_list("name", flat=True))
```

Generate rhel_streams using filter from manifest.py::update_rhel_manifests.py function:
```
In [55]: RHEL_MANIFEST
Out[55]: re.compile(r'rhel-[89]{1}(.*)\.0$', re.UNICODE)

In [56]: for ps in m.ProductStream.objects.filter(name__startswith="rhel").exclude(name__startswith="rhel-br"):
    ...:     if RHEL_MANIFEST.match(ps.name):
    ...:         rhel_streams.add(ps.name)
    ...: 

In [57]: rhel_streams
Out[57]: 
{'rhel-7.9.z',
 'rhel-8.0',
 'rhel-8.1.0',
 'rhel-8.2.0',
 'rhel-8.3.0',
 'rhel-8.4.0',
 'rhel-8.5.0',
 'rhel-8.6.0',
 'rhel-8.7.0',
 'rhel-8.8.0',
 'rhel-8.9.0',
 'rhel-9.0',
 'rhel-9.1.0',
 'rhel-9.2.0',
 'rhel-9.3.0'}
```

Combine the 2 lists to compare with the supported_streams list

``` 
In [81]: filtered_streams.update(rhel_streams)

In [83]: supported_streams = set(supported_stream_cpes.keys())
```

These are mostly new streams that have become active since we created supported_streams, although it also contains more (historical) RHEL GA streams. If the streams don't have any released components no manifest will be created for them in cpu_update_ps_manifest task.
```
In [82]: filtered_streams - supported_streams
Out[82]: 
{'ceph-6',
 'certificate_system_9.7.z',
 'cnv-4.13',
 'cnv-4.14',
 'convert2rhel-6',
 'devtools-compilers-2023-2.z',
 'dts-12.1.z',
 'mtr-1.1',
 'mtv-2.4',
 'openshift-4.13.z',
 'openshift-4.14',
 'openstack-18.0',
 'ossm-2.4',
 'rhacm-2.7.z',
 'rhacm-2.8',
 'rhel-8.0',
 'rhel-8.1.0',
 'rhel-8.2.0',
 'rhel-8.3.0',
 'rhel-8.4.0',
 'rhel-8.5.0',
 'rhel-8.6.0',
 'rhel-8.7.0',
 'rhel-8.9.0',
 'rhel-9.0',
 'rhel-9.1.0',
 'rhel-9.3.0',
 'rhods-1.25',
 'rhods-1.26',
 'rhods-1.27',
 'rhosc-1-3',
 'rhosc-1-4',
 'wto-1.6'}
```

This also contains some new streams, and a couple which probably should have been in original supported_cpe_streams map.

```
In [78]: supported_streams - filtered_streams
Out[78]: 
{'cnv-4.10',
 'devtools-compilers-2022-4.z',
 'dts-12.0.z',
 'dts-12.1',
 'mtv-2.2',
 'openshift-4.13',
 'openstack-13-optools',
 'rhacm-2.7',
 'rhel-av-8.4.0.z',
 'rhods-1.20',
 'rhods-1.21',
 'rhods-1.23',
 'rhosc-1'}
```

I also deactivated 3 streams in prod_defs (-/merge_requests/2184) which is not reflected here yet.