### PR TITLE
CORGI-729: Fix warning about unpatched SSL module

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -404,11 +404,6 @@ UMB_BROKER_URL = os.getenv("CORGI_UMB_BROKER_URL")
 # https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
 UMB_BREW_MONITOR_ENABLED = strtobool(os.getenv("CORGI_UMB_BREW_MONITOR_ENABLED", "true"))
 
-if CORGI_DOMAIN.endswith(".fedoraproject.org"):
-    CORGI_DOMAIN_BASE = ".fedoraproject.org"
-else:
-    CORGI_DOMAIN_BASE = ".prodsec.redhat.com"
-
 # Brew
 BREW_URL = os.getenv("CORGI_BREW_URL")
 BREW_WEB_URL = os.getenv("CORGI_BREW_WEB_URL")

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -9,7 +9,7 @@ ALLOWED_HOSTS = [
     # Allow local host's IP address and hostname for health probes
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
-    CORGI_DOMAIN_BASE,  # noqa: F405
+    CORGI_DOMAIN,  # noqa: F405
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True

--- a/config/settings/stage.py
+++ b/config/settings/stage.py
@@ -9,7 +9,7 @@ ALLOWED_HOSTS = [
     # Allow local host's IP address and hostname for health probes
     socket.gethostname(),
     socket.gethostbyname(socket.gethostname()),
-    CORGI_DOMAIN_BASE,  # noqa: F405
+    CORGI_DOMAIN,  # noqa: F405
 ]
 
 CSP_UPGRADE_INSECURE_REQUESTS = True

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,3 +1,13 @@
+import os
+
+from gevent.monkey import patch_ssl
+
+if os.getenv("RUNNING_GUNICORN"):
+    # Monekypatch the SSL module before preloading the app to avoid warnings / odd behavior
+    # Other modules that can be monkeypatched are not imported by the WSGI application
+    # patching only what's required is safer, since gunicorn hasn't forked workers yet
+    patch_ssl()
+
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       - .env
     environment:
       CORGI_DB_HOST: corgi-db
-    command: ./run_service.sh dev
+    command: ./run_service.sh
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8008/api/healthy || exit 1"]
       interval: "60s"

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -21,3 +21,6 @@ timeout = 300
 if not running_dev():
     # Saves memory in the worker process, but breaks --reload
     preload_app = True
+else:
+    # Support hot-reloading of Gunicorn / Django when files change
+    reload = True

--- a/run_service.sh
+++ b/run_service.sh
@@ -9,9 +9,4 @@
 python3 manage.py collectstatic --noinput
 
 # start gunicorn
-if [[ $1 == dev ]]; then
-    exec gunicorn config.wsgi --config gunicorn_config.py --reload
-else
-    exec gunicorn config.wsgi --config gunicorn_config.py
-fi
-
+exec gunicorn config.wsgi --config gunicorn_config.py

--- a/run_service.sh
+++ b/run_service.sh
@@ -9,4 +9,5 @@
 python3 manage.py collectstatic --noinput
 
 # start gunicorn
-exec gunicorn config.wsgi --config gunicorn_config.py
+# set env var so we monkeypatch ssl module before preloading app
+RUNNING_GUNICORN=true exec gunicorn config.wsgi --config gunicorn_config.py


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This fixes a few minor issues, but probably not the root cause of this bug. The biggest change fixes a Gunicorn warning which may cause "silent failures" and other heisenbugs.

Since we use the gevent worker type in gunicorn, the standard library is automatically monkeypatched to support greenthreads logic during gunicorn's setup. This means that an application-managed greenthread can cooperatively multitask with other greenthreads, whenever code calls time.sleep(), socket.recv(), etc.

The greenthread will automatically be suspended whenever it would block while waiting for I/O, and another greenthread will automatically start running instead. This works well for I/O bound workloads, since it has much lower overhead than spawning a new process, and avoids contention when an OS-managed thread needs to acquire Python's Global Interpreter Lock.

But if you import a module too soon, before gunicorn has finished setting up, you will get the unpatched version of that module. Importing a module "too soon" can also happen when you do "from package.module import func", if package has some \_\_init\_\_.py module that itself imports other code.

Then any calls to time.sleep() or socket.recv() would end up blocking as normal instead of cooperatively multitasking / yielding control to another greenthread. At best your other greenthreads will starve and never execute, but at worst this causes heisenbugs like RecursionError or "silent failures", according to the text in the warning.

But if we monkeypatch too early, before gunicorn has forked its workers, monkeypatching may cause issuses with signaling between the parent process and all the workers it spawns, or the OS, or something. There are only vague mentions of this in some Github issues I read, so I don't have any more details. I think this change should be OK, since the warning is only about / we only patch the SSL module early. Gunicorn probably only needs an unpatched socket module to communicate between the parent and worker processes.

In our case we're calling django.core.wsgi.get_wsgi_application(), which loads our Django app. Currently we preload the app once in the parent process, so that we don't load the Django app each time a new worker process is spawned. This reduces the memory used by each worker, which hopefully reduces how often the Gunicorn worker runs out of memory and dies (bad gateway error described in 729).

To fix this warning about an unpatched SSL module, we need to either monkeypatch before the app is preloaded by the parent process (what this PR does), or load the app once per worker without preloading. Given how magical gevent is, I'm not sure if I should merge this, just give up on preloading, try some other fix like a different worker class (not Gevent or eventlet which both use greenthreads), or just give up completely and CANTFIX this ticket.