### PR TITLE
Pass kwarg to Celery / the task scheduler, not the task itself

### DIFF
--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -341,7 +341,8 @@ def parse_variants_from_brew_tags(
                             # New and old product names might not be present
                             changed_products,
                         ),
-                        kwargs={"countdown": 300},
+                        # kwarg for Celery, not the task
+                        countdown=300,
                     )
 
 

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -377,11 +377,11 @@ def test_product_variant_index_out_of_range(mock_update_builds, requests_mock):
                 ("version", existing_stream.productversions.name),
                 ("product", existing_stream.products.name),
             ),
-            kwargs={"countdown": 300},
+            countdown=300,
         ),
         # Variant 1 and 2 are then moved from "stream" to the new_stream
-        call(args=("1", ("new_stream", "stream"), None, None), kwargs={"countdown": 300}),
-        call(args=("2", ("new_stream", "stream"), None, None), kwargs={"countdown": 300}),
+        call(args=("1", ("new_stream", "stream"), None, None), countdown=300),
+        call(args=("2", ("new_stream", "stream"), None, None), countdown=300),
     ]
 
     # Assert that "new_stream" was created after "stream"


### PR DESCRIPTION
Quick fix for previous MR and error in monitoring emails.