### PR TITLE
CORGI-726 keep stream variants up to date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,7 @@ ENV/
 env.bak/
 venv.bak/
 .env
-.env-enterprise
+.env*
 
 # Spyder project settings
 .spyderproject
@@ -126,6 +126,7 @@ celerybeat-schedule
 
 # Database dump
 corgi.db
+restore-elements
 
 # UMB certificates
 *.key

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Optional
 
 from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
@@ -11,11 +12,13 @@ from corgi.collectors.models import (
 )
 from corgi.collectors.prod_defs import ProdDefs
 from corgi.core.models import (
+    Component,
     Product,
     ProductNode,
     ProductStream,
     ProductVariant,
     ProductVersion,
+    SoftwareBuild,
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
@@ -23,6 +26,66 @@ logger = get_task_logger(__name__)
 # Find a substring that looks like a version (e.g. "3", "3.5", "3-5", "1.2.z") at the end of a
 # searched string.
 RE_VERSION_LIKE_STRING = re.compile(r"\d[\dz.-]*$|$")
+
+
+@app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
+def slow_update_builds_for_variant(
+    variant_name: str,
+    updated_stream: tuple[str, str],
+    updated_version: Optional[tuple[str, str]] = None,
+    updated_product: Optional[tuple[str, str]] = None,
+):
+    """Ensures new stream parent of the passed in variant is reflected in all the variant's builds
+    and child components"""
+    logger.info(
+        f"Updating components related to {variant_name} with new stream details: {updated_stream}"
+    )
+    updated_stream_objs = (
+        ProductStream.objects.get(name=updated_stream[0]),
+        ProductStream.objects.get(name=updated_stream[1]),
+    )
+    updated_version_objs = None
+    updated_product_objs = None
+    if updated_version:
+        logger.info(f"Also updating product_version with {updated_version}")
+        updated_version_objs = (
+            ProductVersion.objects.get(name=updated_version[0]),
+            ProductVersion.objects.get(name=updated_version[1]),
+        )
+    if updated_product:
+        logger.info(f"Also updating product {updated_product}")
+        updated_product_objs = (
+            Product.objects.get(name=updated_product[0]),
+            Product.objects.get(name=updated_product[1]),
+        )
+    for software_build in (
+        SoftwareBuild.objects.filter(relations__product_ref=variant_name).distinct().iterator()
+    ):
+        component = software_build.components.get()
+        _update_product_streams(
+            component, updated_stream_objs, updated_version_objs, updated_product_objs
+        )
+        for cnode in component.cnodes.get_queryset().iterator():
+            for d in cnode.get_descendants().iterator():
+                _update_product_streams(
+                    d.obj, updated_stream_objs, updated_version_objs, updated_product_objs
+                )
+
+
+def _update_product_streams(
+    component: Component,
+    updated_stream: tuple[ProductStream, ProductStream],
+    updated_version: Optional[tuple[ProductVersion, ProductVersion]] = None,
+    updated_product: Optional[tuple[Product, Product]] = None,
+):
+    component.productstreams.add(updated_stream[0])
+    component.productstreams.remove(updated_stream[1])
+    if updated_version:
+        component.productversions.add(updated_version[0])
+        component.productversions.remove(updated_version[1])
+    if updated_product:
+        component.products.add(updated_product[0])
+        component.products.remove(updated_product[1])
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
@@ -63,192 +126,283 @@ def update_products() -> None:
             )
 
             for pd_product_version in pd_product_versions:
-                pd_product_streams = pd_product_version.pop("product_streams", [])
+                parse_product_version(pd_product_version, product, product_node)
 
-                name = pd_product_version.pop("id")
-                if match_version := RE_VERSION_LIKE_STRING.search(name):
-                    version = match_version.group()
-                description = pd_product_version.pop("public_description", [])
 
+def parse_product_version(
+    pd_product_version: dict[str, Any], product: Product, product_node: ProductNode
+):
+    """Parse the product versions from ps_modules in product-definitions.json"""
+    pd_product_streams = pd_product_version.pop("product_streams", [])
+    name = pd_product_version.pop("id")
+    if match_version := RE_VERSION_LIKE_STRING.search(name):
+        version = match_version.group()
+    description = pd_product_version.pop("public_description", [])
+    logger.debug(
+        "Creating or updating Product Version: name=%s, description=%s",
+        name,
+        description,
+    )
+    product_version, _ = ProductVersion.objects.update_or_create(
+        name=name,
+        defaults={
+            "version": version,
+            "description": description,
+            "products": product,
+            "meta_attr": pd_product_version,
+        },
+    )
+    product_version_node, _ = ProductNode.objects.get_or_create(
+        object_id=product_version.pk,
+        defaults={
+            "parent": product_node,
+            "obj": product_version,
+        },
+    )
+    for pd_product_stream in pd_product_streams:
+        parse_product_stream(
+            pd_product_stream, product, product_version, product_version_node, version
+        )
+
+
+def parse_product_stream(
+    pd_product_stream: dict[str, Any],
+    product: Product,
+    product_version: ProductVersion,
+    product_version_node: ProductNode,
+    version: str,
+):
+    """Parse the product streams from ps_update_streams in product-definitions.json"""
+    active = pd_product_stream.pop("active")
+    errata_info = pd_product_stream.pop("errata_info", [])
+    brew_tags = pd_product_stream.pop("brew_tags", [])
+    yum_repos = pd_product_stream.pop("yum_repositories", [])
+    composes = pd_product_stream.pop("composes", [])
+    brew_tags_dict = {brew_tag["tag"]: brew_tag["inherit"] for brew_tag in brew_tags}
+    composes_dict = {}
+    for compose in composes:
+        composes_dict[compose["url"]] = compose["variants"]
+    name = pd_product_stream.pop("id")
+    if match_version := RE_VERSION_LIKE_STRING.search(name):
+        version = match_version.group()
+    logger.debug("Creating or updating Product Stream: name=%s", name)
+    product_stream, _ = ProductStream.objects.update_or_create(
+        name=name,
+        defaults={
+            "version": version,
+            "description": "",
+            "products": product,
+            "productversions": product_version,
+            "active": active,
+            "brew_tags": brew_tags_dict,
+            "meta_attr": pd_product_stream,
+            "yum_repositories": yum_repos,
+            "composes": composes_dict,
+        },
+    )
+    product_stream_node, _ = ProductNode.objects.get_or_create(
+        object_id=product_stream.pk,
+        defaults={
+            "parent": product_version_node,
+            "obj": product_stream,
+        },
+    )
+    parse_variants_from_brew_tags(
+        brew_tags_dict, name, product, product_stream, product_stream_node, product_version
+    )
+    parse_errata_info(errata_info, product, product_stream, product_stream_node, product_version)
+
+
+def parse_variants_from_brew_tags(
+    brew_tags: dict[str, bool],
+    stream_name: str,
+    product: Product,
+    product_stream: ProductStream,
+    product_stream_node: ProductNode,
+    product_version: ProductVersion,
+):
+    """Match streams using brew_tags to Errata Tool Product Versions and their Variants"""
+    # quay-3 Errata Tool product version Quay-3-RHEL-8 list too many brew tags
+    # Linking quay streams to the 8Base-Quay-3 variant here via brew tags leads
+    # to builds from later streams being included in earlier ones,
+    # see PROJQUAY-5312.
+    # The rhn_satellite_6 streams have brew tags, but those brew tags are associated
+    # with the RHEL-7-SATELLITE-6.10 ET Product Version. We skip them
+    # here to ensure the rhn_satelite_6.10 variants only get linked with that stream
+    # I haven't filed a product bug to get them fixed since 6.7 - 6.9 are no longer
+    # active. See CORGI-546 for more details.
+    # Also skip brew_tag matching for dts ps_module which share Variants/Brew Tags with rhscl
+    # See CORGI-726
+    if (
+        len(brew_tags) > 0
+        and product_version.name != "quay-3"
+        and not product_version.name.startswith("dts-")
+        and stream_name not in ("rhn_satellite_6.7", "rhn_satellite_6.8", "rhn_satellite_6.9")
+    ):
+        logger.debug(
+            "Found brew tags (%s) in product stream: %s",
+            brew_tags,
+            product_stream.name,
+        )
+        for brew_tag in brew_tags.keys():
+            # Also match brew tags in prod_defs with those from ET
+            trimmed_brew_tag = brew_tag.removesuffix("-released")
+            et_pvs = CollectorErrataProductVersion.objects.filter(
+                brew_tags__contains=[trimmed_brew_tag]
+            )
+
+            for et_pv in et_pvs:
                 logger.debug(
-                    "Creating or updating Product Version: name=%s, description=%s",
-                    name,
-                    description,
+                    "Found Product Version (%s) in ET matching brew tag %s",
+                    et_pv.name,
+                    brew_tag,
                 )
-                product_version, _ = ProductVersion.objects.update_or_create(
-                    name=name,
-                    defaults={
-                        "version": version,
-                        "description": description,
-                        "products": product,
-                        "meta_attr": pd_product_version,
-                    },
-                )
-                product_version_node, _ = ProductNode.objects.get_or_create(
-                    object_id=product_version.pk,
-                    defaults={
-                        "parent": product_node,
-                        "obj": product_version,
-                    },
-                )
-
-                for pd_product_stream in pd_product_streams:
-                    active = pd_product_stream.pop("active")
-                    errata_info = pd_product_stream.pop("errata_info", [])
-                    brew_tags = pd_product_stream.pop("brew_tags", [])
-                    yum_repos = pd_product_stream.pop("yum_repositories", [])
-                    composes = pd_product_stream.pop("composes", [])
-
-                    brew_tags_dict = {}
-                    for brew_tag in brew_tags:
-                        brew_tags_dict[brew_tag["tag"]] = brew_tag["inherit"]
-
-                    composes_dict = {}
-                    for compose in composes:
-                        composes_dict[compose["url"]] = compose["variants"]
-
-                    name = pd_product_stream.pop("id")
-                    if match_version := RE_VERSION_LIKE_STRING.search(name):
-                        version = match_version.group()
-
-                    logger.debug("Creating or updating Product Stream: name=%s", name)
-                    product_stream, _ = ProductStream.objects.update_or_create(
-                        name=name,
-                        defaults={
-                            "version": version,
-                            "description": "",
-                            "products": product,
-                            "productversions": product_version,
-                            "active": active,
-                            "brew_tags": brew_tags_dict,
-                            "meta_attr": pd_product_stream,
-                            "yum_repositories": yum_repos,
-                            "composes": composes_dict,
-                        },
+                for et_variant in et_pv.variants.all():
+                    logger.info(
+                        "Assigning Variant %s to product stream %s",
+                        et_variant.name,
+                        product_stream.name,
                     )
-                    product_stream_node, _ = ProductNode.objects.get_or_create(
-                        object_id=product_stream.pk,
-                        defaults={
-                            "parent": product_version_node,
-                            "obj": product_stream,
-                        },
+                    variant_product_version: CollectorErrataProductVersion = (
+                        et_variant.product_version
                     )
-                    # quay-3 Errata Tool product version Quay-3-RHEL-8 list too many brew tags
-                    # Linking quay streams to the 8Base-Quay-3 variant here via brew tags leads
-                    # to builds from later streams being included in earlier ones,
-                    # see PROJQUAY-5312.
-                    # The rhn_satellite_6 streams have brew tags, but those brew tags are associated
-                    # with the RHEL-7-SATELLITE-6.10 ET Product Version. We skip them
-                    # here to ensure the rhn_satelite_6.10 variants only get linked with that stream
-                    # I haven't filed a product bug to get them fixed since 6.7 - 6.9 are no longer
-                    # active. See CORGI-546 for more details.
-                    if (
-                        len(brew_tags) > 0
-                        and product_version.name != "quay-3"
-                        and name
-                        not in ["rhn_satellite_6.7", "rhn_satellite_6.8", "rhn_satellite_6.9"]
-                    ):
-                        #    continue
-                        logger.debug(
-                            "Found brew tags (%s) in product stream: %s",
-                            brew_tags,
-                            product_stream.name,
+                    # We don't use update_or_create here in order to get the existing product detail
+                    # of the variant. We then clear the existing product details from all associated
+                    # builds and there components before adding the new product details.
+                    variant_created = False
+                    try:
+                        product_variant = ProductVariant.objects.get(name=et_variant.name)
+                        product_variant.cpe = et_variant.cpe
+                        product_variant.meta_attr = {
+                            "et_product": variant_product_version.product.name,
+                            "et_product_version": variant_product_version.name,
+                        }
+                        product_variant.save()
+                    except ProductVariant.DoesNotExist:
+                        product_variant = ProductVariant.objects.create(
+                            name=et_variant.name,
+                            cpe=et_variant.cpe,
+                            products=product,
+                            productversions=product_version,
+                            productstreams=product_stream,
+                            meta_attr={
+                                "et_product": variant_product_version.product.name,
+                                "et_product_version": variant_product_version.name,
+                            },
                         )
-                        for brew_tag in brew_tags:
-                            # Also match brew tags in prod_defs with those from ET
-                            trimmed_brew_tag = brew_tag["tag"].removesuffix("-released")
-                            et_pvs = CollectorErrataProductVersion.objects.filter(
-                                brew_tags__contains=[trimmed_brew_tag]
-                            )
+                        variant_created = True
 
-                            for et_pv in et_pvs:
-                                logger.debug(
-                                    "Found Product Version (%s) in ET matching brew tag %s",
-                                    et_pv.name,
-                                    brew_tag,
-                                )
-                                for et_variant in et_pv.variants.get_queryset():
-                                    logger.info(
-                                        "Assigning Variant %s to product stream %s",
-                                        et_variant.name,
-                                        product_stream.name,
-                                    )
-                                    variant_product_version: CollectorErrataProductVersion = (
-                                        et_variant.product_version
-                                    )
-                                    product_variant, _ = ProductVariant.objects.update_or_create(
-                                        name=et_variant.name,
-                                        defaults={
-                                            "version": "",
-                                            "cpe": et_variant.cpe,
-                                            "description": "",
-                                            "products": product,
-                                            "productversions": product_version,
-                                            "productstreams": product_stream,
-                                            "meta_attr": {
-                                                "et_product": variant_product_version.product.name,
-                                                "et_product_version": variant_product_version.name,
-                                            },
-                                        },
-                                    )
-                                    ProductNode.objects.get_or_create(
-                                        object_id=product_variant.pk,
-                                        defaults={
-                                            "parent": product_stream_node,
-                                            "obj": product_variant,
-                                        },
-                                    )
-                                    product_variant.save_product_taxonomy()
-                    et_product_versions_set = set(product_stream.et_product_versions)
-                    for et_product in errata_info:
-                        et_product_name = et_product.pop("product_name")
-                        et_product_versions = et_product.pop("product_versions")
+                    _, node_created = ProductNode.objects.update_or_create(
+                        object_id=product_variant.pk,
+                        defaults={
+                            "parent": product_stream_node,
+                            "obj": product_variant,
+                        },
+                    )
+                    if node_created and variant_created:
+                        # This is a new Variant, so no need to update anything
+                        continue
 
-                        for et_product_version in et_product_versions:
-                            et_pv_name = et_product_version["name"]
-                            et_product_versions_set.add(et_pv_name)
+                    # If there was an existing product variant, and it was updated
+                    # to now be associated with a different stream we need to
+                    # update all the builds to reflect the new product relationships
+                    # Capture all the old stream details before updating the foreign keys
+                    existing_product_name = product_variant.products.name
+                    existing_version_name = product_variant.productversions.name
+                    existing_stream_name = product_variant.productstreams.name
+                    product_variant.products = product
+                    product_variant.productversions = product_version
+                    product_variant.productstreams = product_stream
+                    product_variant.save()
 
-                            for variant in et_product_version["variants"]:
-                                logger.debug(
-                                    "Creating or updating Product Variant: name=%s", variant
-                                )
-                                et_variant_cpe = (
-                                    CollectorErrataProductVariant.objects.filter(name=variant)
-                                    .values_list("cpe", flat=True)
-                                    .first()
-                                )
+                    if existing_product_name != product.name:
+                        slow_update_builds_for_variant.apply_async(
+                            product_variant.name,
+                            (
+                                product_stream.name,
+                                existing_stream_name,
+                            ),
+                            (
+                                product_version.name,
+                                existing_version_name,
+                            ),
+                            (
+                                product.name,
+                                existing_product_name,
+                            ),
+                            countdown=300,
+                        )
+                    elif existing_version_name != product_version.name:
+                        slow_update_builds_for_variant.apply_async(
+                            product_variant.name,
+                            (
+                                product_stream.name,
+                                existing_stream_name,
+                            ),
+                            (
+                                product_version.name,
+                                existing_version_name,
+                            ),
+                            countdown=300,
+                        )
+                    else:
+                        slow_update_builds_for_variant.apply_async(
+                            product_variant.name,
+                            (
+                                product_stream.name,
+                                existing_stream_name,
+                            ),
+                            countdown=300,
+                        )
 
-                                product_variant, _ = ProductVariant.objects.update_or_create(
-                                    name=variant,
-                                    defaults={
-                                        "version": "",
-                                        "description": "",
-                                        "cpe": et_variant_cpe if et_variant_cpe else "",
-                                        "products": product,
-                                        "productversions": product_version,
-                                        "productstreams": product_stream,
-                                        "meta_attr": {
-                                            "et_product": et_product_name,
-                                            "et_product_version": et_pv_name,
-                                        },
-                                    },
-                                )
-                                ProductNode.objects.get_or_create(
-                                    object_id=product_variant.pk,
-                                    defaults={
-                                        "parent": product_stream_node,
-                                        "obj": product_variant,
-                                    },
-                                )
-                                product_variant.save_product_taxonomy()
-                    # persist et_product_versions plucked from errata_info
-                    product_stream.et_product_versions = sorted(et_product_versions_set)
-                    product_stream.save()
 
-                    # Save taxonomies for newly-created model at end of each loop iteration
-                    # All child models + nodes have already been created and had taxonomies saved
-                    # This should be a no-op since we link models directly upon creation above
-                    # Keeping it here just to be safe, but we could remove in future
-                    product_stream.save_product_taxonomy()
-                product_version.save_product_taxonomy()
-            product.save_product_taxonomy()
+def parse_errata_info(
+    errata_info: list[dict],
+    product: Product,
+    product_stream: ProductStream,
+    product_stream_node: ProductNode,
+    product_version: ProductVersion,
+):
+    """Parse and create ProductVariants from errata_info in product-definitions.json"""
+    et_product_versions_set = set(product_stream.et_product_versions)
+    for et_product in errata_info:
+        et_product_name = et_product.pop("product_name")
+        et_product_versions = et_product.pop("product_versions")
+
+        for et_product_version in et_product_versions:
+            et_pv_name = et_product_version["name"]
+            et_product_versions_set.add(et_pv_name)
+
+            for variant in et_product_version["variants"]:
+                logger.debug("Creating or updating Product Variant: name=%s", variant)
+                et_variant_cpe = (
+                    CollectorErrataProductVariant.objects.filter(name=variant)
+                    .values_list("cpe", flat=True)
+                    .first()
+                )
+
+                product_variant, _ = ProductVariant.objects.update_or_create(
+                    name=variant,
+                    defaults={
+                        "version": "",
+                        "description": "",
+                        "cpe": et_variant_cpe if et_variant_cpe else "",
+                        "products": product,
+                        "productversions": product_version,
+                        "productstreams": product_stream,
+                        "meta_attr": {
+                            "et_product": et_product_name,
+                            "et_product_version": et_pv_name,
+                        },
+                    },
+                )
+                ProductNode.objects.get_or_create(
+                    object_id=product_variant.pk,
+                    defaults={
+                        "parent": product_stream_node,
+                        "obj": product_variant,
+                    },
+                )
+    # persist et_product_versions plucked from errata_info
+    product_stream.et_product_versions = sorted(et_product_versions_set)
+    product_stream.save()

--- a/scripts/dump_db.sh
+++ b/scripts/dump_db.sh
@@ -3,9 +3,8 @@ set -e
 
 export PGPASSWORD=test
 
-if ! podman ps | grep 'corgi-db' &>/dev/null; then
-    echo 'error: corgi "corgi-db" container does not appear to be running.'
-    exit 1
-fi
+# Use 2 parallel threads to dump the database in directory format
+# Using directory format allows us to potentially restore restore to AWS RDS
+# Having multiple files allows rsync to work more effectively.
 
-pg_dump -v -j 2 -F d -f corgi.db -U corgi-db-user -h localhost -p 5433 corgi-db
+pg_dump --verboase --jobs=2 --format=d --file=corgi.db --username=corgi-db-user --host=localhost --port=5433 corgi-db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,13 @@ def api_path(api_version):
     return f"/api/{api_version}"
 
 
-def setup_product():
+def setup_product(stream_name: str = ""):
     product = ProductFactory()
     version = ProductVersionFactory(products=product)
-    stream = ProductStreamFactory(products=product, productversions=version)
+    if stream_name:
+        stream = ProductStreamFactory(name=stream_name, products=product, productversions=version)
+    else:
+        stream = ProductStreamFactory(products=product, productversions=version)
     variant = ProductVariantFactory(
         name="1", products=product, productversions=version, productstreams=stream
     )

--- a/tests/data/proddefs-update-variants-moved.json
+++ b/tests/data/proddefs-update-variants-moved.json
@@ -1,0 +1,39 @@
+{
+  "ps_update_streams": {
+    "stream": {
+      "brew_tags": [
+        {
+          "tag": "two_streams_with_same_tag",
+          "inherit": false
+        }
+      ]
+    },
+    "new_stream": {
+      "brew_tags": [
+        {
+          "tag": "two_streams_with_same_tag",
+          "inherit": false
+        }
+      ]
+    }
+  },
+  "ps_modules": {
+    "version": {
+      "active_ps_update_streams": [
+        "new_stream"
+      ],
+      "ps_update_streams": [
+        "stream", "new_stream"
+      ]
+    }
+  },
+  "ps_products": {
+    "product": {
+      "name": "product",
+      "ps_modules": [
+        "version"
+      ],
+      "business_unit": "test"
+    }
+  }
+}

--- a/tests/data/proddefs-update-variants.json
+++ b/tests/data/proddefs-update-variants.json
@@ -1,0 +1,31 @@
+{
+  "ps_update_streams": {
+    "stream": {
+      "brew_tags": [
+        {
+          "tag": "test_tag",
+          "inherit": false
+        }
+      ]
+    }
+  },
+  "ps_modules": {
+    "version": {
+      "active_ps_update_streams": [
+        "stream"
+      ],
+      "ps_update_streams": [
+        "stream"
+      ]
+    }
+  },
+  "ps_products": {
+    "product": {
+      "name": "product",
+      "ps_modules": [
+        "version"
+      ],
+      "business_unit": "test"
+    }
+  }
+}

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import call, patch
 
 import pytest
 from django.conf import settings
@@ -8,14 +9,28 @@ from corgi.collectors.models import (
     CollectorErrataProductVariant,
     CollectorErrataProductVersion,
 )
-from corgi.core.models import Product, ProductStream
-from corgi.tasks.prod_defs import update_products
+from corgi.core.models import (
+    ComponentNode,
+    Product,
+    ProductComponentRelation,
+    ProductStream,
+    ProductVariant,
+)
+from corgi.tasks.prod_defs import slow_update_builds_for_variant, update_products
+from tests.conftest import setup_product
+from tests.factories import (
+    ComponentFactory,
+    ProductStreamFactory,
+    ProductVersionFactory,
+    SoftwareBuildFactory,
+)
 
 pytestmark = pytest.mark.unit
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
-def test_products(requests_mock):
+@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
+def test_products(mock_update_builds, requests_mock):
     with open("tests/data/product-definitions.json") as prod_defs:
         text = prod_defs.read()
         text = text.replace("{CORGI_TEST_DOWNLOAD_URL}", os.getenv("CORGI_TEST_DOWNLOAD_URL"))
@@ -44,6 +59,7 @@ def test_products(requests_mock):
         product_version=et_product_version,
     )
     assert et_variant_without_cpe.cpe == ""
+    assert et_product_version.variants.all().count() == 2
 
     update_products()
 
@@ -76,9 +92,13 @@ def test_products(requests_mock):
     # Which should include the stream's CPE + all the child variant CPEs (if any)
     assert et_variant.cpe in rhacm24z.cpes
 
+    # Assert mock_update_builds was not called because no variants moved between streams
+    assert not mock_update_builds.called
+
 
 @pytest.mark.django_db
-def test_skip_brew_tag_linking_for_buggy_products(requests_mock):
+@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
+def test_skip_brew_tag_linking_for_buggy_products(mock_update_builds, requests_mock):
     """RHEL-7-SATELLITE-6.10 has a brew_tag for 6.7 version, which means the 7Server-Satellite67
     ProductVariant gets incorrectly associated with the rhn_satellite_6.7 product stream"""
 
@@ -109,3 +129,267 @@ def test_skip_brew_tag_linking_for_buggy_products(requests_mock):
     assert len(sat_610_variants) == 2
     for variant in sat_610_variants:
         assert variant.name in ("7Server-Capsule610", "7Server-Satellite610")
+
+    assert not mock_update_builds.called
+
+
+@pytest.mark.django_db
+@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
+def test_stream_variants_updated(mock_update_builds, requests_mock):
+    # Creates ProductStream, "stream", with an existing ProductVariant called "1"
+    # The ps_update_stream loaded from proddefs-*.json below has a matching name "stream"
+    stream, variant = setup_product("stream")
+    # Sets up a CollectorErrataProductVersion with a matching brew tag
+    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
+    et_version = CollectorErrataProductVersion.objects.create(
+        et_id=10, product=et_product, name="et_stream_1", brew_tags=["test_tag"]
+    )
+    # Attaching a different Variant, called "2" to the CollectorErrataProductVersion
+    CollectorErrataProductVariant.objects.create(et_id=100, name="2", product_version=et_version)
+
+    with open("tests/data/proddefs-update-variants.json") as prod_defs:
+        requests_mock.get(
+            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
+        )
+
+    update_products()
+
+    # Verify that a new ProductVariant called "2" was created
+    variant_2 = ProductVariant.objects.get(name="2")
+    assert stream == variant_2.productstreams
+
+    # Verify that the original variant is still associated with the stream
+    assert stream == variant.productstreams
+
+    assert not mock_update_builds.called
+
+
+@pytest.mark.django_db
+@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
+def test_stream_variants_moved_to_new_stream(mock_update_builds, requests_mock):
+    # Creates ProductStream, "stream", with an existing ProductVariant called "1"
+    # The ps_update_stream loaded from proddefs-*.json below has a matching name "stream"
+    stream, variant = setup_product("stream")
+
+    # Verify that the original variant is associated with the stream
+    assert stream == variant.productstreams
+
+    # Sets up a CollectorErrataProductVersion with a matching brew tag
+    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
+    et_version = CollectorErrataProductVersion.objects.create(
+        et_id=10, product=et_product, name="et_stream_1", brew_tags=["two_streams_with_same_tag"]
+    )
+    # This is the same variant as the original to the CollectorErrataProductVersion
+    CollectorErrataProductVariant.objects.create(et_id=100, name="1", product_version=et_version)
+
+    with open("tests/data/proddefs-update-variants-moved.json") as prod_defs:
+        requests_mock.get(
+            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
+        )
+
+    update_products()
+
+    variant = ProductVariant.objects.get(name="1")
+    new_stream = ProductStream.objects.get(name="new_stream")
+    # The variant is now associated with the new stream
+    assert variant.productstreams == new_stream
+    assert mock_update_builds.called_with("1", ("new_stream", "stream"), countdown=300)
+
+
+def _create_builds_and_components(stream):
+    stream_build = SoftwareBuildFactory()
+    stream_component = ComponentFactory(software_build=stream_build)
+    stream_component_node = ComponentNode.objects.create(
+        parent=None, obj=stream_component, type=ComponentNode.ComponentNodeType.SOURCE
+    )
+    stream_child_component = ComponentFactory()
+    ComponentNode.objects.create(
+        parent=stream_component_node,
+        obj=stream_child_component,
+        type=ComponentNode.ComponentNodeType.PROVIDES,
+    )
+    stream_component.productstreams.add(stream)
+    stream_component.productversions.add(stream.productversions)
+    stream_component.products.add(stream.products)
+    return stream_build, stream_component, stream_child_component
+
+
+@pytest.mark.django_db
+def test_slow_update_builds_for_variant_same_version():
+    stream, _ = setup_product("stream")
+    new_stream = ProductStreamFactory(
+        name="new_stream", products=stream.products, productversions=stream.productversions
+    )
+
+    # Create builds and components for stream
+    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
+
+    # Relate the stream_build to the variant "1" created by setup_product
+    ProductComponentRelation.objects.create(
+        type=ProductComponentRelation.Type.ERRATA,
+        product_ref="1",
+        software_build=stream_build,
+        build_id=stream_build.build_id,
+        build_type=stream_build.build_type,
+    )
+
+    slow_update_builds_for_variant(
+        "1",
+        (
+            new_stream.name,
+            stream.name,
+        ),
+    )
+
+    assert stream_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_component.productstreams.filter(name="stream").exists()
+
+    assert stream_child_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_child_component.productstreams.filter(name="stream").exists()
+
+
+@pytest.mark.django_db
+def test_slow_update_builds_for_variant_same_product():
+    stream, _ = setup_product("stream")
+    new_version = ProductVersionFactory(products=stream.products)
+    new_stream = ProductStreamFactory(
+        name="new_stream", products=stream.products, productversions=new_version
+    )
+    # Create builds and components for stream
+    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
+
+    # Relate the stream_build to the variant "1" created by setup_product
+    ProductComponentRelation.objects.create(
+        type=ProductComponentRelation.Type.ERRATA,
+        product_ref="1",
+        software_build=stream_build,
+        build_id=stream_build.build_id,
+        build_type=stream_build.build_type,
+    )
+
+    slow_update_builds_for_variant(
+        "1",
+        (
+            new_stream.name,
+            stream.name,
+        ),
+        (
+            new_version.name,
+            stream.productversions.name,
+        ),
+    )
+
+    assert stream_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_component.productstreams.filter(name="stream").exists()
+
+    assert stream_child_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_child_component.productstreams.filter(name="stream").exists()
+
+    assert stream_component.productversions.filter(name=new_version.name).exists()
+    assert not stream_component.productversions.filter(name=stream.productversions.name).exists()
+
+
+@pytest.mark.django_db
+def test_slow_update_builds_for_variant_different_product():
+    stream, _ = setup_product("stream")
+    new_product = Product.objects.create(name="new_product")
+    new_version = ProductVersionFactory(products=new_product)
+    new_stream = ProductStreamFactory(name="new_stream", productversions=new_version)
+    # Create builds and components for stream
+    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
+
+    # Relate the stream_build to the variant "1" created by setup_product
+    ProductComponentRelation.objects.create(
+        type=ProductComponentRelation.Type.ERRATA,
+        product_ref="1",
+        software_build=stream_build,
+        build_id=stream_build.build_id,
+        build_type=stream_build.build_type,
+    )
+
+    slow_update_builds_for_variant(
+        "1",
+        (
+            new_stream.name,
+            stream.name,
+        ),
+        (
+            new_version.name,
+            stream.productversions.name,
+        ),
+        (
+            new_product.name,
+            stream.products.name,
+        ),
+    )
+
+    assert stream_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_component.productstreams.filter(name="stream").exists()
+
+    assert stream_child_component.productstreams.filter(name="new_stream").exists()
+    assert not stream_child_component.productstreams.filter(name="stream").exists()
+
+    assert stream_component.productversions.filter(name=new_version.name).exists()
+    assert not stream_component.productversions.filter(name=stream.productversions.name).exists()
+
+    assert stream_component.products.filter(name=new_product.name).exists()
+    assert not stream_component.products.filter(name=stream.products.name).exists()
+
+
+@pytest.mark.django_db
+@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
+def test_product_variant_index_out_of_range(mock_update_builds, requests_mock):
+    # This test was written because when loading the actual product_definitions the product
+    # taxonomy was being truncated by stream which shared a brew_tag. The issue was fixed
+    # by not called variant.save_product_taxonomy in the `for et_variant in et_pv.variants.all()`
+    # loop in `parse_variants_from_brew_tags function`
+    existing_stream, existing_variant = setup_product()
+
+    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
+    # Sets up 2 CollectorErrataProductVersions with matching brew tags
+    # The brew tag matches the 2 new streams in product_definitions
+    et_version_2 = CollectorErrataProductVersion.objects.create(
+        et_id=12, product=et_product, name="et_stream_2", brew_tags=["two_streams_with_same_tag"]
+    )
+    et_version = CollectorErrataProductVersion.objects.create(
+        et_id=11, product=et_product, name="et_stream_1", brew_tags=["two_streams_with_same_tag"]
+    )
+    # Variant 2 is a new Variant, while "1" was created by setup_product
+    CollectorErrataProductVariant.objects.create(et_id=102, name="2", product_version=et_version_2)
+    CollectorErrataProductVariant.objects.create(et_id=101, name="1", product_version=et_version)
+
+    assert existing_stream.name != "stream"
+    assert existing_stream.name != "new_stream"
+    assert existing_stream.products != "product"
+
+    with open("tests/data/proddefs-update-variants-moved.json") as prod_defs:
+        requests_mock.get(
+            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
+        )
+
+    update_products()
+
+    assert mock_update_builds.call_args_list == [
+        call(
+            "1",
+            ("stream", existing_stream.name),
+            ("version", existing_stream.productversions.name),
+            ("product", existing_stream.products.name),
+            countdown=300,
+        ),
+        # Variant 1 and 2 are then moved from "stream" to the new_stream
+        call("1", ("new_stream", "stream"), countdown=300),
+        call("2", ("new_stream", "stream"), countdown=300),
+    ]
+
+    # Assert that "new_stream" was created after "stream"
+    new_stream = ProductStream.objects.get(name="new_stream")
+    stream = ProductStream.objects.get(name="stream")
+    assert new_stream.created_at > stream.created_at
+
+    # Assert both new variants are only associated with the new_stream (created 2nd)
+    variant = ProductVariant.objects.get(name="1")
+    assert variant.productstreams == new_stream
+
+    variant_2 = ProductVariant.objects.get(name="2")
+    assert variant_2.productstreams == new_stream


### PR DESCRIPTION
Sometimes a variant is moved from one stream to another. This allows that move, and also ensures all the builds associated with that stream are updated to reflect the new stream/variant relationship. The variant will no longer be associated with the old stream, but any builds we've called save_product_taxonomy on before the variant was moved will still reflect both streams, but that's OK in my opinion.