### PR TITLE
CORGI-780: Move now() inside loop so each build timestamp / ID is unique

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -36,8 +36,8 @@ def refresh_service_manifests() -> None:
 def cpu_manifest_service(product_stream_id: str, service_components: list) -> None:
     service = ProductStream.objects.get(pk=product_stream_id)
 
-    now = timezone.now()
     for service_component in service_components:
+        now = timezone.now()
         analyzed_components = []
         component_version = ""
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, another fix. This should be the last one needed for this one issue, and I feel silly I missed this the first time.