### PR TITLE
CORGI-772: Don't skip kernel during SCA scan after we fixed .git in source URLs

### DIFF
--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -178,10 +178,6 @@ def cpu_software_composition_analysis(build_uuid, force_process: bool = False):
         )
         return
 
-    if root_component.name == "kernel":
-        logger.info("skipping scan of the kernel, see CORGI-270")
-        return
-
     root_node = root_component.cnodes.first()
     if not root_node:
         raise ValueError(f"Didn't find root component node for {root_component.purl}")


### PR DESCRIPTION
@jasinner We saw some kind of issue when cloning kernel repos from dist-git, so we disabled SCA scanning of kernel components. But we've fixed WorkerLostErrors due to not enough resources, so really big repos shouldn't be a problem anymore.

We also fixed an error with "kernel-rt" SCA scanning, where cloning the repo failed due to an extra ".git" in the name / path. So I think it should be safe to run the SCA task on kernel components again.