### PR TITLE
CORGI-554: Improve component type detection 

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -178,6 +178,19 @@ class Brew:
             return Component.Type.MAVEN, component.replace(":", "/"), version
         return None
 
+    @staticmethod
+    def _check_npm_component(
+        component: str, version: str
+    ) -> Optional[tuple[Component.Type, str, str]]:
+        # NPM bundled packages appear to follow the pattern of
+        # "rh-nodejsXX-component", where component is something
+        # other than "nodejs"
+        if "nodejs" in component:
+            component_match = re.match(r"^rh-nodejs\d+(?!-nodejs)-(.*)", component)
+            if component_match:
+                return Component.Type.NPM, component_match.group(1), version
+        return None
+
     @classmethod
     def _get_bundled_component_type(
         cls, component_type: str, component: str
@@ -206,6 +219,10 @@ class Brew:
             if not component:
                 continue
             bundled_component = cls._check_maven_component(component, version)
+            if bundled_component:
+                bundled_components.append(bundled_component)
+                continue
+            bundled_component = cls._check_npm_component(component, version)
             if bundled_component:
                 bundled_components.append(bundled_component)
                 continue

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -180,14 +180,22 @@ class Brew:
             return Component.Type.MAVEN, component, version
         elif component.startswith("apache-commons"):
             return Component.Type.MAVEN, component, version
+        elif component.startswith("java-"):
+            return Component.Type.MAVEN, component, version
         return None
 
     @staticmethod
     def _check_npm_component(
         component: str, version: str
     ) -> Optional[tuple[Component.Type, str, str]]:
-        if "nodejs" in component:
-            component_match = re.match(r"^nodejs\d*-(.*)", component)
+        if component.startswith("js-"):
+            return Component.Type.NPM, component[len("js-") :], version
+        elif component.startswith("npm-"):
+            return Component.Type.NPM, component[len("npm-") :], version
+        elif component.startswith("nodejs-"):
+            return Component.Type.NPM, component[len("nodejs-") :], version
+        else:
+            component_match = re.match(r"^nodejs\d+-(.*)", component)
             if component_match:
                 return Component.Type.NPM, component, version
         return None

--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -176,19 +176,20 @@ class Brew:
     ) -> Optional[tuple[Component.Type, str, str]]:
         if ":" in component:
             return Component.Type.MAVEN, component.replace(":", "/"), version
+        elif component.startswith("maven"):
+            return Component.Type.MAVEN, component, version
+        elif component.startswith("apache-commons"):
+            return Component.Type.MAVEN, component, version
         return None
 
     @staticmethod
     def _check_npm_component(
         component: str, version: str
     ) -> Optional[tuple[Component.Type, str, str]]:
-        # NPM bundled packages appear to follow the pattern of
-        # "rh-nodejsXX-component", where component is something
-        # other than "nodejs"
         if "nodejs" in component:
-            component_match = re.match(r"^rh-nodejs\d+(?!-nodejs)-(.*)", component)
+            component_match = re.match(r"^nodejs\d*-(.*)", component)
             if component_match:
-                return Component.Type.NPM, component_match.group(1), version
+                return Component.Type.NPM, component, version
         return None
 
     @classmethod
@@ -218,6 +219,8 @@ class Brew:
             component = cls._bundled_or_golang(component)
             if not component:
                 continue
+            if component.startswith("rh-"):
+                component = component[3:]
             bundled_component = cls._check_maven_component(component, version)
             if bundled_component:
                 bundled_components.append(bundled_component)

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -851,13 +851,25 @@ def test_parsing_bundled_provides():
         "bundled(cocoa(hello-world))",
         # Unknown package type; TODO: find example
         "bundled(libsomething)",
-        # Below entries do not match bundled deps and are not present in expected values
+        # Should now be detected as an NPM package, see CORGI-554
         "rh-nodejs12-npm",
+        # Below entries do not match bundled deps and are not present in expected values
         "",
         # brew rpmID=8178747
         "bundled(org.yaml:snakeyaml)",
         "bundled(commons-codec:commons-codec)",
         "bundled(biz.source_code:base64coder)",
+        # brew rpmID=12267521
+        "bundled(rh-nodejs14-nghttp2)",
+        "bundled(rh-nodejs14-uvwasi)",
+        "bundled(rh-nodejs14-v8)",
+        # brew rpmID=10080036
+        "bundled(apache-commons-lang3)",
+        "bundled(apache-commons-logging)",
+        "bundled(apache-commons-parent)",
+        "bundled(maven-enforcer)",
+        "bundled(maven-file-management)",
+        "bundled(maven-filtering)",
     ]
     # Add mock version; we're testing component name parsing here only
     test_provides = [(str(provide), "0") for provide in test_provides]
@@ -873,18 +885,27 @@ def test_parsing_bundled_provides():
         (Component.Type.PYPI, "django-stubs"),
         (Component.Type.PYPI, "selectors2"),
         (Component.Type.NPM, "@babel/code-frame"),
-        (Component.Type.NPM, "yargs-parser"),
+        (Component.Type.NPM, "nodejs-yargs-parser"),
         (Component.Type.GEM, "fileutils"),
         (Component.Type.GEM, "example"),
         (Component.Type.GEM, "another-example"),
         (Component.Type.CARGO, "aho-corasick/default"),
-        (Component.Type.GENERIC, "rh-nodejs12-zlib"),
+        (Component.Type.NPM, "nodejs12-zlib"),
         (Component.Type.NPM, "backbone"),
         (Component.Type.GENERIC, "hello-world"),
         (Component.Type.GENERIC, "libsomething"),
         (Component.Type.MAVEN, "org.yaml/snakeyaml"),
         (Component.Type.MAVEN, "commons-codec/commons-codec"),
         (Component.Type.MAVEN, "biz.source_code/base64coder"),
+        (Component.Type.NPM, "nodejs14-nghttp2"),
+        (Component.Type.NPM, "nodejs14-uvwasi"),
+        (Component.Type.NPM, "nodejs14-v8"),
+        (Component.Type.MAVEN, "apache-commons-lang3"),
+        (Component.Type.MAVEN, "apache-commons-logging"),
+        (Component.Type.MAVEN, "apache-commons-parent"),
+        (Component.Type.MAVEN, "maven-enforcer"),
+        (Component.Type.MAVEN, "maven-file-management"),
+        (Component.Type.MAVEN, "maven-filtering"),
     ]
     expected_values = [parsed + ("0",) for parsed in expected_values]
     assert Brew._extract_bundled_provides(test_provides) == expected_values

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -885,7 +885,7 @@ def test_parsing_bundled_provides():
         (Component.Type.PYPI, "django-stubs"),
         (Component.Type.PYPI, "selectors2"),
         (Component.Type.NPM, "@babel/code-frame"),
-        (Component.Type.NPM, "nodejs-yargs-parser"),
+        (Component.Type.NPM, "yargs-parser"),
         (Component.Type.GEM, "fileutils"),
         (Component.Type.GEM, "example"),
         (Component.Type.GEM, "another-example"),


### PR DESCRIPTION
Some components are labeled generic when their type can probably be better inferred.