### PR TITLE
CORGI-730: Don't run slow_delete_brew_build automatically to fix DB issues

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -12,7 +12,6 @@ import requests
 import yaml
 from django.conf import settings
 
-from config.celery import app
 from corgi.collectors.models import CollectorRhelModule, CollectorRPM, CollectorSRPM
 from corgi.core.constants import CONTAINER_REPOSITORY
 from corgi.core.models import Component, SoftwareBuild
@@ -954,13 +953,14 @@ class Brew:
         build_id = build["id"]
         # Determine build state
         state = build.get("state")
-        if state == koji.BUILD_STATES["DELETED"]:
-            app.send_task(
-                "corgi.tasks.brew.slow_delete_brew_build",
-                args=(build_id, state),
-            )
-            return {}
-        elif state != koji.BUILD_STATES["COMPLETE"]:
+        # Disabled due to DB performance issues - see notes in task
+        # if state == koji.BUILD_STATES["DELETED"]:
+        #     app.send_task(
+        #         "corgi.tasks.brew.slow_delete_brew_build",
+        #         args=(build_id, state),
+        #     )
+        #     return {}
+        if state != koji.BUILD_STATES["COMPLETE"]:
             raise BrewBuildInvalidState(f"Build {build_id} state is {state}; skipping!")
 
         if build["name"] in self.COMPONENT_EXCLUDES:

--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -49,7 +49,8 @@ class BrewUMBHandler(UMBHandler):
     def __init__(self) -> None:
         addresses: dict[str, Callable[[Event], bool]] = {
             f"{VIRTUAL_TOPIC_PREFIX}.brew.build.complete": BrewUMBHandler.handle_builds,
-            f"{VIRTUAL_TOPIC_PREFIX}.brew.build.deleted": BrewUMBHandler.handle_deleted_builds,
+            # Disabled due to DB performance issues - see notes in task
+            # f"{VIRTUAL_TOPIC_PREFIX}.brew.build.deleted": BrewUMBHandler.handle_deleted_builds,
             f"{VIRTUAL_TOPIC_PREFIX}.brew.build.tag": BrewUMBHandler.handle_tags,
             f"{VIRTUAL_TOPIC_PREFIX}.brew.build.untag": BrewUMBHandler.handle_tags,
             f"{VIRTUAL_TOPIC_PREFIX}.errata.activity.status": BrewUMBHandler.handle_shipped_errata,

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -1048,7 +1048,8 @@ def test_get_component_data_handles_errors():
             # empty dict means no data, should raise BrewBuildNotFound
             {},
             # DELETED builds should trigger the slow_delete_brew_build task
-            {"id": mock_build_id, "state": koji.BUILD_STATES["DELETED"]},
+            # Disabled due to DB performance issues - see notes in task
+            # {"id": mock_build_id, "state": koji.BUILD_STATES["DELETED"]},
             # Other build states should raise BrewBuildInvalidState
             {"id": mock_build_id, "state": koji.BUILD_STATES["FAILED"]},
             # COMPLETED builds with excluded names should be skipped
@@ -1058,12 +1059,13 @@ def test_get_component_data_handles_errors():
     with pytest.raises(BrewBuildNotFound):
         brew.get_component_data(mock_build_id)
 
-    with patch("corgi.collectors.brew.app") as mock_app:
-        brew.get_component_data(mock_build_id)
-        mock_app.send_task.assert_called_once_with(
-            "corgi.tasks.brew.slow_delete_brew_build",
-            args=(mock_build_id, koji.BUILD_STATES["DELETED"]),
-        )
+    # Disabled due to DB performance issues - see notes in task
+    # with patch("corgi.collectors.brew.app") as mock_app:
+    #     brew.get_component_data(mock_build_id)
+    #     mock_app.send_task.assert_called_once_with(
+    #         "corgi.tasks.brew.slow_delete_brew_build",
+    #         args=(mock_build_id, koji.BUILD_STATES["DELETED"]),
+    #     )
 
     with pytest.raises(BrewBuildInvalidState):
         brew.get_component_data(mock_build_id)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -62,7 +62,8 @@ def test_brew_umb_handler_defines_settings():
     handler = BrewUMBHandler()
     assert handler.virtual_topic_addresses == {
         f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.complete": handler.handle_builds,
-        f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.deleted": handler.handle_deleted_builds,
+        # Disabled due to DB performance issues - see notes in task
+        # f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.deleted": handler.handle_deleted_builds,
         f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.tag": handler.handle_tags,
         f"{ADDRESS_PREFIX}VirtualTopic.eng.brew.build.untag": handler.handle_tags,
         f"{ADDRESS_PREFIX}VirtualTopic.eng."
@@ -104,7 +105,7 @@ def test_brew_umb_handler_setup():
         )
         for address in dispatcher.virtual_topic_addresses
     ]
-    assert len(handler.virtual_topic_addresses) == 5
+    assert len(handler.virtual_topic_addresses) == 4
     mock_umb_event.container.create_receiver.assert_has_calls(create_receiver_calls)
 
 
@@ -170,10 +171,11 @@ def test_brew_umb_handler_handles_builds():
     slow_fetch_brew_build_mock.assert_has_calls((call(args=(mock_id,)), call(args=(mock_id,))))
 
 
-def test_brew_umb_handler_deletes_builds():
+def brew_umb_handler_deletes_builds():
     """Test that the BrewUMBHandler class either
     accepts a "build deleted" message, when no exception is raised
     OR rejects the message if any exception is raised"""
+    # Disabled due to DB performance issues - see notes in task
     # Stub out the SSLDomain config class to avoid needing real UMB certs in tests
     with patch("corgi.monitor.consumer.SSLDomain"):
         dispatcher = UMBDispatcher()
@@ -227,7 +229,7 @@ def test_handle_tag_and_untag_messages():
     # Only want addresses from Brew here
     handler = BrewUMBHandler()
     addresses = handler.virtual_topic_addresses
-    _, _, tag_address, untag_address, _ = addresses.keys()
+    _, tag_address, untag_address, _ = addresses.keys()
     assert ADDRESS_PREFIX in tag_address
     assert ADDRESS_PREFIX in untag_address
     assert ".tag" in tag_address


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, going to merge this once the pipeline passes. If that doesn't fix the DB issues we're seeing, I'll look more Monday at where these BackendStoreErrors are coming from.