### PR TITLE
CORGI-729: Fix Gunicorn worker out-of-memory issues

### DIFF
--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -351,6 +351,20 @@ class SoftwareBuildSummarySerializer(IncludeExcludeFieldsSerializer):
 
 
 class ProductTaxonomySerializer(IncludeExcludeFieldsSerializer):
+    tags = TagSerializer(many=True, read_only=True)
+    link = serializers.SerializerMethodField()
+
+    products = serializers.SerializerMethodField()
+    product_versions = serializers.SerializerMethodField()
+    product_streams = serializers.SerializerMethodField()
+    product_variants = serializers.SerializerMethodField()
+    channels = serializers.SerializerMethodField()
+
+    @staticmethod
+    @abstractmethod
+    def get_link(instance) -> str:
+        pass
+
     def get_products(
         self, instance: Union[ProductModel, ProductTaxonomyMixin]
     ) -> list[dict[str, str]]:
@@ -408,15 +422,6 @@ class ComponentSerializer(ProductTaxonomySerializer):
     Add or remove fields using ?include_fields=&exclude_fields="""
 
     software_build = serializers.SerializerMethodField()
-    tags = TagSerializer(many=True, read_only=True)
-
-    link = serializers.SerializerMethodField()
-
-    products = serializers.SerializerMethodField()
-    product_versions = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
-    channels = serializers.SerializerMethodField()
 
     provides = serializers.SerializerMethodField()
     sources = serializers.SerializerMethodField()
@@ -550,18 +555,10 @@ class ComponentListSerializer(IncludeExcludeFieldsSerializer):
 
 
 class ProductModelSerializer(ProductTaxonomySerializer):
-    tags = TagSerializer(many=True, read_only=True)
     components = serializers.SerializerMethodField()
     upstreams = serializers.SerializerMethodField()
     builds = serializers.SerializerMethodField()
-    link = serializers.SerializerMethodField()
     build_count = serializers.SerializerMethodField()
-    channels = serializers.SerializerMethodField()
-
-    @staticmethod
-    @abstractmethod
-    def get_link(instance) -> str:
-        pass
 
     @staticmethod
     def get_components(instance: ProductModel) -> str:
@@ -613,10 +610,6 @@ class ProductSerializer(ProductModelSerializer):
     """Show detailed information for Product(s).
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    product_versions = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
-
     @staticmethod
     def get_link(instance: Product) -> str:
         return get_model_ofuri_link("products", instance.ofuri)
@@ -635,10 +628,6 @@ class ProductSerializer(ProductModelSerializer):
 class ProductVersionSerializer(ProductModelSerializer):
     """Show detailed information for ProductVersion(s).
     Add or remove fields using ?include_fields=&exclude_fields="""
-
-    products = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
 
     @staticmethod
     def get_link(instance: ProductVersion) -> str:
@@ -662,11 +651,6 @@ class ProductStreamSerializer(ProductModelSerializer):
 
     cpes = serializers.ListField(child=serializers.CharField(max_length=1000), read_only=True)
     manifest = serializers.SerializerMethodField()
-
-    products = serializers.SerializerMethodField()
-    product_versions = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
-
     relations = serializers.SerializerMethodField()
 
     @staticmethod
@@ -723,11 +707,7 @@ class ComponentProductStreamSummarySerializer(ProductModelSerializer):
 
     component_link = serializers.SerializerMethodField()
     manifest = serializers.SerializerMethodField()
-    component_purl = serializers.SerializerMethodField()
-
-    @staticmethod
-    def get_component_purl(obj):
-        return obj.component_purl
+    component_purl = serializers.CharField()
 
     @staticmethod
     def get_link(instance: ProductStream) -> str:
@@ -756,10 +736,6 @@ class ProductVariantSerializer(ProductModelSerializer):
     """Show detailed information for ProductVariant(s).
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    products = serializers.SerializerMethodField()
-    product_versions = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-
     relations = serializers.SerializerMethodField()
 
     @staticmethod
@@ -782,12 +758,6 @@ class ProductVariantSerializer(ProductModelSerializer):
 class ChannelSerializer(ProductTaxonomySerializer):
     """Show detailed information for Channel(s).
     Add or remove fields using ?include_fields=&exclude_fields="""
-
-    link = serializers.SerializerMethodField()
-    products = serializers.SerializerMethodField()
-    product_versions = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
 
     class Meta:
         model = Channel

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -294,9 +294,9 @@ class SoftwareBuildSerializer(IncludeExcludeFieldsSerializer):
 
     tags = TagSerializer(many=True, read_only=True)
 
-    link = serializers.SerializerMethodField()
-    web_url = serializers.SerializerMethodField()
-    components = serializers.SerializerMethodField()
+    link = serializers.SerializerMethodField(read_only=True)
+    web_url = serializers.SerializerMethodField(read_only=True)
+    components = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_link(instance: SoftwareBuild) -> str:
@@ -338,7 +338,7 @@ class SoftwareBuildSummarySerializer(IncludeExcludeFieldsSerializer):
     """Show summary information for a SoftwareBuild.
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    link = serializers.SerializerMethodField()
+    link = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_link(instance: SoftwareBuild) -> str:
@@ -352,13 +352,13 @@ class SoftwareBuildSummarySerializer(IncludeExcludeFieldsSerializer):
 
 class ProductTaxonomySerializer(IncludeExcludeFieldsSerializer):
     tags = TagSerializer(many=True, read_only=True)
-    link = serializers.SerializerMethodField()
+    link = serializers.SerializerMethodField(read_only=True)
 
-    products = serializers.SerializerMethodField()
-    product_versions = serializers.SerializerMethodField()
-    product_streams = serializers.SerializerMethodField()
-    product_variants = serializers.SerializerMethodField()
-    channels = serializers.SerializerMethodField()
+    products = serializers.SerializerMethodField(read_only=True)
+    product_versions = serializers.SerializerMethodField(read_only=True)
+    product_streams = serializers.SerializerMethodField(read_only=True)
+    product_variants = serializers.SerializerMethodField(read_only=True)
+    channels = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     @abstractmethod
@@ -421,13 +421,13 @@ class ComponentSerializer(ProductTaxonomySerializer):
     """Show detailed information for a Component.
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    software_build = serializers.SerializerMethodField()
+    software_build = serializers.SerializerMethodField(read_only=True)
 
-    provides = serializers.SerializerMethodField()
-    sources = serializers.SerializerMethodField()
-    upstreams = serializers.SerializerMethodField()
+    provides = serializers.SerializerMethodField(read_only=True)
+    sources = serializers.SerializerMethodField(read_only=True)
+    upstreams = serializers.SerializerMethodField(read_only=True)
 
-    manifest = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField(read_only=True)
 
     @extend_schema_field(SoftwareBuildSummarySerializer(many=False, read_only=True))
     def get_software_build(self, obj):
@@ -526,8 +526,8 @@ class ComponentSerializer(ProductTaxonomySerializer):
 class ComponentListSerializer(IncludeExcludeFieldsSerializer):
     """List all Components. Add or remove fields using ?include_fields=&exclude_fields="""
 
-    link = serializers.SerializerMethodField()
-    build_completion_dt = serializers.SerializerMethodField()
+    link = serializers.SerializerMethodField(read_only=True)
+    build_completion_dt = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_build_completion_dt(instance: Component) -> Optional[datetime.datetime]:
@@ -555,10 +555,10 @@ class ComponentListSerializer(IncludeExcludeFieldsSerializer):
 
 
 class ProductModelSerializer(ProductTaxonomySerializer):
-    components = serializers.SerializerMethodField()
-    upstreams = serializers.SerializerMethodField()
-    builds = serializers.SerializerMethodField()
-    build_count = serializers.SerializerMethodField()
+    components = serializers.SerializerMethodField(read_only=True)
+    upstreams = serializers.SerializerMethodField(read_only=True)
+    builds = serializers.SerializerMethodField(read_only=True)
+    build_count = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_components(instance: ProductModel) -> str:
@@ -650,8 +650,8 @@ class ProductStreamSerializer(ProductModelSerializer):
     Add or remove fields using ?include_fields=&exclude_fields="""
 
     cpes = serializers.ListField(child=serializers.CharField(max_length=1000), read_only=True)
-    manifest = serializers.SerializerMethodField()
-    relations = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField(read_only=True)
+    relations = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_link(instance: ProductStream) -> str:
@@ -683,7 +683,7 @@ class ProductStreamSummarySerializer(ProductModelSerializer):
     """Show summary information for a ProductStream.
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    manifest = serializers.SerializerMethodField()
+    manifest = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_link(instance: ProductStream) -> str:
@@ -705,9 +705,9 @@ class ProductStreamSummarySerializer(ProductModelSerializer):
 class ComponentProductStreamSummarySerializer(ProductModelSerializer):
     """custom component view displaying product information."""
 
-    component_link = serializers.SerializerMethodField()
-    manifest = serializers.SerializerMethodField()
-    component_purl = serializers.CharField()
+    component_link = serializers.SerializerMethodField(read_only=True)
+    manifest = serializers.SerializerMethodField(read_only=True)
+    component_purl = serializers.CharField(read_only=True)
 
     @staticmethod
     def get_link(instance: ProductStream) -> str:
@@ -736,7 +736,7 @@ class ProductVariantSerializer(ProductModelSerializer):
     """Show detailed information for ProductVariant(s).
     Add or remove fields using ?include_fields=&exclude_fields="""
 
-    relations = serializers.SerializerMethodField()
+    relations = serializers.SerializerMethodField(read_only=True)
 
     @staticmethod
     def get_link(instance: ProductVariant) -> str:

--- a/corgi/api/serializers.py
+++ b/corgi/api/serializers.py
@@ -423,9 +423,11 @@ class ComponentSerializer(ProductTaxonomySerializer):
 
     software_build = serializers.SerializerMethodField(read_only=True)
 
-    provides = serializers.SerializerMethodField(read_only=True)
-    sources = serializers.SerializerMethodField(read_only=True)
-    upstreams = serializers.SerializerMethodField(read_only=True)
+    provides = serializers.HyperlinkedIdentityField(view_name="component-provides", read_only=True)
+    sources = serializers.HyperlinkedIdentityField(view_name="component-sources", read_only=True)
+    upstreams = serializers.HyperlinkedIdentityField(
+        view_name="component-upstreams", read_only=True
+    )
 
     manifest = serializers.SerializerMethodField(read_only=True)
 
@@ -444,37 +446,6 @@ class ComponentSerializer(ProductTaxonomySerializer):
     @staticmethod
     def get_link(instance: Component) -> str:
         return get_component_purl_link(instance.purl)
-
-    # @staticmethod
-    def get_provides(self, instance: Component):
-        include_exclude_serializer = self.get_include_exclude_serializer(
-            "provides", ComponentSerializer, instance.provides
-        )
-        if include_exclude_serializer:
-            return include_exclude_serializer.data
-        return get_component_data_list(
-            instance.provides.values_list("purl", flat=True).using("read_only").iterator()
-        )
-
-    def get_sources(self, instance: Component):
-        include_exclude_serializer = self.get_include_exclude_serializer(
-            "sources", ComponentSerializer, instance.sources
-        )
-        if include_exclude_serializer:
-            return include_exclude_serializer.data
-        return get_component_data_list(
-            instance.sources.values_list("purl", flat=True).using("read_only").iterator()
-        )
-
-    def get_upstreams(self, instance: Component):
-        include_exclude_serializer = self.get_include_exclude_serializer(
-            "upstreams", ComponentSerializer, instance.upstreams
-        )
-        if include_exclude_serializer:
-            return include_exclude_serializer.data
-        return get_component_data_list(
-            instance.upstreams.values_list("purl", flat=True).using("read_only").iterator()
-        )
 
     @staticmethod
     def get_manifest(instance: Component) -> str:

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -377,7 +377,6 @@ class ProductDataViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled u
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend, filters.SearchFilter]
     search_fields = ["name", "description", "meta_attr"]
     filterset_class = ProductDataFilter
-    lookup_url_kwarg = "uuid"
     ordering_field = "name"
 
 
@@ -492,8 +491,8 @@ class ProductStreamViewSetSet(ProductDataViewSet):
             raise Http404
 
     @action(methods=["get"], detail=True)
-    def manifest(self, request: Request, uuid: Union[str, None] = None) -> Response:
-        obj = self.queryset.filter(uuid=uuid).first()
+    def manifest(self, request: Request, pk: str = "") -> Response:
+        obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
         manifest = json.loads(obj.manifest)
@@ -539,7 +538,6 @@ class ChannelViewSet(ReadOnlyModelViewSet):
     serializer_class = ChannelSerializer
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend, filters.SearchFilter]
     filterset_class = ChannelFilter
-    lookup_url_kwarg = "uuid"
 
 
 @INCLUDE_EXCLUDE_FIELDS_SCHEMA
@@ -557,7 +555,6 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
     search_fields = ["name", "description", "release", "version", "meta_attr"]
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend, filters.SearchFilter]
     filterset_class = ComponentFilter
-    lookup_url_kwarg = "uuid"
 
     def get_queryset(self) -> QuerySet[Component]:
         # 'latest' and 'root components' filter automagically turn on
@@ -630,14 +627,14 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
                 component = Component.objects.db_manager("read_only").get(purl=purl)
             else:
                 pk = req.path.split("/")[-1]  # there must be better ways ...
-                component = Component.objects.db_manager("read_only").get(uuid=pk)
+                component = Component.objects.db_manager("read_only").get(pk=pk)
             return component
         except Component.DoesNotExist:
             raise Http404
 
     @action(methods=["get"], detail=True)
-    def manifest(self, request: Request, uuid: str = "") -> Response:
-        obj = self.queryset.filter(uuid=uuid).first()
+    def manifest(self, request: Request, pk: str = "") -> Response:
+        obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
         manifest = json.loads(obj.manifest)
@@ -649,11 +646,11 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         authentication_classes=[TokenAuthentication],
         permission_classes=[IsAuthenticatedOrReadOnly],
     )
-    def update_license(self, request: Request, uuid: Union[str, None] = None) -> Response:
+    def update_license(self, request: Request, pk: str = "") -> Response:
         """Allow OpenLCS to upload copyright text / license scan results for a component"""
         # In the future these could be separate endpoints
         # For testing we'll just keep it under one endpoint
-        component = self.queryset.filter(uuid=uuid).using("default").first()
+        component = self.queryset.filter(pk=pk).using("default").first()
         if not component:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -693,8 +690,8 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         return response
 
     @action(methods=["get"], detail=True)
-    def provides(self, request: Request, uuid: Union[str, None] = None) -> Response:
-        obj = self.queryset.filter(uuid=uuid).first()
+    def provides(self, request: Request, pk: str = "") -> Response:
+        obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
         dicts = get_component_taxonomy(
@@ -704,8 +701,8 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         return Response(dicts)
 
     @action(methods=["get"], detail=True)
-    def taxonomy(self, request: Request, uuid: Union[str, None] = None) -> Response:
-        obj = self.queryset.filter(uuid=uuid).first()
+    def taxonomy(self, request: Request, pk: str = "") -> Response:
+        obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
         dicts = get_component_taxonomy(obj, tuple(ComponentNode.ComponentNodeType.values))

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -691,14 +691,48 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
 
     @action(methods=["get"], detail=True)
     def provides(self, request: Request, pk: str = "") -> Response:
+        """
+        List a Component's provides, using pagination when needed.
+        """
         obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        dicts = get_component_taxonomy(
-            obj,
-            ComponentNode.PROVIDES_NODE_TYPES,
-        )
-        return Response(dicts)
+
+        related_qs = obj.provides.get_queryset().using("read_only")
+        return self._paginate_queryset(related_qs)
+
+    @action(methods=["get"], detail=True)
+    def sources(self, request: Request, pk: str = "") -> Response:
+        """
+        List a Component's sources, using pagination when needed.
+        """
+        obj = self.queryset.filter(pk=pk).first()
+        if not obj:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        related_qs = obj.sources.get_queryset().using("read_only")
+        return self._paginate_queryset(related_qs)
+
+    @action(methods=["get"], detail=True)
+    def upstreams(self, request: Request, pk: str = "") -> Response:
+        """
+        List a Component's upstreams, using pagination when needed.
+        """
+        obj = self.queryset.filter(pk=pk).first()
+        if not obj:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        related_qs = obj.upstreams.get_queryset().using("read_only")
+        return self._paginate_queryset(related_qs)
+
+    def _paginate_queryset(self, queryset: QuerySet) -> Response:
+        """Helper method to apply pagination to arbitrary querysets."""
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
     @action(methods=["get"], detail=True)
     def taxonomy(self, request: Request, pk: str = "") -> Response:

--- a/openapi.yml
+++ b/openapi.yml
@@ -565,7 +565,28 @@ paths:
   /api/v1/components/{uuid}/provides:
     get:
       operationId: v1_components_provides_retrieve
-      description: View for api/v1/components
+      description: List a Component's provides, using pagination when needed.
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this component.
+        required: true
+      tags:
+      - v1
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Component'
+          description: ''
+  /api/v1/components/{uuid}/sources:
+    get:
+      operationId: v1_components_sources_retrieve
+      description: List a Component's sources, using pagination when needed.
       parameters:
       - in: path
         name: uuid
@@ -632,6 +653,27 @@ paths:
               $ref: '#/components/schemas/Component'
       security:
       - tokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Component'
+          description: ''
+  /api/v1/components/{uuid}/upstreams:
+    get:
+      operationId: v1_components_upstreams_retrieve
+      description: List a Component's upstreams, using pagination when needed.
+      parameters:
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this component.
+        required: true
+      tags:
+      - v1
       responses:
         '200':
           content:
@@ -1508,12 +1550,15 @@ components:
           readOnly: true
         sources:
           type: string
+          format: uri
           readOnly: true
         provides:
           type: string
+          format: uri
           readOnly: true
         upstreams:
           type: string
+          format: uri
           readOnly: true
         manifest:
           type: string

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1193,29 +1193,101 @@ def test_oci_component_provides_sources_upstreams(client, api_path):
 
     response = client.get(f"{api_path}/components/{root_comp.uuid}")
     assert response.status_code == 200
-    assert response.json()["name"] == root_comp.name
-    assert response.json()["related_url"] == root_comp.related_url
-    assert len(response.json()["sources"]) == 0
-    assert len(response.json()["provides"]) == 2
-    assert len(response.json()["upstreams"]) == 1
+    response = response.json()
+
+    assert response["name"] == root_comp.name
+    assert response["related_url"] == root_comp.related_url
+    assert response["sources"] == f"http://testserver{api_path}/components/{root_comp.uuid}/sources"
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["provides"] == f"http://testserver{api_path}/components/{root_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 2
+
+    assert (
+        response["upstreams"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
     response = client.get(f"{api_path}/components/{dep_comp.uuid}")
     assert response.status_code == 200
-    assert len(response.json()["sources"]) == 1
-    assert len(response.json()["provides"]) == 1
-    assert len(response.json()["upstreams"]) == 0
+    response = response.json()
+    assert response["sources"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/sources"
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
+    assert (
+        response["provides"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
+    assert (
+        response["upstreams"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
 
     response = client.get(f"{api_path}/components/{dep2_comp.uuid}")
     assert response.status_code == 200
-    assert len(response.json()["sources"]) == 2
-    assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 0
+    response = response.json()
+    assert response["sources"] == f"http://testserver{api_path}/components/{dep2_comp.uuid}/sources"
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 2
+
+    assert (
+        response["provides"] == f"http://testserver{api_path}/components/{dep2_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["upstreams"]
+        == f"http://testserver{api_path}/components/{dep2_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
 
     response = client.get(f"{api_path}/components/{upstream_comp.uuid}")
     assert response.status_code == 200
-    assert len(response.json()["sources"]) == 0
-    assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 0
+    response = response.json()
+    assert (
+        response["sources"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/sources"
+    )
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["provides"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["upstreams"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
 
     # retrieve all sources of root_comp
     response = client.get(f"{api_path}/components?provides={quote(root_comp.purl)}")
@@ -1259,28 +1331,39 @@ def test_oci_component_provides_sources_upstreams(client, api_path):
     )
     assert response.status_code == 200
     assert "upstreams" not in response.json()
-    assert len(response.json()["provides"]) == 2
-    for provide in response.json()["provides"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["provides"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/provides"
+    )
+    related_response = client.get(response.json()["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 2
+
     response = client.get(
         f"{api_path}/components/{root_comp.uuid}?include_fields=upstreams.name,upstreams.purl"
     )
     assert response.status_code == 200
     assert "provides" not in response.json()
-    assert len(response.json()["upstreams"]) == 1
-    for provide in response.json()["upstreams"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["upstreams"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response.json()["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
     response = client.get(
         f"{api_path}/components/{dep_comp.uuid}?include_fields=sources.name,sources.purl"
     )
     assert response.status_code == 200
     assert "provides" not in response.json()
-    assert len(response.json()["sources"]) == 1
-    for provide in response.json()["sources"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["sources"]
+        == f"http://testserver{api_path}/components/{dep_comp.uuid}/sources"
+    )
+    related_response = client.get(response.json()["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -1375,23 +1458,78 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
 
     response = client.get(f"{api_path}/components/{root_comp.uuid}")
     assert response.status_code == 200
-    assert response.json()["name"] == root_comp.name
-    assert response.json()["related_url"] == root_comp.related_url
-    assert len(response.json()["sources"]) == 0
-    assert len(response.json()["provides"]) == 1
-    assert len(response.json()["upstreams"]) == 1
+    response = response.json()
+
+    assert response["name"] == root_comp.name
+    assert response["related_url"] == root_comp.related_url
+    assert response["sources"] == f"http://testserver{api_path}/components/{root_comp.uuid}/sources"
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["provides"] == f"http://testserver{api_path}/components/{root_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
+    assert (
+        response["upstreams"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
     response = client.get(f"{api_path}/components/{dep_comp.uuid}")
     assert response.status_code == 200
-    assert len(response.json()["sources"]) == 1
-    assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 1
+    response = response.json()
+    assert response["sources"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/sources"
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
+    assert (
+        response["provides"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["upstreams"] == f"http://testserver{api_path}/components/{dep_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
     response = client.get(f"{api_path}/components/{upstream_comp.uuid}")
     assert response.status_code == 200
-    assert len(response.json()["sources"]) == 0
-    assert len(response.json()["provides"]) == 0
-    assert len(response.json()["upstreams"]) == 1
+    response = response.json()
+    assert (
+        response["sources"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/sources"
+    )
+    related_response = client.get(response["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["provides"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/provides"
+    )
+    related_response = client.get(response["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 0
+
+    assert (
+        response["upstreams"]
+        == f"http://testserver{api_path}/components/{upstream_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
     # retrieve all sources of root_comp
     response = client.get(f"{api_path}/components?provides={quote(root_comp.purl)}")
@@ -1426,28 +1564,39 @@ def test_srpm_component_provides_sources_upstreams(client, api_path):
     )
     assert response.status_code == 200
     assert "upstreams" not in response.json()
-    assert len(response.json()["provides"]) == 1
-    for provide in response.json()["provides"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["provides"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/provides"
+    )
+    related_response = client.get(response.json()["provides"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
     response = client.get(
         f"{api_path}/components/{root_comp.uuid}?include_fields=upstreams.name,upstreams.purl"
     )
     assert response.status_code == 200
     assert "provides" not in response.json()
-    assert len(response.json()["upstreams"]) == 1
-    for provide in response.json()["upstreams"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["upstreams"]
+        == f"http://testserver{api_path}/components/{root_comp.uuid}/upstreams"
+    )
+    related_response = client.get(response.json()["upstreams"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
+
     response = client.get(
         f"{api_path}/components/{dep_comp.uuid}?include_fields=sources.name,sources.purl"
     )
     assert response.status_code == 200
     assert "provides" not in response.json()
-    assert len(response.json()["sources"]) == 1
-    for provide in response.json()["sources"]:
-        assert "name" in provide
-        assert "purl" in provide
+    assert (
+        response.json()["sources"]
+        == f"http://testserver{api_path}/components/{dep_comp.uuid}/sources"
+    )
+    related_response = client.get(response.json()["sources"])
+    assert related_response.status_code == 200
+    assert related_response.json()["count"] == 1
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)


### PR DESCRIPTION
This will move the sources, provides, and upstreams data to separate (paginated) endpoints. These fields will now show a link to this endpoint for the current component, instead of displaying all the component's sources / provides / upstreams data inline.

This is needed to avoid OoM issues in Gunicorn which trigger "bad gateway" errors in Nginx. These errors happen somewhat randomly for different queries, whenever the amount of data returned / the number of sources, provides, and upstreams on one page is very large. The error is consistent for a particular query as long as the list of components doesn't change. 

This does require a breaking API change, but is the smallest change I could make that actually solves the issue. We can't paginate these fields currently because the top-level request is already paginated. Using ?exclude_fields=sources doesn't work for all usecases, since e.g. Griffon sometimes needs to see this data.

@JimFuller-RedHat is on PTO I think, but let's discuss this change when you're back to make sure it won't cause more issues for Griffon.

I also need to add separate tests for the new endpoints, but I have lots of other stuff to do and there's no point working on tests before we figure out if this is OK for Griffon. Leaving as a draft for now.