### PR TITLE
nginx and gunicorn should have matching keepalive settings

### DIFF
--- a/etc/nginx/proxy.conf
+++ b/etc/nginx/proxy.conf
@@ -34,4 +34,7 @@ location / {
     proxy_read_timeout 300s;
     # Not used in production, but required in Dev to get correct links in the /api/v1 menu
     proxy_set_header   Host localhost:8080;
+
+    keepalive_timeout 5s;
+    keepalive_requests 1000;
 }

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -18,6 +18,8 @@ forwarded_allow_ips = "*"
 
 timeout = 300
 
+keepalive = 5
+
 if not running_dev():
     # Saves memory in the worker process, but breaks --reload
     preload_app = True


### PR DESCRIPTION
will be a matching component-registry-ops PR for setting in stage/prod