### PR TITLE
CORGI-725: Fix typo in migration

### DIFF
--- a/corgi/core/migrations/0072_productcomponentrelation_sb_fk_data.py
+++ b/corgi/core/migrations/0072_productcomponentrelation_sb_fk_data.py
@@ -19,9 +19,9 @@ def update_build_to_sb_fk(apps, schema_editor):
         .order_by()
     )
     for build_id, build_type, pk in existing_build_ids.iterator():
-        ProductComponentRelation.filter(build_id=build_id, build_type=build_type).order_by().update(
-            software_build=pk
-        )
+        ProductComponentRelation.objects.filter(
+            build_id=build_id, build_type=build_type
+        ).order_by().update(software_build=pk)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
@jasinner FYI. I don't want to merge this right now since it will probably interfere with the running migration, but I'll check the status and merge myself once it finishes. Either tonight before I step out or tomorrow morning.

If the migration is still timing out and not working later in your day, you might try running below in a psql-util pod:
```
SELECT substring(query, 1, 50) AS query,
      calls,
      round(total_exec_time::numeric, 2) AS total_time,
      round(mean_exec_time::numeric, 2) AS mean_time,
      round((100 * total_exec_time / sum(total_exec_time) OVER ())::numeric, 2) AS percentage
FROM pg_stat_statements
ORDER BY total_exec_time DESC
LIMIT 10;
```
If you see any queries on the ProductComponentRelations table which are taking a long time, you might try running .explain() on the Django querysets that use ProductComponentRelation in a Python shell to see the raw SQL, for example:
```
>>> ProductComponentRelation.objects.filter(build_id=1, build_type="BREW").explain()

"Index Scan using core_produc_build_i_f6e300_idx on core_productcomponentrelation  (cost=0.14..2.36 rows=1 width=1510)
Index Cond: (((build_id)::text = '1'::text) AND ((build_type)::text = 'BREW'::text))"
```
Once you figure out which queryset is generating the slow query, you could try rewrtiting it or adding an index for any combination of fields that use "Sequential Scan" (slow) instead of "Index Scan" (fast).