### PR TITLE
CORGI-668: Add back indexes that we might need to delete ComponentNodes

### DIFF
--- a/corgi/core/migrations/0070_fix_indexes.py
+++ b/corgi/core/migrations/0070_fix_indexes.py
@@ -1,0 +1,58 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = (("core", "0069_auto_20230606_1542"),)
+
+    operations = (
+        # Below were originally added in 0037_custom_indexes.py
+        # These were manually created by us to improve performance
+        # If you want to add custom indexes, update models.py
+        # Do not run custom SQL, or Postgres and Django will disagree
+        # about the current state of our tables / models
+        migrations.RunSQL("DROP INDEX core_componentnode_tree_parent_lft_idx"),
+        migrations.RunSQL("DROP INDEX core_cn_tree_lft_purl_parent_idx"),
+        # Already removed in 0059
+        # migrations.RunSQL("DROP INDEX core_cn_lft_tree_idx"),
+        migrations.RunSQL("DROP INDEX core_cn_lft_rght_tree_idx"),
+        # Add them back so the model definition is in sync with the DB
+        migrations.AddIndex(
+            model_name="componentnode",
+            index=models.Index(
+                fields=("tree_id", "parent_id", "lft"), name="core_cn_tree_parent_lft_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="componentnode",
+            index=models.Index(
+                fields=("tree_id", "lft", "purl", "parent_id"),
+                name="core_cn_tree_lft_purl_prnt_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="componentnode",
+            index=models.Index(fields=("lft", "tree_id"), name="core_cn_lft_tree_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="componentnode",
+            index=models.Index(fields=("lft", "rght", "tree_id"), name="core_cn_lft_rght_tree_idx"),
+        ),
+        # Below are default indexes to support foreign keys / constraints
+        # These were automatically created by Django, then removed in 0059
+        # If you want to delete them, update models.py
+        # Do not run custom SQL, or Postgres and Django will disagree
+        # about the current state of our tables / models
+        migrations.RunSQL(
+            "CREATE INDEX core_componentnode_parent_id_be93cab7 "
+            "ON public.core_componentnode USING btree (parent_id)"
+        ),
+        migrations.RunSQL(
+            "CREATE INDEX core_componentnode_content_type_id_334077a8 "
+            "ON public.core_componentnode USING btree (content_type_id)"
+        ),
+        migrations.RunSQL(
+            "CREATE INDEX core_component_channels_component_id_9c8754af "
+            "ON public.core_component_channels USING btree (component_id)"
+        ),
+    )

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -213,13 +213,18 @@ class ComponentNode(NodeModel):
                 condition=models.Q(parent__isnull=True),
             ),
         )
-        # 0037_custom_indexes.py contains the following custom performance indexes
-        #    core_componentnode_tree_parent_lft_idx
-        #    core_cn_tree_lft_purl_parent_idx
-        #    core_cn_lft_rght_tree_idx
         indexes = (  # type: ignore[assignment]
             models.Index(fields=("type", "parent", "purl")),
             models.Index(fields=("parent",)),
+            models.Index(
+                fields=("tree_id", "parent_id", "lft"), name="core_cn_tree_parent_lft_idx"
+            ),
+            models.Index(
+                fields=("tree_id", "lft", "purl", "parent_id"),
+                name="core_cn_tree_lft_purl_prnt_idx",
+            ),
+            models.Index(fields=("lft", "tree_id"), name="core_cn_lft_tree_idx"),
+            models.Index(fields=("lft", "rght", "tree_id"), name="core_cn_lft_rght_tree_idx"),
             *NodeModel.Meta.indexes,
         )
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review.

In order to fix the purls on all container image components / remove the "redhat/" namespace from the start of the purl, we have to migrate purl values on each container's nodes. This was attempted previously, but failed due to duplicate (type, parent, purl) values on certain nodes.

Given that the data is duplicated, I tried to just delete the duplicate ComponentNodes. There are also other duplicate nodes that need to be cleaned up as part of other tickets. However, currently the deletion times out and no data can be cleaned up.

I see there were some custom ComponentNode indexes added in migration number 37 to improve performance, and I also see one of these indexes was removed in migration number 59 because it looked unused. If I remember right, we enabled / reset Postgres statistics about index usage, waited 24 hours, then checked the statistics to see which indexes were unused.

I assume we never manually cleaned up any nodes / other data in that very small window, so the indexes we removed might be needed in order to delete things. This MR adds back the missing indexes, in the hope (no guarantee) that will let us delete these duplicate nodes. I also redefined the other indexes from 0037 on the ComponentNode model, so that our Django models remain in sync with our Postgres database.

In the future:
1. We should wait at least a week after resetting statistics, before checking to see which indexes are unused. This prevents accidentally removing an index which is needed by some infrequently-run query, e.g. in one of our weekly tasks.

2. We should always make changes to Django models (including indexes and constraints) in models.py, never by running custom SQL. This prevents the Django models from becoming desynchronized with the actual underlying schema in the database.

3. We should never delete indexes that Django creates, such as for a field's unique=True constraint, a UniqueConstraint on multiple fields, a ForeignKey field, a ManyToManyField, or a TextField. These indexes support checking uniqueness on insertion / updates, iterating over related models, and running SQL LIKE queries, respectively.

4. We should always ensure that get_or_create() and update_or_create() use keyword arguments that exactly match the list of fields in a UniqueConstraint. These functions are atomic and guaranteed to work correctly, only when the keyword arguments / fields given are guaranteed to be unique (so appear together in a UniqueConstraint), and have an index to support this uniqueness check.