### PR TITLE
CORGI-745: Add support for HTTPS URLs when cloning sources for SCA task

### DIFF
--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -242,10 +242,10 @@ def _clone_source(source_url: str, build_uuid: str) -> Tuple[Path, str, str]:
     # (scheme, netloc, path, parameters, query, fragment)
     url = urlparse(source_url)
 
-    # We only support git, git+https, git+ssh
-    if not url.scheme.startswith("git"):
+    # We only support git, git+https, git+ssh, etc. and https
+    if not url.scheme.startswith("git") and url.scheme != "https":
         raise ValueError(
-            f"Build {build_uuid} had a source_url with a non-git protocol: {source_url}"
+            f"Build {build_uuid} had a source_url with a non-git, non-HTTPS protocol: {source_url}"
         )
 
     protocol = url.scheme

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -183,12 +183,12 @@ def test_clone_source(mock_subprocess):
 
 
 archive_source_test_data_for_failures = (
-    # Fails due to ValueError - only git:// protocol supported
+    # Fails due to ValueError - only git://, git+https://, etc. or https:// protocol supported
     (
-        "https://src.fedoraproject.org/rpms/nodejs",
+        "http://src.fedoraproject.org/rpms/nodejs",
         "3cbed2be4171502499d0d89bea1ead91690af7d2",
         "nodejs",
-        1,
+        "1",
         "/tmp/1",
         False,
     ),
@@ -197,7 +197,7 @@ archive_source_test_data_for_failures = (
         "git://src.fedoraproject.org/tooshort",
         "3cbed2be4171502499d0d89bea1ead91690af7d2",
         "nodejs",
-        1,
+        "1",
         "/tmp/1",
         False,
     ),
@@ -206,7 +206,17 @@ archive_source_test_data_for_failures = (
         "git+https://src.fedoraproject.org/rpms/nodejs",
         "3cbed2be4171502499d0d89bea1ead91690af7d2",
         "nodejs",
-        1,
+        "1",
+        "/tmp/1",
+        True,
+    ),
+    # Fails due to FileExistsError
+    # AKA https:// URLs get past the "is this scheme supported?" check
+    (
+        "https://src.fedoraproject.org/rpms/nodejs",
+        "3cbed2be4171502499d0d89bea1ead91690af7d2",
+        "nodejs",
+        "1",
         "/tmp/1",
         True,
     ),


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This will fix a failure in our monitoring email that blocks reloading data.