### PR TITLE
CORGI-257 persist errata modules

### DIFF
--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -7,11 +7,13 @@ import requests
 from django.conf import settings
 from requests_gssapi import HTTPSPNEGOAuth
 
+from corgi.collectors.brew import Brew
 from corgi.collectors.models import (
     CollectorErrataProduct,
     CollectorErrataProductVariant,
     CollectorErrataProductVersion,
 )
+from corgi.core.models import SoftwareBuild
 
 logger = logging.getLogger(__name__)
 
@@ -149,11 +151,17 @@ class ErrataTool:
           }
         }
         """
-        variant_to_component_map = defaultdict(list)
+        variant_to_component_map: typing.DefaultDict[str, list] = defaultdict(list)
         builds = self.get(f"api/v1/erratum/{erratum_id}/builds_list.json")
+        brew = Brew(SoftwareBuild.Type.BREW)
         for product_version in builds.values():
             for build in product_version["builds"]:
                 for build_nvr, build_data in build.items():
+                    if build_data["is_module"]:
+                        self._parse_module(
+                            build_nvr, build_data["variant_arch"], brew, variant_to_component_map
+                        )
+                        continue
                     build_id = build_data["id"]
                     for variant, components_by_arch in build_data["variant_arch"].items():
                         variant_components = []
@@ -225,3 +233,31 @@ class ErrataTool:
             for component in variant:
                 build_ids.update(component.keys())
         return list(build_ids)
+
+    def _parse_module(
+        self,
+        module_name: str,
+        module_data: dict[str, dict[str, list[str]]],
+        brew: Brew,
+        variant_to_component_map: typing.DefaultDict[str, list],
+    ) -> None:
+        """Persist collector models for modular builds from errata build_list.json. This allows
+        later processing of modular builds in the Brew task slow_fetch_modular_build"""
+        for variant, components_by_arch in module_data.items():
+            modular_rpms = []
+            for arch, components in components_by_arch.items():
+                # SRPMS are looked up in persist_modules from Brew via RPMs
+                if arch == "SRPMS":
+                    continue
+                # persist_modules expects the .rpm suffix stripped
+                rpm_suffix_len = ".rpm"
+                stripped_components = [
+                    rpm[: -len(rpm_suffix_len)] for rpm in components if rpm.endswith(".rpm")
+                ]
+                modular_rpms.extend(stripped_components)
+            build_ids = brew.persist_modules({module_name: modular_rpms})
+            for build_id in build_ids:
+                # persist_modules returns a flat list of build_ids, so its no longer possible to
+                # map modular_rpms to build_ids. In slow_save_errata these are only saved as
+                # meta_attr so, let's just save the entire list for each build_id
+                variant_to_component_map[variant].append({build_id: modular_rpms})

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -169,7 +169,9 @@ def slow_fetch_brew_build(
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def slow_fetch_modular_build(build_id: str, force_process: bool = False) -> None:
+def slow_fetch_modular_build(
+    build_id: str, save_product: bool = True, force_process: bool = False
+) -> None:
     logger.info("Fetch modular build called with build id: %s", build_id)
     rhel_module_data = Brew.fetch_rhel_module(build_id)
     # Some compose build_ids in the relations table will be for SRPMs, skip those here
@@ -205,7 +207,7 @@ def slow_fetch_modular_build(build_id: str, force_process: bool = False) -> None
         if "brew_build_id" in c:
             slow_fetch_brew_build.delay(c["brew_build_id"])
         save_component(c, node)
-    slow_fetch_brew_build.delay(build_id, force_process=force_process)
+    slow_fetch_brew_build.delay(build_id, save_product=save_product, force_process=force_process)
     logger.info("Finished fetching modular build: %s", build_id)
 
 

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -108,12 +108,12 @@ def slow_load_errata(erratum_name: str, force_process: bool = False) -> None:
             # We set save_product argument to False because it reads from the
             # ProductComponentRelations table which this function writes to. We've seen contention
             # on this database table causes by recursive looping of this task, and the
-            # slow_fetch_brew_build task, eg CORGI-21. We call save_product_taxonomy from
+            # slow_fetch_modular_build task, eg CORGI-21. We call save_product_taxonomy from
             # this task only after all the builds in the errata have been loaded instead.
-            logger.info("Calling slow_fetch_brew_build for %s", build_id)
+            logger.info("Calling slow_fetch_modular_build for %s", build_id)
             app.send_task(
-                "corgi.tasks.brew.slow_fetch_brew_build",
-                args=(build_id, build_type),
+                "corgi.tasks.brew.slow_fetch_modular_build",
+                args=(build_id,),
                 # Do not pass force_process through to child tasks
                 # Or Celery will get stuck in an infinite loop
                 # processing the same Brew builds / errata repeatedly

--- a/tests/data/errata/errata_modular_and_normal_builds_list.json
+++ b/tests/data/errata/errata_modular_and_normal_builds_list.json
@@ -1,0 +1,55 @@
+{
+  "CERTSYS-10.4-RHEL-8": {
+    "name": "CERTSYS-10.4-RHEL-8",
+    "description": "Red Hat Certificate System 10.4 for RHEL-8",
+    "builds": [
+      {
+        "redhat-pki-10-8060020220420152504.07fb4edf": {
+          "nvr": "redhat-pki-10-8060020220420152504.07fb4edf",
+          "nevr": "redhat-pki-0:10-8060020220420152504.07fb4edf",
+          "id": 1979262,
+          "is_module": true,
+          "variant_arch": {
+            "8Base-CertSys-10.4": {
+              "noarch": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "python3-redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.noarch.rpm"
+              ],
+              "SRPMS": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.src.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.src.rpm"
+              ],
+              "x86_64": [
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm"
+              ]
+            }
+          }
+        }
+      },
+      {
+          "polkit-0.112-18.el7_6.3": {
+            "nvr": "polkit-0.112-18.el7_6.3",
+            "nevr": "polkit-0:0.112-18.el7_6.3",
+            "id": 1848203,
+            "is_module": false,
+            "variant_arch": {
+              "7Server-7.6.AUS": {
+                "SRPMS": [
+                  "polkit-0.112-18.el7_6.3.src.rpm"
+                ],
+                "x86_64": [
+                  "polkit-0.112-18.el7_6.3.x86_64.rpm"
+                ]
+              }
+            }
+          }
+        }
+    ]
+  }
+}

--- a/tests/data/errata/errata_modular_and_normal_builds_list_mixed_variants.json
+++ b/tests/data/errata/errata_modular_and_normal_builds_list_mixed_variants.json
@@ -1,0 +1,57 @@
+{
+  "CERTSYS-10.4-RHEL-8": {
+    "name": "CERTSYS-10.4-RHEL-8",
+    "description": "Red Hat Certificate System 10.4 for RHEL-8",
+    "builds": [
+      {
+        "redhat-pki-10-8060020220420152504.07fb4edf": {
+          "nvr": "redhat-pki-10-8060020220420152504.07fb4edf",
+          "nevr": "redhat-pki-0:10-8060020220420152504.07fb4edf",
+          "id": 1979262,
+          "is_module": true,
+          "variant_arch": {
+            "8Base-CertSys-10.4": {
+              "noarch": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.noarch.rpm"
+              ],
+              "SRPMS": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.src.rpm"
+              ],
+              "x86_64": ["jss-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm"]
+            },
+            "7Server-7.6.AUS": {
+              "noarch": ["python3-redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm"],
+              "SRPMS": [
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.src.rpm"
+              ],
+              "x86_64": ["redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm"]
+            }
+          }
+        }
+      },
+      {
+        "polkit-0.112-18.el7_6.3": {
+          "nvr": "polkit-0.112-18.el7_6.3",
+          "nevr": "polkit-0:0.112-18.el7_6.3",
+          "id": 1848203,
+          "is_module": false,
+          "variant_arch": {
+            "7Server-7.6.AUS": {
+              "SRPMS": [
+                "polkit-0.112-18.el7_6.3.src.rpm"
+              ],
+              "x86_64": [
+                "polkit-0.112-18.el7_6.3.x86_64.rpm"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/data/errata/errata_modular_and_normal_builds_list_same_variant.json
+++ b/tests/data/errata/errata_modular_and_normal_builds_list_same_variant.json
@@ -1,0 +1,55 @@
+{
+  "CERTSYS-10.4-RHEL-8": {
+    "name": "CERTSYS-10.4-RHEL-8",
+    "description": "Red Hat Certificate System 10.4 for RHEL-8",
+    "builds": [
+      {
+        "redhat-pki-10-8060020220420152504.07fb4edf": {
+          "nvr": "redhat-pki-10-8060020220420152504.07fb4edf",
+          "nevr": "redhat-pki-0:10-8060020220420152504.07fb4edf",
+          "id": 1979262,
+          "is_module": true,
+          "variant_arch": {
+            "8Base-CertSys-10.4": {
+              "noarch": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "python3-redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.noarch.rpm"
+              ],
+              "SRPMS": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.src.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.src.rpm"
+              ],
+              "x86_64": [
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm"
+              ]
+            }
+          }
+        }
+      },
+      {
+          "polkit-0.112-18.el7_6.3": {
+            "nvr": "polkit-0.112-18.el7_6.3",
+            "nevr": "polkit-0:0.112-18.el7_6.3",
+            "id": 1848203,
+            "is_module": false,
+            "variant_arch": {
+              "8Base-CertSys-10.4": {
+                "SRPMS": [
+                  "polkit-0.112-18.el7_6.3.src.rpm"
+                ],
+                "x86_64": [
+                  "polkit-0.112-18.el7_6.3.x86_64.rpm"
+                ]
+              }
+            }
+          }
+        }
+    ]
+  }
+}

--- a/tests/data/errata/errata_modular_builds_list.json
+++ b/tests/data/errata/errata_modular_builds_list.json
@@ -1,0 +1,61 @@
+{
+  "CERTSYS-10.4-RHEL-8": {
+    "name": "CERTSYS-10.4-RHEL-8",
+    "description": "Red Hat Certificate System 10.4 for RHEL-8",
+    "builds": [
+      {
+        "redhat-pki-10-8060020220420152504.07fb4edf": {
+          "nvr": "redhat-pki-10-8060020220420152504.07fb4edf",
+          "nevr": "redhat-pki-0:10-8060020220420152504.07fb4edf",
+          "id": 1979262,
+          "is_module": true,
+          "variant_arch": {
+            "8Base-CertSys-10.4": {
+              "noarch": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "ldapjdk-javadoc-4.23.0-1.module+el8pki+14677+1ef79a68.noarch.rpm",
+                "python3-redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-acme-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-base-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-base-java-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-ca-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-console-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-console-theme-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-javadoc-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-kra-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-ocsp-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-server-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-server-theme-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "redhat-pki-tks-10.13.0-2.module+el8pki+14894+cc476c07.noarch.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.noarch.rpm"
+              ],
+              "SRPMS": [
+                "idm-console-framework-1.3.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "ldapjdk-4.23.0-1.module+el8pki+14677+1ef79a68.src.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.src.rpm",
+                "tomcatjss-7.7.2-1.module+el8pki+14677+1ef79a68.src.rpm"
+              ],
+              "x86_64": [
+                "jss-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "jss-debuginfo-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "jss-debugsource-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "jss-javadoc-4.9.2-1.module+el8pki+14677+1ef79a68.x86_64.rpm",
+                "redhat-pki-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-debuginfo-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-debugsource-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-symkey-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-symkey-debuginfo-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-tools-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-tools-debuginfo-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-tps-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm",
+                "redhat-pki-tps-debuginfo-10.13.0-2.module+el8pki+14894+cc476c07.x86_64.rpm"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The errata tool builds list requires extra processing to capture modular builds. This change looks for modular builds in the errata builds list and prepares the modular data for processing by the existing Brew.persist_module function. It also switches slow_load_errata to use slow_fetch_modular_build instead of slow_fetch_brew_build.