### PR TITLE
CORGI-668: Fix slow migration

### DIFF
--- a/corgi/core/migrations/0075_fix_oci_purls.py
+++ b/corgi/core/migrations/0075_fix_oci_purls.py
@@ -1,11 +1,10 @@
-from django.db import IntegrityError, migrations, transaction
+from django.db import migrations
 from django.db.models import Value, functions
 
 
 def fix_oci_purls(apps, schema_editor):
     """Remove "redhat/" namespace from all "pkg:oci/" purls"""
     Component = apps.get_model("core", "Component")
-    ComponentNode = apps.get_model("core", "ComponentNode")
 
     oci_purl = "pkg:oci/"
     redhat_oci_purl = f"{oci_purl}redhat/"
@@ -13,18 +12,6 @@ def fix_oci_purls(apps, schema_editor):
     Component.objects.filter(purl__startswith=redhat_oci_purl).update(
         purl=functions.Replace("purl", Value(redhat_oci_purl), Value(oci_purl))
     )
-    for node in ComponentNode.objects.filter(purl__startswith=redhat_oci_purl).iterator():
-        # Can't do .update() here since some type + parent combos have two nodes
-        # One node purl starts with "pkg:oci/name" and one starts with "pkg:oci/redhat/name"
-        # type + parent + purl combos must be unique, so we can't remove redhat/ from the 2nd purl
-        # just delete the 2nd node with "pkg:oci/redhat/name" purl instead
-        # A list of build IDs to reingest has already been added to CORGI-566
-        try:
-            with transaction.atomic():
-                node.purl = node.purl.replace(redhat_oci_purl, oci_purl, 1)
-                node.save()
-        except IntegrityError:
-            node.delete()
 
 
 class Migration(migrations.Migration):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -113,7 +113,7 @@ def test_displaying_pregenerated_manifest() -> None:
 def generate_manifest_with_many_components() -> dict:
     """Helper method for timeit to generate a manifest with many components"""
     large_component_purl = (
-        "pkg:oci/redhat/ubi9-container"
+        "pkg:oci/ubi9-container"
         "@sha256:276b287ff6143f807342296908cc4ae09bfd584d66ba35dab5efc726b7be097b"
         "?repository_url=registry.redhat.io/ubi9&tag=9.1.0-1822"
     )


### PR DESCRIPTION
Bailing out here since the migration takes too long and I can't get it to work any faster. We can update the purls on all ComponentNodes as part of CORGI-566, or just delete and reload everything. Purls on all Components have already been fixed. We've also fixed our code so we won't create more bad data in the future.