### PR TITLE
CORGI-748 revert buggy code for moving variant between streams

### DIFF
--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Optional
+from typing import Any
 
 from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
@@ -12,13 +12,11 @@ from corgi.collectors.models import (
 )
 from corgi.collectors.prod_defs import ProdDefs
 from corgi.core.models import (
-    Component,
     Product,
     ProductNode,
     ProductStream,
     ProductVariant,
     ProductVersion,
-    SoftwareBuild,
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
@@ -26,66 +24,6 @@ logger = get_task_logger(__name__)
 # Find a substring that looks like a version (e.g. "3", "3.5", "3-5", "1.2.z") at the end of a
 # searched string.
 RE_VERSION_LIKE_STRING = re.compile(r"\d[\dz.-]*$|$")
-
-
-@app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
-def slow_update_builds_for_variant(
-    variant_name: str,
-    updated_stream: tuple[str, str],
-    updated_version: Optional[tuple[str, str]] = None,
-    updated_product: Optional[tuple[str, str]] = None,
-):
-    """Ensures new stream parent of the passed in variant is reflected in all the variant's builds
-    and child components"""
-    logger.info(
-        f"Updating components related to {variant_name} with new stream details: {updated_stream}"
-    )
-    updated_stream_objs = (
-        ProductStream.objects.get(name=updated_stream[0]),
-        ProductStream.objects.get(name=updated_stream[1]),
-    )
-    updated_version_objs = None
-    updated_product_objs = None
-    if updated_version:
-        logger.info(f"Also updating product_version with {updated_version}")
-        updated_version_objs = (
-            ProductVersion.objects.get(name=updated_version[0]),
-            ProductVersion.objects.get(name=updated_version[1]),
-        )
-    if updated_product:
-        logger.info(f"Also updating product {updated_product}")
-        updated_product_objs = (
-            Product.objects.get(name=updated_product[0]),
-            Product.objects.get(name=updated_product[1]),
-        )
-    for software_build in (
-        SoftwareBuild.objects.filter(relations__product_ref=variant_name).distinct().iterator()
-    ):
-        component = software_build.components.get()
-        _update_product_streams(
-            component, updated_stream_objs, updated_version_objs, updated_product_objs
-        )
-        for cnode in component.cnodes.get_queryset().iterator():
-            for d in cnode.get_descendants().iterator():
-                _update_product_streams(
-                    d.obj, updated_stream_objs, updated_version_objs, updated_product_objs
-                )
-
-
-def _update_product_streams(
-    component: Component,
-    updated_stream: tuple[ProductStream, ProductStream],
-    updated_version: Optional[tuple[ProductVersion, ProductVersion]] = None,
-    updated_product: Optional[tuple[Product, Product]] = None,
-):
-    component.productstreams.add(updated_stream[0])
-    component.productstreams.remove(updated_stream[1])
-    if updated_version:
-        component.productversions.add(updated_version[0])
-        component.productversions.remove(updated_version[1])
-    if updated_product:
-        component.products.add(updated_product[0])
-        component.products.remove(updated_product[1])
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
@@ -268,84 +206,29 @@ def parse_variants_from_brew_tags(
                     variant_product_version: CollectorErrataProductVersion = (
                         et_variant.product_version
                     )
-                    # We don't use update_or_create here in order to get the existing product detail
-                    # of the variant. We then clear the existing product details from all associated
-                    # builds and there components before adding the new product details.
-                    variant_created = False
-                    try:
-                        product_variant = ProductVariant.objects.get(name=et_variant.name)
-                        product_variant.cpe = et_variant.cpe
-                        product_variant.meta_attr = {
-                            "et_product": variant_product_version.product.name,
-                            "et_product_version": variant_product_version.name,
-                        }
-                        product_variant.save()
-                    except ProductVariant.DoesNotExist:
-                        product_variant = ProductVariant.objects.create(
-                            name=et_variant.name,
-                            cpe=et_variant.cpe,
-                            products=product,
-                            productversions=product_version,
-                            productstreams=product_stream,
-                            meta_attr={
+                    product_variant, _ = ProductVariant.objects.update_or_create(
+                        name=et_variant.name,
+                        defaults={
+                            "version": "",
+                            "cpe": et_variant.cpe,
+                            "description": "",
+                            "products": product,
+                            "productversions": product_version,
+                            "productstreams": product_stream,
+                            "meta_attr": {
                                 "et_product": variant_product_version.product.name,
                                 "et_product_version": variant_product_version.name,
                             },
-                        )
-                        variant_created = True
-
-                    _, node_created = ProductNode.objects.update_or_create(
+                        },
+                    )
+                    ProductNode.objects.get_or_create(
                         object_id=product_variant.pk,
                         defaults={
                             "parent": product_stream_node,
                             "obj": product_variant,
                         },
                     )
-                    if node_created and variant_created:
-                        # This is a new Variant, so no need to update anything
-                        continue
-
-                    # If there was an existing product variant, and it was updated
-                    # to now be associated with a different stream we need to
-                    # update all the builds to reflect the new product relationships
-                    # Capture all the old stream details before updating the foreign keys
-                    existing_product_name = product_variant.products.name
-                    existing_version_name = product_variant.productversions.name
-                    existing_stream_name = product_variant.productstreams.name
-                    product_variant.products = product
-                    product_variant.productversions = product_version
-                    product_variant.productstreams = product_stream
-                    product_variant.save()
-
-                    changed_products = None
-                    changed_versions = None
-                    if existing_product_name != product.name:
-                        changed_products = (
-                            product.name,
-                            existing_product_name,
-                        )
-                    if existing_version_name != product_version.name:
-                        changed_versions = (
-                            product_version.name,
-                            existing_version_name,
-                        )
-                    slow_update_builds_for_variant.apply_async(
-                        args=(
-                            # Variant name is always present
-                            product_variant.name,
-                            # New and old stream names are always present
-                            (
-                                product_stream.name,
-                                existing_stream_name,
-                            ),
-                            # New and old version names might not be present
-                            changed_versions,
-                            # New and old product names might not be present
-                            changed_products,
-                        ),
-                        # kwarg for Celery, not the task
-                        countdown=300,
-                    )
+                    product_variant.save_product_taxonomy()
 
 
 def parse_errata_info(

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import call, patch
 
 import pytest
 from django.conf import settings
@@ -9,28 +8,15 @@ from corgi.collectors.models import (
     CollectorErrataProductVariant,
     CollectorErrataProductVersion,
 )
-from corgi.core.models import (
-    ComponentNode,
-    Product,
-    ProductComponentRelation,
-    ProductStream,
-    ProductVariant,
-)
-from corgi.tasks.prod_defs import slow_update_builds_for_variant, update_products
-from tests.conftest import setup_product
-from tests.factories import (
-    ComponentFactory,
-    ProductStreamFactory,
-    ProductVersionFactory,
-    SoftwareBuildFactory,
-)
+from corgi.core.models import ComponentNode, Product, ProductStream
+from corgi.tasks.prod_defs import update_products
+from tests.factories import ComponentFactory, SoftwareBuildFactory
 
 pytestmark = pytest.mark.unit
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
-@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
-def test_products(mock_update_builds, requests_mock):
+def test_products(requests_mock):
     with open("tests/data/product-definitions.json") as prod_defs:
         text = prod_defs.read()
         text = text.replace("{CORGI_TEST_DOWNLOAD_URL}", os.getenv("CORGI_TEST_DOWNLOAD_URL"))
@@ -92,13 +78,9 @@ def test_products(mock_update_builds, requests_mock):
     # Which should include the stream's CPE + all the child variant CPEs (if any)
     assert et_variant.cpe in rhacm24z.cpes
 
-    # Assert mock_update_builds was not called because no variants moved between streams
-    assert not mock_update_builds.called
-
 
 @pytest.mark.django_db
-@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
-def test_skip_brew_tag_linking_for_buggy_products(mock_update_builds, requests_mock):
+def test_skip_brew_tag_linking_for_buggy_products(requests_mock):
     """RHEL-7-SATELLITE-6.10 has a brew_tag for 6.7 version, which means the 7Server-Satellite67
     ProductVariant gets incorrectly associated with the rhn_satellite_6.7 product stream"""
 
@@ -130,71 +112,6 @@ def test_skip_brew_tag_linking_for_buggy_products(mock_update_builds, requests_m
     for variant in sat_610_variants:
         assert variant.name in ("7Server-Capsule610", "7Server-Satellite610")
 
-    assert not mock_update_builds.called
-
-
-@pytest.mark.django_db
-@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
-def test_stream_variants_updated(mock_update_builds, requests_mock):
-    # Creates ProductStream, "stream", with an existing ProductVariant called "1"
-    # The ps_update_stream loaded from proddefs-*.json below has a matching name "stream"
-    stream, variant = setup_product("stream")
-    # Sets up a CollectorErrataProductVersion with a matching brew tag
-    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
-    et_version = CollectorErrataProductVersion.objects.create(
-        et_id=10, product=et_product, name="et_stream_1", brew_tags=["test_tag"]
-    )
-    # Attaching a different Variant, called "2" to the CollectorErrataProductVersion
-    CollectorErrataProductVariant.objects.create(et_id=100, name="2", product_version=et_version)
-
-    with open("tests/data/proddefs-update-variants.json") as prod_defs:
-        requests_mock.get(
-            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
-        )
-
-    update_products()
-
-    # Verify that a new ProductVariant called "2" was created
-    variant_2 = ProductVariant.objects.get(name="2")
-    assert stream == variant_2.productstreams
-
-    # Verify that the original variant is still associated with the stream
-    assert stream == variant.productstreams
-
-    assert not mock_update_builds.called
-
-
-@pytest.mark.django_db
-@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
-def test_stream_variants_moved_to_new_stream(mock_update_builds, requests_mock):
-    # Creates ProductStream, "stream", with an existing ProductVariant called "1"
-    # The ps_update_stream loaded from proddefs-*.json below has a matching name "stream"
-    stream, variant = setup_product("stream")
-
-    # Verify that the original variant is associated with the stream
-    assert stream == variant.productstreams
-
-    # Sets up a CollectorErrataProductVersion with a matching brew tag
-    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
-    et_version = CollectorErrataProductVersion.objects.create(
-        et_id=10, product=et_product, name="et_stream_1", brew_tags=["two_streams_with_same_tag"]
-    )
-    # This is the same variant as the original to the CollectorErrataProductVersion
-    CollectorErrataProductVariant.objects.create(et_id=100, name="1", product_version=et_version)
-
-    with open("tests/data/proddefs-update-variants-moved.json") as prod_defs:
-        requests_mock.get(
-            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
-        )
-
-    update_products()
-
-    variant = ProductVariant.objects.get(name="1")
-    new_stream = ProductStream.objects.get(name="new_stream")
-    # The variant is now associated with the new stream
-    assert variant.productstreams == new_stream
-    assert mock_update_builds.called_with("1", ("new_stream", "stream"), countdown=300)
-
 
 def _create_builds_and_components(stream):
     stream_build = SoftwareBuildFactory()
@@ -212,186 +129,3 @@ def _create_builds_and_components(stream):
     stream_component.productversions.add(stream.productversions)
     stream_component.products.add(stream.products)
     return stream_build, stream_component, stream_child_component
-
-
-@pytest.mark.django_db
-def test_slow_update_builds_for_variant_same_version():
-    stream, _ = setup_product("stream")
-    new_stream = ProductStreamFactory(
-        name="new_stream", products=stream.products, productversions=stream.productversions
-    )
-
-    # Create builds and components for stream
-    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
-
-    # Relate the stream_build to the variant "1" created by setup_product
-    ProductComponentRelation.objects.create(
-        type=ProductComponentRelation.Type.ERRATA,
-        product_ref="1",
-        software_build=stream_build,
-        build_id=stream_build.build_id,
-        build_type=stream_build.build_type,
-    )
-
-    slow_update_builds_for_variant(
-        "1",
-        (
-            new_stream.name,
-            stream.name,
-        ),
-    )
-
-    assert stream_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_component.productstreams.filter(name="stream").exists()
-
-    assert stream_child_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_child_component.productstreams.filter(name="stream").exists()
-
-
-@pytest.mark.django_db
-def test_slow_update_builds_for_variant_same_product():
-    stream, _ = setup_product("stream")
-    new_version = ProductVersionFactory(products=stream.products)
-    new_stream = ProductStreamFactory(
-        name="new_stream", products=stream.products, productversions=new_version
-    )
-    # Create builds and components for stream
-    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
-
-    # Relate the stream_build to the variant "1" created by setup_product
-    ProductComponentRelation.objects.create(
-        type=ProductComponentRelation.Type.ERRATA,
-        product_ref="1",
-        software_build=stream_build,
-        build_id=stream_build.build_id,
-        build_type=stream_build.build_type,
-    )
-
-    slow_update_builds_for_variant(
-        "1",
-        (
-            new_stream.name,
-            stream.name,
-        ),
-        (
-            new_version.name,
-            stream.productversions.name,
-        ),
-    )
-
-    assert stream_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_component.productstreams.filter(name="stream").exists()
-
-    assert stream_child_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_child_component.productstreams.filter(name="stream").exists()
-
-    assert stream_component.productversions.filter(name=new_version.name).exists()
-    assert not stream_component.productversions.filter(name=stream.productversions.name).exists()
-
-
-@pytest.mark.django_db
-def test_slow_update_builds_for_variant_different_product():
-    stream, _ = setup_product("stream")
-    new_product = Product.objects.create(name="new_product")
-    new_version = ProductVersionFactory(products=new_product)
-    new_stream = ProductStreamFactory(name="new_stream", productversions=new_version)
-    # Create builds and components for stream
-    stream_build, stream_component, stream_child_component = _create_builds_and_components(stream)
-
-    # Relate the stream_build to the variant "1" created by setup_product
-    ProductComponentRelation.objects.create(
-        type=ProductComponentRelation.Type.ERRATA,
-        product_ref="1",
-        software_build=stream_build,
-        build_id=stream_build.build_id,
-        build_type=stream_build.build_type,
-    )
-
-    slow_update_builds_for_variant(
-        "1",
-        (
-            new_stream.name,
-            stream.name,
-        ),
-        (
-            new_version.name,
-            stream.productversions.name,
-        ),
-        (
-            new_product.name,
-            stream.products.name,
-        ),
-    )
-
-    assert stream_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_component.productstreams.filter(name="stream").exists()
-
-    assert stream_child_component.productstreams.filter(name="new_stream").exists()
-    assert not stream_child_component.productstreams.filter(name="stream").exists()
-
-    assert stream_component.productversions.filter(name=new_version.name).exists()
-    assert not stream_component.productversions.filter(name=stream.productversions.name).exists()
-
-    assert stream_component.products.filter(name=new_product.name).exists()
-    assert not stream_component.products.filter(name=stream.products.name).exists()
-
-
-@pytest.mark.django_db
-@patch("corgi.tasks.prod_defs.slow_update_builds_for_variant.apply_async")
-def test_product_variant_index_out_of_range(mock_update_builds, requests_mock):
-    # This test was written because when loading the actual product_definitions the product
-    # taxonomy was being truncated by stream which shared a brew_tag. The issue was fixed
-    # by not called variant.save_product_taxonomy in the `for et_variant in et_pv.variants.all()`
-    # loop in `parse_variants_from_brew_tags function`
-    existing_stream, existing_variant = setup_product()
-
-    et_product = CollectorErrataProduct.objects.create(et_id=1, name="et_product_1")
-    # Sets up 2 CollectorErrataProductVersions with matching brew tags
-    # The brew tag matches the 2 new streams in product_definitions
-    et_version_2 = CollectorErrataProductVersion.objects.create(
-        et_id=12, product=et_product, name="et_stream_2", brew_tags=["two_streams_with_same_tag"]
-    )
-    et_version = CollectorErrataProductVersion.objects.create(
-        et_id=11, product=et_product, name="et_stream_1", brew_tags=["two_streams_with_same_tag"]
-    )
-    # Variant 2 is a new Variant, while "1" was created by setup_product
-    CollectorErrataProductVariant.objects.create(et_id=102, name="2", product_version=et_version_2)
-    CollectorErrataProductVariant.objects.create(et_id=101, name="1", product_version=et_version)
-
-    assert existing_stream.name != "stream"
-    assert existing_stream.name != "new_stream"
-    assert existing_stream.products != "product"
-
-    with open("tests/data/proddefs-update-variants-moved.json") as prod_defs:
-        requests_mock.get(
-            f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=(prod_defs.read())
-        )
-
-    update_products()
-
-    assert mock_update_builds.call_args_list == [
-        call(
-            args=(
-                "1",
-                ("stream", existing_stream.name),
-                ("version", existing_stream.productversions.name),
-                ("product", existing_stream.products.name),
-            ),
-            countdown=300,
-        ),
-        # Variant 1 and 2 are then moved from "stream" to the new_stream
-        call(args=("1", ("new_stream", "stream"), None, None), countdown=300),
-        call(args=("2", ("new_stream", "stream"), None, None), countdown=300),
-    ]
-
-    # Assert that "new_stream" was created after "stream"
-    new_stream = ProductStream.objects.get(name="new_stream")
-    stream = ProductStream.objects.get(name="stream")
-    assert new_stream.created_at > stream.created_at
-
-    # Assert both new variants are only associated with the new_stream (created 2nd)
-    variant = ProductVariant.objects.get(name="1")
-    assert variant.productstreams == new_stream
-
-    variant_2 = ProductVariant.objects.get(name="2")
-    assert variant_2.productstreams == new_stream


### PR DESCRIPTION
Seems this code has caused corruption of the ProductNode tree for at least the `7Client-RH7-RHOS-TOOLS-13.0` variant. We're also seeing many variants being moved back and forth between the same streams, and in other cases added and removed to the same stream.