### PR TITLE
CORGI-780: Include microseconds in App-Interface build IDs to avoid collisions

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -73,7 +73,7 @@ def cpu_manifest_service(product_stream_id: str, service_components: list) -> No
                 ProductComponentRelation.objects.filter(software_build=build).delete()
                 build.delete()
 
-            build_id = now.strftime("%Y%m%d%H%M%S")
+            build_id = now.strftime("%Y%m%d%H%M%S%f")
             build = SoftwareBuild.objects.create(
                 name=service_component["name"],
                 build_type=SoftwareBuild.Type.APP_INTERFACE,


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, here's a quick fix for errors seen in this morning's monitoring email.

I'm going to just merge this since it should fix this one error, and mangen stuff is still broken anyway due to missing permissions on many Quay images / Github repos. If for some reason this causes more problems, I'll fix things on Monday.