### PR TITLE
CORGI-772: Fix a very silly typo that added an extra "/git/" to some source URLs

### DIFF
--- a/corgi/collectors/brew.py
+++ b/corgi/collectors/brew.py
@@ -145,7 +145,7 @@ class Brew:
         dist_git_url = f"https://{dist_git_hostname}/git/"
 
         for git_url in gitlike_urls:
-            git_url_with_path = f"{git_url}/git/"
+            git_url_with_path = f"{git_url}git/"
 
             # If "/git/" is already present, just fix the scheme
             if source_url.startswith(git_url_with_path):

--- a/corgi/core/migrations/0081_fix_build_sources.py
+++ b/corgi/core/migrations/0081_fix_build_sources.py
@@ -29,7 +29,7 @@ def fix_build_source_urls(apps, schema_editor):
     for git_url in gitlike_urls:
         # Always use https:// instead of git:// or similar
         builds_to_update = SoftwareBuild.objects.filter(source__startswith=git_url)
-        git_url_with_path = f"{git_url}/git/"
+        git_url_with_path = f"{git_url}git/"
 
         # If "/git/" is already present, just fix the scheme
         builds_with_git = builds_to_update.filter(source__startswith=git_url_with_path)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. My last PR had an f-string that joined a prefix like "https://hostname/" with a trailing slash, to a path like "/git/" with a leading slash.

We ended up with a final value like "https://hostname//git/" that has two // slashes, which obviously didn't match anything in the database. This caused the code to fall through to an else case. We changed "https://hostname/" with a trailing slash but no "git/" in the path to "https://hostname/git/", in order to add the "git/" value to the path since it was "missing".

Now 1393 builds in stage have source URLs with a doubled-up "/git/git/". I don't know any legitimate reason why a source URL would have this value, so I'm assuming all of these are a side-effect of the last migration and can be switched back to just one "/git/" value.