### PR TITLE
avoid Bad Gateways

### DIFF
--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -8,6 +8,7 @@ if os.getenv("RUNNING_GUNICORN"):
     # patching only what's required is safer, since gunicorn hasn't forked workers yet
     patch_ssl()
 
+
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,9 @@
+# to avoid MonkeyPatchWarning error/warnings
+from gevent import monkey
+
 from config.utils import running_dev
+
+monkey.patch_all(thread=False, select=False)
 
 workers = 4
 worker_class = "gevent"
@@ -21,8 +26,8 @@ timeout = 300
 if not running_dev():
     # Saves memory in the worker process, but breaks --reload
     preload_app = True
-    # ensure we finish off requests before restarting
-    graceful_timeout = 300
+    # we let openshift restart a pod in case of memory leaks
+    max_requests = 0
 else:
     # Support hot-reloading of Gunicorn / Django when files change
     reload = True


### PR DESCRIPTION
We were getting a Bad Gateway whenever gunicorn restarts ... there exists a graceful_restart gunicorn param but it is not 'graceful' enough ... we let infra restart pod in the case of memory leaks