### PR TITLE
CORGI-730: Fix slow query when deleting builds

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -494,7 +494,6 @@ def test_slow_delete_brew_builds():
     assert ComponentNode.objects.count() == 3
 
     nodes = ComponentNode.objects.order_by("created_at")
-    assert nodes.count() == 3
     assert nodes.first().purl == index_container.purl
     assert nodes[1].purl == shipped_upstream.purl
     assert nodes.last().purl == shipped_binary_rpm.purl


### PR DESCRIPTION
Just a draft for now, we need to fix a bug first before merging this. Some GENERIC components are created as root components and have no sources / upstreams. The new logic here will delete those components as well, which we don't want.

Once that data is fixed (all generic components are linked correctly to their root components), we can assume that all non-root / child components will have either non-null sources (are provided components) or non-null downstreams (are upstream components).

Any non-root / child components with both null sources and null upstreams, are either provided components or upstream components. They are not linked to their source / downstream root component anymore because that root component (and its build) just got deleted. We should be able to safely clean them up, but I need to confirm we don't have other edge cases in our data.