### PR TITLE
CORGI-738 match more variants via brew tags

### DIFF
--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -186,9 +186,14 @@ def parse_variants_from_brew_tags(
         )
         for brew_tag in brew_tags.keys():
             # Also match brew tags in prod_defs with those from ET
-            trimmed_brew_tag = brew_tag.removesuffix("-released")
+            # Brew tags in ET
+            trimmed_brew_tag = brew_tag.removesuffix("-candidate")
+            trimmed_brew_tag = trimmed_brew_tag.removesuffix("-released")
+            # This is a special case for 'rhaos-4-*` brew tags which don't have the -container
+            # suffix in ET, but do have that suffix in product_definitions
+            sans_container_released = brew_tag.removesuffix("-container-released")
             et_pvs = CollectorErrataProductVersion.objects.filter(
-                brew_tags__contains=[trimmed_brew_tag]
+                brew_tags__overlap=[trimmed_brew_tag, sans_container_released]
             )
 
             for et_pv in et_pvs:

--- a/tests/data/product-definitions.json
+++ b/tests/data/product-definitions.json
@@ -150,6 +150,16 @@
           ]
         }
       ]
+    },
+    "gitops-1.7": {
+      "pp_label": "gitops-1.7",
+      "version": "1.7.2",
+      "brew_tags": [
+        {
+          "tag": "gitops-1.7-rhel-8-candidate",
+          "inherit": false
+        }
+      ]
     }
   },
   "ps_modules": {
@@ -334,40 +344,71 @@
       "risk": null
     },
     "rhn_satellite_6": {
-			"public_description": "Red Hat Satellite 6",
-			"ps_update_streams": ["rhn_satellite_6.7", "rhn_satellite_6.10"],
-			"active_ps_update_streams": ["rhn_satellite_6.10"],
-			"default_ps_update_streams": ["rhn_satellite_6.10"],
-			"unacked_ps_update_stream": "rhn_satellite_6-default",
-			"bts": {
-				"name": "bugzilla",
-				"key": "Red Hat Satellite",
-				"groups": {
-					"public": ["redhat"],
-					"embargoed": ["security", "qe_staff"]
-				}
-			},
-			"allow_defer": false,
-			"default_cc": ["+sat6"],
-			"component_cc": {},
-			"components": {
-				"default": "Security"
-			},
-			"autofile_trackers": false,
-			"private_trackers_allowed": true,
-			"lifecycle": {
-				"supported_from": null,
-				"supported_until": null
-			},
-			"cpe": ["cpe:/a:redhat:satellite:6",
-				"cpe:/a:redhat:satellite_capsule:6",
-				"cpe:/a:redhat:rhel_satellite_tools:*"],
-			"risk": null,
-			"checklist": null,
-			"exceptions": [],
-			"opengrok": false,
-			"manifest": true
-		}
+      "public_description": "Red Hat Satellite 6",
+      "ps_update_streams": [
+        "rhn_satellite_6.7",
+        "rhn_satellite_6.10"
+      ],
+      "active_ps_update_streams": [
+        "rhn_satellite_6.10"
+      ],
+      "default_ps_update_streams": [
+        "rhn_satellite_6.10"
+      ],
+      "unacked_ps_update_stream": "rhn_satellite_6-default",
+      "bts": {
+        "name": "bugzilla",
+        "key": "Red Hat Satellite",
+        "groups": {
+          "public": [
+            "redhat"
+          ],
+          "embargoed": [
+            "security",
+            "qe_staff"
+          ]
+        }
+      },
+      "allow_defer": false,
+      "default_cc": [
+        "+sat6"
+      ],
+      "component_cc": {},
+      "components": {
+        "default": "Security"
+      },
+      "autofile_trackers": false,
+      "private_trackers_allowed": true,
+      "lifecycle": {
+        "supported_from": null,
+        "supported_until": null
+      },
+      "cpe": [
+        "cpe:/a:redhat:satellite:6",
+        "cpe:/a:redhat:satellite_capsule:6",
+        "cpe:/a:redhat:rhel_satellite_tools:*"
+      ],
+      "risk": null,
+      "checklist": null,
+      "exceptions": [],
+      "opengrok": false,
+      "manifest": true
+    },
+    "gitops-1": {
+      "public_description": "Red Hat OpenShift GitOps",
+      "ps_update_streams": [
+        "gitops-1.7"
+      ],
+      "active_ps_update_streams": [
+        "gitops-1.7"
+      ],
+      "default_ps_update_streams": [
+        "gitops-1.7"
+      ],
+      "cpe": [
+        "cpe:/a:redhat:openshift_gitops:1"
+      ]
+    }
   },
   "ps_products": {
     "rhel": {
@@ -426,6 +467,18 @@
         "SATELLITE",
         "SAT-TOOLS",
         "Satellite Client"
+      ]
+    },
+    "gitops": {
+      "name": "Red Hat OpenShift GitOps",
+      "team": "codeready",
+      "lifecycle_url": "https://access.redhat.com/support/policy/updates/openshift/#gitops",
+      "ps_modules": [
+        "gitops-1"
+      ],
+      "business_unit": "Core Developer",
+      "errata_product_tags": [
+        "GitOps"
       ]
     }
   },

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -111,21 +111,3 @@ def test_skip_brew_tag_linking_for_buggy_products(requests_mock):
     assert len(sat_610_variants) == 2
     for variant in sat_610_variants:
         assert variant.name in ("7Server-Capsule610", "7Server-Satellite610")
-
-
-def _create_builds_and_components(stream):
-    stream_build = SoftwareBuildFactory()
-    stream_component = ComponentFactory(software_build=stream_build)
-    stream_component_node = ComponentNode.objects.create(
-        parent=None, obj=stream_component, type=ComponentNode.ComponentNodeType.SOURCE
-    )
-    stream_child_component = ComponentFactory()
-    ComponentNode.objects.create(
-        parent=stream_component_node,
-        obj=stream_child_component,
-        type=ComponentNode.ComponentNodeType.PROVIDES,
-    )
-    stream_component.productstreams.add(stream)
-    stream_component.productversions.add(stream.productversions)
-    stream_component.products.add(stream.products)
-    return stream_build, stream_component, stream_child_component

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -8,9 +8,8 @@ from corgi.collectors.models import (
     CollectorErrataProductVariant,
     CollectorErrataProductVersion,
 )
-from corgi.core.models import ComponentNode, Product, ProductStream
+from corgi.core.models import Product, ProductStream
 from corgi.tasks.prod_defs import update_products
-from tests.factories import ComponentFactory, SoftwareBuildFactory
 
 pytestmark = pytest.mark.unit
 
@@ -49,7 +48,7 @@ def test_products(requests_mock):
 
     update_products()
 
-    assert Product.objects.count() == 4
+    assert Product.objects.count() == 5
 
     rhel_product = Product.objects.get(name="rhel")
     assert rhel_product.name == "rhel"
@@ -111,3 +110,42 @@ def test_skip_brew_tag_linking_for_buggy_products(requests_mock):
     assert len(sat_610_variants) == 2
     for variant in sat_610_variants:
         assert variant.name in ("7Server-Capsule610", "7Server-Satellite610")
+
+
+# We stip -candidate from tags before persisting Collector models
+brew_tag_streams = [
+    # In the actual ET data the brew tag is gitops-1.7-rhel-8-candidate
+    # This matches ps_update_stream gitops-1.7, which has a brew tag
+    # gitops-1.7-rhel-8-candidate
+    ("8Base-GitOps-1.7", "gitops-1.7-rhel-8", "gitops-1.7"),
+    # In the actual ET data the brew tag is rhaos-4.10-rhel-8-candidate
+    # This matches ps_update_stream openshift-4.10.z, which has a brew tag
+    # rhaos-4.10-rhel-8-container-released
+    ("OSE-4.10-RHEL-8", "rhaos-4.10-rhel-8", "openshift-4.10.z"),
+    # In the actual ET data the brew tag is rhacm-2.4-rhel-7-container-candidate
+    # This matches the ps_update_stream rhacm-2.4.z, which has a brew tag
+    # rhacm-2.4-rhel-7-container-released
+    ("RHACM-2.4", "rhacm-2.4-rhel-7-container", "rhacm-2.4.z"),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("variant_name,brew_tag,stream_name", brew_tag_streams)
+def test_brew_tag_matching(variant_name, brew_tag, stream_name, requests_mock):
+    et_product = CollectorErrataProduct.objects.create(et_id=1, name="product")
+    et_product_version = CollectorErrataProductVersion.objects.create(
+        et_id=10, name="product_version", product=et_product, brew_tags=[brew_tag]
+    )
+    CollectorErrataProductVariant.objects.create(
+        et_id=100, name=variant_name, product_version=et_product_version
+    )
+
+    with open("tests/data/product-definitions.json") as prod_defs:
+        requests_mock.get(
+            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
+        )
+
+    update_products()
+
+    stream = ProductStream.objects.get(name=stream_name)
+    assert stream.productvariants.first().name == variant_name


### PR DESCRIPTION
This allows matches between variants and streams for extra streams including openshift-4.13.z as in the description of CORGI-738.