### PR TITLE
CORGI-693: Set namespace correctly for Maven components, and fix old data

### DIFF
--- a/corgi/core/constants.py
+++ b/corgi/core/constants.py
@@ -13,6 +13,12 @@ CONTAINER_REPOSITORY = "registry.redhat.io"
 CORGI_PRODUCT_TAXONOMY_VERSION = "v1"
 CORGI_COMPONENT_TAXONOMY_VERSION = "v1"
 
+# Assume Red Hat Maven components are always located in the GA repo
+# There's also an Early Access repo: https://maven.repository.redhat.com/earlyaccess/all
+# But anything in there should become GA eventually
+# and we don't want the purls to change over time / we don't know when GA will happen
+RED_HAT_MAVEN_REPOSITORY = "https://maven.repository.redhat.com/ga"
+
 # Map MPTT node levels in our product taxonomy to model names as defined in models.py
 NODE_LEVEL_MODEL_MAPPING = {
     0: "product",

--- a/corgi/core/migrations/0081_fix_maven_namespaces.py
+++ b/corgi/core/migrations/0081_fix_maven_namespaces.py
@@ -1,0 +1,62 @@
+from django.db import migrations
+from packageurl import PackageURL
+
+from corgi.core.constants import RED_HAT_MAVEN_REPOSITORY
+
+
+def fix_maven_namespaces(apps, schema_editor):
+    """Set namespace to REDHAT for Maven components with "redhat" in their version strings"""
+    Component = apps.get_model("core", "Component")
+    ComponentNode = apps.get_model("core", "ComponentNode")
+
+    # Values in current data are always -redhat or .redhat
+    maven_components = Component.objects.filter(
+        type="MAVEN", namespace="UPSTREAM", version__contains="redhat"
+    )
+
+    # Fix all Components and ComponentNodes (custom code in .save() does not work here)
+    for component in maven_components.iterator():
+        component.namespace = "REDHAT"
+        old_purl = component.purl
+        component.purl = fix_maven_purl(component)
+        component.save()
+
+        ComponentNode.objects.filter(purl=old_purl).update(purl=component.purl)
+
+
+def fix_maven_purl(component):
+    """Helper method copied from corgi.core.models.Component._build_maven_purl()
+    because custom code isn't accessible when running migrations"""
+    # We only call this function for Maven components in the REDHAT namespace
+    # So the repository_url should always be set to the Red Hat Maven server
+    qualifiers = {"repository_url": RED_HAT_MAVEN_REPOSITORY}
+
+    classifier = component.meta_attr.get("classifier")
+    if classifier:
+        qualifiers["classifier"] = classifier
+
+    extension = component.meta_attr.get("type")
+    if extension:
+        qualifiers["type"] = extension
+
+    purl_data = {
+        "type": str(component.type).lower(),
+        "name": component.name,
+        "version": component.version,
+        "qualifiers": qualifiers,
+    }
+    group_id = component.meta_attr.get("group_id")
+    if group_id:
+        purl_data["namespace"] = group_id
+
+    purl_obj = PackageURL(**purl_data)
+    return purl_obj.to_string()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0080_adjust_product_cpe_fields"),
+    ]
+
+    operations = [migrations.RunPython(fix_maven_namespaces)]

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -254,6 +254,8 @@ def save_component(
         related_url = ""
 
     license_declared_raw = meta.pop("license", "")
+    version = meta.pop("version", "")
+    namespace = Brew.check_red_hat_namespace(component_type, version)
     # We can't build a purl before the component is saved,
     # so we can't handle an IntegrityError (duplicate purl) here like we do in the SCA task
     # But that's OK - this task shouldn't ever raise an IntegrityError
@@ -262,14 +264,12 @@ def save_component(
     obj, _ = Component.objects.update_or_create(
         type=component_type,
         name=meta.pop("name", ""),
-        version=meta.pop("version", ""),
+        version=version,
         release=meta.pop("release", ""),
         arch=meta.pop("arch", "noarch"),
         defaults={
             "description": meta.pop("description", ""),
-            "namespace": Component.Namespace.REDHAT
-            if component_type == Component.Type.RPM
-            else Component.Namespace.UPSTREAM,
+            "namespace": namespace,
             "related_url": related_url,
             "epoch": int(meta.pop("epoch", 0)),
         },

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -42,8 +42,7 @@ def slow_save_errata_product_taxonomy(erratum_id: int) -> None:
     for build_id, build_type, _ in relation_builds:
         logger.info("Saving product taxonomy for build (%s, %s)", build_id, build_type)
         # once all build's components are ingested we must save product taxonomy
-        sb = SoftwareBuild.objects.get(build_id=build_id, build_type=build_type)
-        sb.save_product_taxonomy()
+        app.send_task("corgi.tasks.brew.slow_save_taxonomy", args=(build_id, build_type))
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -260,12 +260,16 @@ def _clone_source(source_url: str, build_uuid: str) -> Tuple[Path, str, str]:
         raise ValueError(
             f"Build {build_uuid} had a source_url with a non-git, non-HTTPS protocol: {source_url}"
         )
+    path = url.path
+    if "kernel-rt.git" in path:
+        # Source URLs from Brew are incorrect, give 404
+        path = path.replace("kernel-rt.git", "kernel-rt")
 
     protocol = url.scheme
     if protocol.startswith("git+"):
         protocol = protocol.removeprefix("git+")
-    git_remote = f"{protocol}://{url.netloc}{url.path}"
-    path_parts = url.path.rsplit("/", 2)
+    git_remote = f"{protocol}://{url.netloc}{path}"
+    path_parts = path.rsplit("/", 2)
     if len(path_parts) != 3:
         raise ValueError(f"Build {build_uuid} had a source_url with a too-short path: {source_url}")
     package_type = path_parts[1]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,9 +33,9 @@ celery-singleton==0.3.1 \
     --hash=sha256:260ce4978e631f8682ea0ccb03d7f3b87d42bc20e04e9bd46ddb78a2f8035d1e \
     --hash=sha256:76b30a1bbe31d42030924b3eecfcaae2ab3ab99bf43e607cd46437f012434420
     # via -r requirements/base.in
-certifi==2022.12.7 \
-    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
-    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via requests
 cffi==1.15.1 \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -86,9 +86,9 @@ celery-singleton==0.3.1 \
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-certifi==2022.12.7 \
-    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
-    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via
     #   -r requirements/base.txt
     #   -r requirements/lint.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -29,9 +29,9 @@ black==22.1.0 \
     --hash=sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61 \
     --hash=sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3
     # via -r requirements/lint.in
-certifi==2022.12.7 \
-    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
-    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via requests
 charset-normalizer==2.0.9 \
     --hash=sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721 \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -42,9 +42,9 @@ celery-singleton==0.3.1 \
     --hash=sha256:260ce4978e631f8682ea0ccb03d7f3b87d42bc20e04e9bd46ddb78a2f8035d1e \
     --hash=sha256:76b30a1bbe31d42030924b3eecfcaae2ab3ab99bf43e607cd46437f012434420
     # via -r requirements/base.txt
-certifi==2022.12.7 \
-    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
-    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
     # via
     #   -r requirements/base.txt
     #   requests

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -610,14 +610,14 @@ def test_purl2url():
     # maven with group_id
     component = ComponentFactory(
         type=Component.Type.MAVEN,
-        namespace=Component.Namespace.REDHAT,
+        namespace=Component.Namespace.UPSTREAM,
         meta_attr={"group_id": "io.prestosql.benchto"},
         name="benchto-driver",
         version="0.7",
         release=release,
     )
     assert (
-        component.download_url == "https://repo1.maven.org/maven2/io/prestosql/benchto/"
+        component.download_url == "https://repo.maven.apache.org/maven2/io/prestosql/benchto/"
         "benchto-driver/0.7"
     )
     assert (

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -171,7 +171,7 @@ archive_source_test_data = (
     "/containers/openshift-enterprise-console",
     "f95972ce68d2850ae20c10fbf87182a17fa24b19",
     "openshift-enterprise-console",
-    2,
+    "2",
     "/tmp/2",
 )
 
@@ -185,7 +185,14 @@ def test_clone_source(mock_subprocess):
     _clone_source(f"{source_url}#{commit}", build_id)
     mock_subprocess.assert_has_calls(
         (
-            call(["/usr/bin/git", "clone", source_url, PosixPath(expected_path)]),
+            call(
+                [
+                    "/usr/bin/git",
+                    "clone",
+                    source_url.replace("git://", "https://", 1),
+                    PosixPath(expected_path),
+                ]
+            ),
             call(["/usr/bin/git", "checkout", commit], cwd=PosixPath(expected_path), stderr=-3),
         )
     )

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -11,6 +11,7 @@ from packageurl import PackageURL
 
 from corgi.collectors.go_list import GoList
 from corgi.collectors.syft import Syft
+from corgi.core.constants import RED_HAT_MAVEN_REPOSITORY
 from corgi.core.models import Component, ComponentNode
 from corgi.tasks.sca import (
     _clone_source,
@@ -369,7 +370,7 @@ slow_software_composition_analysis_test_data = [
         "md5/587372e4c72d1eddfab8e848457f574e/"
         "hawkular-metrics-schema-installer-0.31.0.Final-redhat-1.jar",
         "tests/data/hawkular-metrics-schema-installer-syft.json",
-        "pkg:maven/com.github.jnr/jffi@1.2.10.redhat-1",
+        f"pkg:maven/com.github.jnr/jffi@1.2.10.redhat-1?repository_url={RED_HAT_MAVEN_REPOSITORY}",
     ),
 ]
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. If this looks right I'll add a test tomorrow before I merge, but I wanted to double-check first:

1. Is it true that all Maven components built by PNC / middleware teams will always have ".redhat" or "-redhat" in their version string? Are there any components we build which don't have these indicators? Or components which have it in e.g. the release instead of the version?

2. Are there any other magic values which indicate a component is built at Red Hat? Right now we assume all RPMs are built at Red Hat, and this PR adds the check for Maven component versions. Everything else is assumed to be upstream.

3. Should we set namespace to REDHAT for e.g. Github components under the RedHat, RedHatProductSecurity, etc. orgs?

4. What about Golang components with "redhat/" or "redhat.com" somewhere in their name / URL?

I guess @kgrant-rh is our middleware expert. Please let me know if I've missed something, or if you think I should double-check with those teams directly.

EDIT: I also added some fixes for errors in this morning's monitoring email. I think we don't need a new test, since we already test SCA creates Maven components with the correct purl. I added "redhat/" to that value and the test began passing again.