### PR TITLE
CORGI-811 stream multi variants

### DIFF
--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -323,22 +323,7 @@ def _parse_cpes_from_brew_tags(
     version_name: str,
 ) -> list[str]:
     """Match streams using brew_tags to Errata Tool Product Versions and their Variants"""
-    # quay-3 streams brew_tags all share a single variant, and we have a one-to-many
-    # cardinality between streams and variants. quay-3 streams should probably be consolidated
-    # into a single stream in prod_defs. See also PROJQUAY-5312.
-    # The rhn_satellite_6 streams have brew tags, but those brew tags are associated
-    # with the RHEL-7-SATELLITE-6.10 ET Product Version. We skip them
-    # here to ensure the rhn_satelite_6.10 variants only get linked with that stream
-    # I haven't filed a product bug to get them fixed since 6.7 - 6.9 are no longer
-    # active. See CORGI-546 for more details.
-    # Also skip brew_tag matching for dts ps_module which share Variants/Brew Tags with rhscl
-    # See CORGI-726
-    if (
-        len(brew_tags) > 0
-        and version_name != "quay-3"
-        and not version_name.startswith("dts-")
-        and stream_name not in ("rhn_satellite_6.7", "rhn_satellite_6.8", "rhn_satellite_6.9")
-    ):
+    if len(brew_tags) > 0:
         logger.debug(f"Found brew tags {brew_tags} in product stream: {stream_name}")
         cpes: set[str] = set()
         for brew_tag in brew_tags.keys():

--- a/tests/data/prod_defs/proddefs-update-multi-stream-variant-active.json
+++ b/tests/data/prod_defs/proddefs-update-multi-stream-variant-active.json
@@ -1,0 +1,55 @@
+{
+  "ps_update_streams": {
+    "ga_stream": {
+      "errata_info": [
+        {
+          "product_name": "RHCERTSYS",
+          "product_versions": [
+            {
+              "name": "CERTSYS-10.4-RHEL-8",
+              "variants": [
+                "8Base-CertSys-10.4"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "z_stream": {
+      "errata_info": [
+        {
+          "product_name": "RHCERTSYS",
+          "product_versions": [
+            {
+              "name": "CERTSYS-10.4-RHEL-8",
+              "variants": [
+                "8Base-CertSys-10.4"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "ps_modules": {
+    "version": {
+      "active_ps_update_streams": [
+        "ga_stream",
+        "z_stream"
+      ],
+      "ps_update_streams": [
+        "ga_stream",
+        "z_stream"
+      ]
+    }
+  },
+  "ps_products": {
+    "product": {
+      "name": "product",
+      "ps_modules": [
+        "version"
+      ],
+      "business_unit": "test"
+    }
+  }
+}

--- a/tests/data/prod_defs/proddefs-update-multi-stream-variant-update.json
+++ b/tests/data/prod_defs/proddefs-update-multi-stream-variant-update.json
@@ -1,0 +1,54 @@
+{
+  "ps_update_streams": {
+    "ga_stream": {
+      "errata_info": [
+        {
+          "product_name": "RHCERTSYS",
+          "product_versions": [
+            {
+              "name": "CERTSYS-10.4-RHEL-8",
+              "variants": [
+                "8Base-CertSys-10.4"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "z_stream": {
+      "errata_info": [
+        {
+          "product_name": "RHCERTSYS",
+          "product_versions": [
+            {
+              "name": "CERTSYS-10.4-RHEL-8",
+              "variants": [
+                "8Base-CertSys-10.4"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "ps_modules": {
+    "version": {
+      "active_ps_update_streams": [
+        "z_stream"
+      ],
+      "ps_update_streams": [
+        "ga_stream",
+        "z_stream"
+      ]
+    }
+  },
+  "ps_products": {
+    "product": {
+      "name": "product",
+      "ps_modules": [
+        "version"
+      ],
+      "business_unit": "test"
+    }
+  }
+}

--- a/tests/data/prod_defs/proddefs-update-multi-stream-variant.json
+++ b/tests/data/prod_defs/proddefs-update-multi-stream-variant.json
@@ -1,0 +1,44 @@
+{
+  "ps_update_streams": {
+    "ga_stream": {
+      "errata_info": [
+        {
+          "product_name": "RHCERTSYS",
+          "product_versions": [
+            {
+              "name": "CERTSYS-10.4-RHEL-8",
+              "variants": [
+                "8Base-CertSys-10.4"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "z_stream": {
+      "yum_repositories": [
+        "https://example.com/rhel-8/compose/yum_stream/"
+      ]
+    }
+  },
+  "ps_modules": {
+    "version": {
+      "active_ps_update_streams": [
+        "ga_stream"
+      ],
+      "ps_update_streams": [
+        "ga_stream",
+        "z_stream"
+      ]
+    }
+  },
+  "ps_products": {
+    "product": {
+      "name": "product",
+      "ps_modules": [
+        "version"
+      ],
+      "business_unit": "test"
+    }
+  }
+}

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -436,6 +436,22 @@ def test_find_by_cpe():
     assert cpe in results
 
 
+@pytest.mark.django_db
+def test_find_by_cpe_substring():
+    product = CollectorErrataProduct.objects.create(name="product", et_id=1)
+    product_version = CollectorErrataProductVersion.objects.create(
+        name="product_version", et_id=10, product=product
+    )
+    cpe = "cpe:/a:redhat:openshift_pipelines:1.7::el8"
+    CollectorErrataProductVariant.objects.create(
+        name="product_variant", et_id=100, product_version=product_version, cpe=cpe
+    )
+
+    results = _find_by_cpe(["cpe:/a:redhat:openshift_pipelines:1"])
+
+    assert cpe in results
+
+
 # We stip -candidate from tags before persisting Collector models
 brew_tag_streams = [
     # In the actual ET data the brew tag is gitops-1.7-rhel-8-candidate
@@ -484,3 +500,83 @@ def test_brew_tag_matching(variant_name, cpe, brew_tag, stream_name, requests_mo
     stream = ProductStream.objects.get(name=stream_name)
     assert stream.productvariants.get_queryset().count() == 0
     assert stream.cpes_from_brew_tags == [cpe]
+
+
+@pytest.mark.django_db
+@patch("corgi.tasks.prod_defs.slow_remove_product_from_build.delay")
+@patch("corgi.tasks.prod_defs.slow_save_taxonomy.delay")
+def test_multi_variant_streams(mock_save, mock_remove, requests_mock):
+    """Test that errata_info variants are only attached to an active stream where that stream
+    shares errata_info with an inactive stream"""
+    with open("tests/data/prod_defs/proddefs-update-multi-stream-variant.json") as prod_defs:
+        text = prod_defs.read()
+        requests_mock.get(f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=text)
+
+    update_products()
+    assert not mock_remove.called
+
+    ga_stream = ProductStream.objects.get(name="ga_stream")
+    assert ga_stream.productvariants.get_queryset().count() == 1
+    z_stream = ProductStream.objects.get(name="z_stream")
+    assert z_stream.productvariants.get_queryset().count() == 0
+    assert z_stream.yum_repositories
+
+    sb = SoftwareBuildFactory()
+
+    ProductComponentRelation.objects.create(
+        external_system_id="https://example.com/rhel-8/compose/yum_stream/",
+        product_ref="z_stream",
+        software_build=sb,
+        type=ProductComponentRelation.Type.YUM_REPO,
+    )
+
+    ProductComponentRelation.objects.create(
+        external_system_id="some_repo",
+        product_ref="8Base-CertSys-10.4",
+        software_build=sb,
+        type=ProductComponentRelation.Type.CDN_REPO,
+    )
+
+    with open("tests/data/prod_defs/proddefs-update-multi-stream-variant-update.json") as prod_defs:
+        text = prod_defs.read()
+        requests_mock.get(f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=text)
+
+    update_products()
+
+    ga_stream.refresh_from_db()
+    assert ga_stream.productvariants.get_queryset().count() == 0
+    z_stream.refresh_from_db()
+    assert z_stream.productvariants.get_queryset().count() == 1
+    assert not ProductComponentRelation.objects.filter(product_ref="z_stream").exists()
+    assert mock_remove.called_once_with(
+        (
+            str(sb.pk),
+            "ProductStream",
+            z_stream.pk,
+        )
+    )
+    assert mock_save.called_once_with(sb.build_id, sb.build_type)
+
+
+@pytest.mark.django_db
+def test_multi_variant_active_streams(requests_mock):
+    """Tests that multiple runs of update_products with multiple active streams sharing errata_info
+    does not cause the variants to move back and forth between the streams"""
+    with open("tests/data/prod_defs/proddefs-update-multi-stream-variant-active.json") as prod_defs:
+        text = prod_defs.read()
+        requests_mock.get(f"{settings.PRODSEC_DASHBOARD_URL}/product-definitions", text=text)
+
+    update_products()
+
+    ga_stream = ProductStream.objects.get(name="ga_stream")
+    assert ga_stream.productvariants.get_queryset().count() == 0
+    z_stream = ProductStream.objects.get(name="z_stream")
+    assert z_stream.productvariants.get_queryset().count() == 1
+
+    # Call update_products again with the same proddefs-update-mult-stream-variant-active.json
+    update_products()
+
+    ga_stream = ProductStream.objects.get(name="ga_stream")
+    assert ga_stream.productvariants.get_queryset().count() == 0
+    z_stream = ProductStream.objects.get(name="z_stream")
+    assert z_stream.productvariants.get_queryset().count() == 1


### PR DESCRIPTION
This addressed CORGI-811 by only attaching variants from errata_info to active streams.

It also removes some logic from brew_tag parsing which skipped some streams. This is no longer required as we don't associate variants with these streams any more.

@RedHatProductSecurity/corgi-devs please review.