### PR TITLE
CORGI-798: Fix more soft time limit errors

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -778,8 +778,8 @@ def load_brew_tags(software_build: SoftwareBuild, brew_tags: list[str]) -> int:
     for stream_name, stream_tags in all_stream_tags:
         distinct_stream_tags = set(stream_tags)
         distinct_stream_tags = distinct_brew_tags.intersection(distinct_stream_tags)
+        brew, build_type, _ = _relation_context_for_stream(stream_name)
         for tag in distinct_stream_tags:
-            brew, build_type, _ = _relation_context_for_stream(stream_name)
             logger.info(f"Creating relations for {stream_name} and {tag}")
             # We do this inline instead of via create_relations function because
             # it's the only time we call it where we have a software_build object created
@@ -798,7 +798,7 @@ def load_brew_tags(software_build: SoftwareBuild, brew_tags: list[str]) -> int:
     return no_created
 
 
-def _relation_context_for_stream(stream_name: str):
+def _relation_context_for_stream(stream_name: str) -> tuple[Brew, SoftwareBuild.Type, app.task]:
     build_type = BUILD_TYPE
     brew = Brew(BUILD_TYPE)
     refresh_task = slow_fetch_modular_build

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -3,7 +3,6 @@ import subprocess
 from datetime import datetime, timedelta
 from typing import Optional
 
-from celery.local import PromiseProxy
 from django.conf import settings
 from django.db.utils import InterfaceError as DjangoInterfaceError
 from django.utils import timezone
@@ -12,6 +11,7 @@ from psycopg2.errors import InterfaceError as Psycopg2InterfaceError
 from redis.exceptions import ConnectionError as RedisConnectionError
 from requests.exceptions import RequestException
 
+from config.celery import app
 from corgi.core.models import ProductComponentRelation, SoftwareBuild
 
 BACKOFF_KWARGS = {"max_tries": 5, "jitter": None}
@@ -76,7 +76,7 @@ def create_relations(
     external_system_id: str,
     product_ref: str,
     relation_type: ProductComponentRelation.Type,
-    refresh_task: Optional[PromiseProxy],
+    refresh_task: Optional[app.task],
 ) -> int:
     no_of_relations = 0
     for build_id in build_ids:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. The tasks are still timing out in some cases, so I've split it further to save the index container / root node and all the arch-specific child containers / nodes together in the first / main task.

Then we save all the upstream go modules, upstream container sources, and upstream nodes together in the second task.

Finally (in the new code), we spawn a third task for each upstream source to save its provides / Cachito components. This means we might spawn many tasks just to load one container build, but it should avoid the risk of timeouts (fingers crossed).