### PR TITLE
Fix "must be a mapping" error in daily monitoring email

### DIFF
--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -371,15 +371,17 @@ def test_product_variant_index_out_of_range(mock_update_builds, requests_mock):
 
     assert mock_update_builds.call_args_list == [
         call(
-            "1",
-            ("stream", existing_stream.name),
-            ("version", existing_stream.productversions.name),
-            ("product", existing_stream.products.name),
-            countdown=300,
+            args=(
+                "1",
+                ("stream", existing_stream.name),
+                ("version", existing_stream.productversions.name),
+                ("product", existing_stream.products.name),
+            ),
+            kwargs={"countdown": 300},
         ),
         # Variant 1 and 2 are then moved from "stream" to the new_stream
-        call("1", ("new_stream", "stream"), countdown=300),
-        call("2", ("new_stream", "stream"), countdown=300),
+        call(args=("1", ("new_stream", "stream"), None, None), kwargs={"countdown": 300}),
+        call(args=("2", ("new_stream", "stream"), None, None), kwargs={"countdown": 300}),
     ]
 
     # Assert that "new_stream" was created after "stream"


### PR DESCRIPTION
@jasinner Please review. This fixes the below error in our daily monitoring email:

```
corgi.tasks.prod_defs.update_products: args="()", kwargs="{}"
result={"exc_type": "TypeError", "exc_message": ["corgi.tasks.prod_defs.slow_update_builds_for_variant() argument after ** must be a mapping, not tuple"], "exc_module": "builtins"}
Traceback (most recent call last):
...some data snipped...
  File "/opt/app-root/src/corgi/tasks/prod_defs.py", line 129, in update_products
    parse_product_version(pd_product_version, product, product_node)
  File "/opt/app-root/src/corgi/tasks/prod_defs.py", line 163, in parse_product_version
    parse_product_stream(
  File "/opt/app-root/src/corgi/tasks/prod_defs.py", line 210, in parse_product_stream
    parse_variants_from_brew_tags(
  File "/opt/app-root/src/corgi/tasks/prod_defs.py", line 349, in parse_variants_from_brew_tags
    slow_update_builds_for_variant.apply_async(
...some data snipped...
  File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 540, in apply_async
    check_arguments(*(args or ()), **(kwargs or {}))
TypeError: corgi.tasks.prod_defs.slow_update_builds_for_variant() argument after ** must be a mapping, not tuple
```