### PR TITLE
Revert "CORGI-780: Fix Component.DoesNotExist when running Syft on managed services"

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -143,13 +143,6 @@ def cpu_manifest_service(product_stream_id: str, service_components: list) -> No
             )
 
             for component in analyzed_components:
-                if "-" in component["meta"]["version"]:
-                    # Syft uses version-release as the version
-                    # And then get_or_create fails (different NEVRA, same purl)
-                    # release needs to be in its own field to match other components
-                    version, release = component["meta"]["version"].split("-", 1)
-                    component["meta"]["version"] = version
-                    component["meta"]["release"] = release
                 save_component(component, root_node)
 
             ProductComponentRelation.objects.create(

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -82,7 +82,8 @@ def save_component(
 ) -> bool:
     meta = component.get("meta", {})
     if component["type"] not in Component.Type.values:
-        raise ValueError("Tried to save component with unknown type: %s", component["type"])
+        logger.warning("Tried to save component with unknown type: %s", component["type"])
+        return False
 
     syft_purl = meta.get("purl")
     if not syft_purl:
@@ -93,8 +94,6 @@ def save_component(
     created = False
     name = meta.pop("name", "")
     version = meta.pop("version", "")
-    release = meta.pop("release", "")
-    arch = meta.pop("arch", "noarch")
 
     namespace = Brew.check_red_hat_namespace(component["type"], version)
     if namespace == Component.Namespace.REDHAT:
@@ -117,8 +116,8 @@ def save_component(
             type=component["type"],
             name=name,
             version=version,
-            release=release,
-            arch=arch,
+            release="",
+            arch="noarch",
             defaults={
                 "meta_attr": meta,
                 "namespace": namespace,


### PR DESCRIPTION
Reverts RedHatProductSecurity/component-registry#584 because it didn't always fix the issue and may have even created a new one.