### PR TITLE
Revert "CORGI-798: Fix more soft time limit errors"

### DIFF
--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -618,7 +618,7 @@ def slow_save_container_children(
     logger.info(f"Saving upstreams for {build_type} container build {build_id}")
     root_node = ComponentNode.objects.get(pk=root_node_pk)
     logger.info(f"{build_type} container build {build_id} had root node with purl {root_node.purl}")
-    any_go_module_created = any_source_created = False
+    any_go_module_created = any_source_created = any_cachito_created = False
 
     meta_attr = {"go_component_type": "gomod", "source": ["collectors/brew"]}
     for module in build_data["meta"].get("upstream_go_modules", ()):
@@ -652,39 +652,10 @@ def slow_save_container_children(
             source["type"], component_name, component_version, source["meta"], extra, root_node
         )
         any_source_created |= temp_created
-        slow_save_container_provides.delay(
-            build_id, build_type, source, upstream_node.pk, save_product
-        )
 
-    if save_product and not build_data.get("sources"):
-        # Save the taxonomy either here in this task (if only upstreams created),
-        # or in the task below (if both upstreams and provides created)
-        slow_save_taxonomy.delay(build_id, build_type)
-
-    return any_go_module_created or any_source_created
-
-
-@app.task(
-    base=Singleton,
-    autoretry_for=RETRYABLE_ERRORS,
-    retry_kwargs=RETRY_KWARGS,
-    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
-)
-def slow_save_container_provides(
-    build_id: str,
-    build_type: str,
-    source: dict,
-    upstream_node_pk: ComponentNode,
-    save_product: bool,
-) -> bool:
-    """Save provides of a container in a separate task to avoid timeouts"""
-    logger.info(f"Saving provides for {build_type} container build {build_id}")
-    upstream_node = ComponentNode.objects.get(pk=upstream_node_pk)
-    logger.info(
-        f"{build_type} container build {build_id} had upstream node with purl {upstream_node.purl}"
-    )
-    # Collect the Cachito dependencies
-    cachito_created = recurse_components(source, upstream_node)
+        # Collect the Cachito dependencies
+        temp_created = recurse_components(source, upstream_node)
+        any_cachito_created |= temp_created
 
     if save_product:
         # slow_fetch_brew_build could finish before this task
@@ -700,7 +671,7 @@ def slow_save_container_provides(
         # Incomplete provides / upstreams ForeignKeys are probably still better
         # than timeouts / failing to load a build and create all the child components
         slow_save_taxonomy.delay(build_id, build_type)
-    return cachito_created
+    return any_go_module_created or any_source_created or any_cachito_created
 
 
 def recurse_components(component: dict, parent: ComponentNode) -> bool:

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -28,7 +28,6 @@ from corgi.tasks.brew import (
     save_component,
     slow_fetch_brew_build,
     slow_save_container_children,
-    slow_save_container_provides,
     slow_save_taxonomy,
 )
 from corgi.tasks.common import BUILD_TYPE
@@ -1266,15 +1265,8 @@ def test_fetch_container_build_rpms(mock_fetch_brew_build, mock_load_errata, moc
                 "corgi.tasks.brew.slow_save_container_children.delay",
                 wraps=slow_save_container_children,
             ) as wrapped_save_children:
-                with patch(
-                    "corgi.tasks.brew.slow_save_container_provides.delay",
-                    wraps=slow_save_container_provides,
-                ) as wrapped_save_provides:
-                    build_id = "1781353"
-                    slow_fetch_brew_build(build_id, SoftwareBuild.Type.BREW)
-                    wrapped_save_provides.assert_called_once_with(
-                        build_id, SoftwareBuild.Type.BREW, ANY, ANY, True
-                    )
+                build_id = "1781353"
+                slow_fetch_brew_build(build_id, SoftwareBuild.Type.BREW)
                 wrapped_save_children.assert_called_once_with(
                     build_id, SoftwareBuild.Type.BREW, ANY, ANY, True
                 )


### PR DESCRIPTION
Reverts RedHatProductSecurity/component-registry#583 because it didn't always fix the issue and may have even created a new one.