### PR TITLE
move performance test to a scheduled task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,9 @@ deploy-prod:
 
 sonarqube:
   stage: test
+  except:
+    refs:
+      - schedules
 
 test:
   stage: test
@@ -139,6 +142,8 @@ test-performance:
     - $DNF_WITH_OPTIONS install $RPM_REQUIREMENTS
     - python3.9 -m pip install tox
     - tox -e corgi -- -m performance --no-cov
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
 
 mypy:
   stage: test


### PR DESCRIPTION
I'll created a new scheduled pipeline in CI where we can run the performance test daily. This is how the reconciliation scripts run in the ops repository. It decouples the most recently code changes from the test which is actually testing the previous changes, not the current change.