### PR TITLE
CORGI-757: Add GitHub repo authentication

### DIFF
--- a/corgi/collectors/app_interface.py
+++ b/corgi/collectors/app_interface.py
@@ -59,11 +59,10 @@ class AppInterface:
                     # Ignore container images in other registries since we assume all images are
                     # in Quay.io.
                     if org_repos["org"]["instance"]["url"] != "quay.io":
-                        logger.warning(
+                        raise ValueError(
                             f"Found non-quay.io container images for {component_name} in "
                             f"app-interface: {org_repos['org']['instance']}"
                         )
-                        continue
                     for repo in org_repos["items"]:
                         repo_name = f"{org_repos['org']['name']}/{repo['name']}"
                         subcomponent_data[repo["name"]]["quay_repo_name"] = repo_name

--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -92,6 +92,15 @@ class Syft:
         An optional target ref can be specified that represents a valid committish in the Git
         repo being scanned.
         """
+        # Convert unauthenticated / web-based URLs to SSH-based URLs
+        # so that "git clone" uses our existing SSH key and doesn't prompt
+        # for a username/password combo if the repo is private
+        if target_url.startswith("https://github.com/"):
+            target_url = target_url.replace("https://github.com/", "git@github.com:", 1)
+        elif target_url.startswith("http://github.com/"):
+            target_url = target_url.replace("http://github.com/", "git@github.com:", 1)
+        # Else it could be an internal Gitlab server - we allow these to fail
+        # They should be made into public repos that work without authentication
         with TemporaryDirectory(dir=settings.SCA_SCRATCH_DIR) as scan_dir:
             logger.info("Cloning %s to %s", target_url, scan_dir)
             # This may fail if we don't have access to the repository. GIT_TERMINAL_PROMPT=0


### PR DESCRIPTION
@mprpic Please review. I've tested both URL formats with the "git clone" command in a stage pod, and this fixup seems to work / force our SSH key to be used for authentication.

This should be the last code change needed from us / in our code. Once this is merged, I'll work with the various repo owners / org admins to make sure we have access to any repo used by a managed service.

That's also waiting on SecArchs to update the list of components for each service. Rght now we're trying to clone some older repos that are no longer used, according to the service teams.

Tests are going to fail due to known / ongoing data issues in stage. Please ignore that for now.