### PR TITLE
fix a bug where we passed the wrong type to slow_load_errata

### DIFF
--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
                                             f"Found variant {variant} in {erratum['id']}"
                                         )
                                     )
-                                    all_errata.add(erratum["id"])
+                                    all_errata.add(str(erratum["id"]))
 
             for erratum in all_errata:
                 self.stdout.write(self.style.SUCCESS(f"Loading erratum: {erratum}"))


### PR DESCRIPTION
This change also makes the command slightly more efficient by loading erratum straight away, rather than waiting for the the check off all product errata to complete