### PR TITLE
CORGI-739: Call save_product_taxonomy() in another task to reduce risk of timeouts

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -13,6 +13,7 @@ from corgi.core.models import (
     ProductStream,
     SoftwareBuild,
 )
+from corgi.tasks.brew import slow_save_taxonomy
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 from corgi.tasks.sca import save_component
 
@@ -107,6 +108,4 @@ def cpu_manifest_service(product_stream_id: str, service_components: list):
                 type=ProductComponentRelation.Type.APP_INTERFACE,
             )
 
-            build.save_product_taxonomy()
-            for component_obj in build.components.get_queryset().iterator():
-                component_obj.save_component_taxonomy()
+            slow_save_taxonomy.delay(build.build_id, build.build_type)

--- a/corgi/tasks/management/commands/updatecomponenttaxonomy.py
+++ b/corgi/tasks/management/commands/updatecomponenttaxonomy.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.core.models import SoftwareBuild
+from corgi.tasks.brew import slow_save_taxonomy
 
 
 class Command(BaseCommand):
@@ -36,6 +37,6 @@ class Command(BaseCommand):
                     f"updating {sb.build_id}: {sb.name}",
                 )
             )
-            sb.save_product_taxonomy()
-            for component in sb.components.get_queryset():
-                component.save_component_taxonomy()
+            # Reuse code, but run inline instead of scheduling task
+            # This may take a long time for large / many builds
+            slow_save_taxonomy(sb.build_id, sb.build_type)

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -178,9 +178,10 @@ def cpu_software_composition_analysis(build_uuid, force_process: bool = False):
                 f"Root component {root_component.purl} for build {build_uuid}"
                 "had child components that were not found in remote-sources.json!"
             )
-        software_build.save_product_taxonomy()
-        for component in software_build.components.get_queryset():
-            component.save_component_taxonomy()
+        app.send_task(
+            "corgi.tasks.brew.slow_save_taxonomy",
+            args=(software_build.build_id, software_build.build_type),
+        )
 
     # clean up source code so that we don't have to deal with reuse and an ever growing disk
     for source in distgit_sources:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review another "fix" that won't actually fix anything. This doesn't make the taxonomy-saving code any faster or fix the root cause of this bug, it just tries to avoid it in some circumstances.

If this looks good I'll merge this tomorrow morning, then merge #539 to delete the bad Component-Variant links, then trigger save_product_taxonomy() for only the latest build IDs with ERRATA-type relations. Saving the taxonomy again will add back the missing Variant links, and then the data should be linked correctly for IR.

There are other usages of this taxonomy-saving code, but I will update those in a future PR. The usages I update here should be the only ones we hit when reingesting a build.