### PR TITLE
CORGI-758: Handle Quarkus release errata

### DIFF
--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import typing
 from collections import defaultdict
@@ -261,3 +262,15 @@ class ErrataTool:
                 # map modular_rpms to build_ids. In slow_save_errata these are only saved as
                 # meta_attr so, let's just save the entire list for each build_id
                 variant_to_component_map[variant].append({build_id: modular_rpms})
+
+    def get_erratum_notes(self, erratum_id: int):
+        # Get the contents of the "Notes" (formerly "How to test") field from an erratum.
+        # Quarkus uses this field to associate an SBOM with an erratum.
+        erratum_json = self.get(f"api/v1/erratum/{erratum_id}?format=json")
+        try:
+            # All products that use SBOMer should have notes set
+            notes = json.loads(erratum_json["content"]["content"]["how_to_test"])
+        except json.JSONDecodeError:
+            logger.warning(f"Couldn't load Notes for erratum {erratum_id}")
+            return {}
+        return notes

--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -263,14 +263,16 @@ class ErrataTool:
                 # meta_attr so, let's just save the entire list for each build_id
                 variant_to_component_map[variant].append({build_id: modular_rpms})
 
-    def get_erratum_notes(self, erratum_id: int):
+    def get_erratum_notes(self, erratum_id: int) -> dict:
         # Get the contents of the "Notes" (formerly "How to test") field from an erratum.
         # Quarkus uses this field to associate an SBOM with an erratum.
         erratum_json = self.get(f"api/v1/erratum/{erratum_id}?format=json")
         try:
             # All products that use SBOMer should have notes set
+            # NB: Though the field in the ET UI is called "Notes", the field name in the API
+            # is "how_to_test", which was the original purpose of the Notes field.
             notes = json.loads(erratum_json["content"]["content"]["how_to_test"])
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as error:
             logger.warning(f"Couldn't load Notes for erratum {erratum_id}")
-            return {}
+            raise error
         return notes

--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from corgi.core.constants import SBOMER_PRODUCT_MAP
 from corgi.core.models import Component
 
 logger = logging.getLogger(__name__)
@@ -99,9 +100,4 @@ class SbomerSbom:
 def is_sbomer_product(product: str, product_release: str) -> bool:
     """Identifies products for which SBOMer produces manifests and which need separate handling
     for release errata"""
-    products = {
-        "RHBQ": [
-            "Red Hat build of Quarkus Middleware",
-        ],
-    }
-    return product in products and product_release in products[product]
+    return product in SBOMER_PRODUCT_MAP and product_release in SBOMER_PRODUCT_MAP[product]

--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -94,3 +94,14 @@ class SbomerSbom:
         # declared in the Components section above. At the moment,
         # only "dependsOn" type relationships are declared.
         self.dependencies = {d["ref"]: d["dependsOn"] for d in data["dependencies"]}
+
+
+def is_sbomer_product(product: str, product_release: str) -> bool:
+    """Identifies products for which SBOMer produces manifests and which need separate handling
+    for release errata"""
+    products = {
+        "RHBQ": [
+            "Red Hat build of Quarkus Middleware",
+        ],
+    }
+    return product in products and product_release in products[product]

--- a/corgi/core/constants.py
+++ b/corgi/core/constants.py
@@ -61,3 +61,11 @@ ROOT_COMPONENTS_CONDITION = (
 
 # Regex for generating el_match field
 EL_MATCH_RE = re.compile(r".*el(\d+)?[._-]?(\d+)?[._-]?(\d+)?(.*)")
+
+# List of products and releases which publish SBOMer manifests and should
+# process shipped errata accordingly
+SBOMER_PRODUCT_MAP = {
+    "RHBQ": [
+        "Red Hat build of Quarkus Middleware",
+    ],
+}

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -178,6 +178,6 @@ def slow_handle_pnc_errata_released(erratum_id: int, erratum_status: str) -> Non
             build_type=build.build_type,
             defaults={
                 "type": ProductComponentRelation.Type.ERRATA,
-                "meta_attr": {"components": component},
+                "meta_attr": {"component_purl": component.purl},
             },
         )

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -4,6 +4,7 @@ import requests
 from celery_singleton import Singleton
 
 from config.celery import app
+from corgi.collectors.errata_tool import ErrataTool
 from corgi.collectors.models import CollectorErrataProductVariant
 from corgi.collectors.pnc import SbomerSbom
 from corgi.core.models import (
@@ -123,3 +124,62 @@ def slow_fetch_pnc_sbom(purl: str, product_data, build_data, sbom_data) -> None:
 
     # Save component taxonomy
     root_component.save_component_taxonomy()
+
+
+@app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
+def slow_handle_pnc_errata_released(erratum_id: int, erratum_status: str) -> None:
+    # Check that the erratum is released
+    if erratum_status != "SHIPPED_LIVE":
+        raise ValueError(f"Invalid status {erratum_status} for erratum {erratum_id}")
+
+    # Get the purl(s) of the related component(s) from the erratum's Notes field
+    et = ErrataTool()
+    notes = et.get_erratum_notes(erratum_id)
+
+    related_purls = set()
+    for ref in notes.get("manifest", {}).get("refs", {}):
+        if ref["type"] == "purl":
+            related_purls.add(ref["uri"])
+
+    if not related_purls:
+        raise ValueError(f"Erratum {erratum_id} had no associated purls")
+
+    # Check that there's a component matching the purls
+    root_components: set[Component] = set()
+    for purl in related_purls:
+        # There should only be one root component of SOURCE type
+        components = Component.objects.filter(meta_attr__purl_declared=purl).filter(
+            type=Component.Type.MAVEN
+        )
+        if components.count() == 0:
+            logger.warning(
+                f"Erratum {erratum_id} refers to purl {purl} which matches no components"
+            )
+            continue
+        if components.count() > 1:
+            logger.warning(
+                f"Erratum {erratum_id} refers to purl {purl} which matches {components.count()}"
+                " components; only handling the first"
+            )
+        root_components.add(components[0])
+
+    # Update relations with this erratum
+    # TODO: Is just the root component okay here, or do I need to recreate the entire tree?
+    for component in root_components:
+        if component.software_build is None:
+            logger.warning(
+                f"Component {component.purl} has no build, can't relate erratum {erratum_id}"
+            )
+        else:
+            build = component.software_build
+            build_relation = ProductComponentRelation.objects.get(software_build=build)
+            ProductComponentRelation.objects.update_or_create(
+                external_system_id=erratum_id,
+                product_ref=build_relation.product_ref,
+                build_id=build.build_id,
+                build_type=build.build_type,
+                defaults={
+                    "type": ProductComponentRelation.Type.ERRATA,
+                    "meta_attr": {"components": component},
+                },
+            )

--- a/tests/data/pnc/erratum_notes.json
+++ b/tests/data/pnc/erratum_notes.json
@@ -1,0 +1,15 @@
+{
+  "manifest" : {
+    "refs" : [ {
+      "type" : "purl",
+      "uri" : "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.SP2-redhat-00001?type=pom"
+    } ]
+  },
+  "simple-mapper" : {
+    "refs" : [ {
+      "type" : "cve-component-mapping",
+      "version" : "0.0.1",
+      "uri" : "https://gitlab.cee.redhat.com/fix-mappings/rhbq/-/raw/main/2.13.8.SP2.GA/cve-mappings.json"
+    } ]
+  }
+}

--- a/tests/data/pnc/notes_no_manifest.json
+++ b/tests/data/pnc/notes_no_manifest.json
@@ -1,0 +1,9 @@
+{
+  "simple-mapper" : {
+    "refs" : [ {
+      "type" : "cve-component-mapping",
+      "version" : "0.0.1",
+      "uri" : "https://gitlab.cee.redhat.com/fix-mappings/rhbq/-/raw/main/2.13.8.SP2.GA/cve-mappings.json"
+    } ]
+  }
+}

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -257,25 +257,25 @@ def test_umb_receiver_handles_shipped_errata():
     mock_sbomer_event.message.address = address
     assert address.replace("topic://", VIRTUAL_TOPIC_ADDRESS_PREFIX) in addresses
 
-    mock_umb_event.message.body = (
-        '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,'
-        ' "product": "Product", "release": "Red Hat release of Product"}'.replace(
-            "MOCK_ID", mock_id
-        )
+    mock_umb_event.message.body = """
+        {"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,
+        "product": "Product", "release": "Red Hat release of Product"}
+    """.replace(
+        "MOCK_ID", mock_id
     )
     # Messages with an invalid status should get filtered out by the topic selector
-    mock_invalid_event.message.body = (
-        '{"errata_status": "DROPPED_NO_SHIP", "errata_id": MOCK_ID,'
-        ' "product": "Product", "release": "Red Hat release of Product"}'.replace(
-            "MOCK_ID", mock_id
-        )
+    mock_invalid_event.message.body = """
+        {"errata_status": "DROPPED_NO_SHIP", "errata_id": MOCK_ID,
+        "product": "Product", "release": "Red Hat release of Product"}
+    """.replace(
+        "MOCK_ID", mock_id
     )
     # Messages for Middleware/SBOMer products should be handled by separately
-    mock_sbomer_event.message.body = (
-        '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,'
-        ' "product": "RHBQ", "release": "Red Hat build of Quarkus Middleware"}'.replace(
-            "MOCK_ID", mock_id
-        )
+    mock_sbomer_event.message.body = """
+        {"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,
+        "product": "RHBQ", "release": "Red Hat build of Quarkus Middleware"}
+    """.replace(
+        "MOCK_ID", mock_id
     )
     mock_id = int(mock_id)
 
@@ -316,8 +316,10 @@ def test_umb_receiver_handles_shipped_errata():
     )
 
     # Test SBOMer release errata
+    side_effects = (None, None, ValueError("Mock invalid erratum value"))
     with patch(
         "corgi.monitor.consumer.slow_handle_pnc_errata_released.apply_async",
+        side_effect=side_effects,
     ) as slow_handle_pnc_errata_released_mock:
         # No exception
         with patch.object(handler, "accept") as mock_accept:
@@ -332,11 +334,20 @@ def test_umb_receiver_handles_shipped_errata():
             handler.on_message(mock_sbomer_event)
             mock_accept.assert_called_once_with(mock_sbomer_event.delivery)
 
+        # Ensure the message is released if there's an exception
+        with patch.object(handler, "release") as mock_release:
+            mock_sbomer_event.message.body = mock_sbomer_event.message.body.replace(
+                "DROPPED_NO_SHIP", "SHIPPED_LIVE"
+            )
+            handler.on_message(mock_sbomer_event)
+            mock_release.assert_called_once_with(mock_sbomer_event.delivery, delivered=True)
+
     # slow_handle_pnc_released_errata takes erratum_id, erratum_status as arguments
     slow_handle_pnc_errata_released_mock.assert_has_calls(
         (
             call(args=(mock_id, "SHIPPED_LIVE")),
             call(args=(mock_id, "DROPPED_NO_SHIP")),
+            call(args=(mock_id, "SHIPPED_LIVE")),
         )
     )
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -249,18 +249,33 @@ def test_umb_receiver_handles_shipped_errata():
 
     mock_umb_event = MagicMock()
     mock_invalid_event = MagicMock()
+    mock_sbomer_event = MagicMock()
     mock_id = "1234"
     address = "topic://VirtualTopic.eng.errata.activity.status"
     mock_umb_event.message.address = address
     mock_invalid_event.message.address = address
+    mock_sbomer_event.message.address = address
     assert address.replace("topic://", VIRTUAL_TOPIC_ADDRESS_PREFIX) in addresses
 
-    mock_umb_event.message.body = '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID}'.replace(
-        "MOCK_ID", mock_id
+    mock_umb_event.message.body = (
+        '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,'
+        ' "product": "Product", "release": "Red Hat release of Product"}'.replace(
+            "MOCK_ID", mock_id
+        )
     )
     # Messages with an invalid status should get filtered out by the topic selector
     mock_invalid_event.message.body = (
-        '{"errata_status": "DROPPED_NO_SHIP", "errata_id": MOCK_ID}'.replace("MOCK_ID", mock_id)
+        '{"errata_status": "DROPPED_NO_SHIP", "errata_id": MOCK_ID,'
+        ' "product": "Product", "release": "Red Hat release of Product"}'.replace(
+            "MOCK_ID", mock_id
+        )
+    )
+    # Messages for Middleware/SBOMer products should be handled by separately
+    mock_sbomer_event.message.body = (
+        '{"errata_status": "SHIPPED_LIVE", "errata_id": MOCK_ID,'
+        ' "product": "RHBQ", "release": "Red Hat build of Quarkus Middleware"}'.replace(
+            "MOCK_ID", mock_id
+        )
     )
     mock_id = int(mock_id)
 
@@ -297,6 +312,31 @@ def test_umb_receiver_handles_shipped_errata():
             call(args=(mock_id, "SHIPPED_LIVE")),
             call(args=(mock_id, "DROPPED_NO_SHIP")),
             call(args=(mock_id, "SHIPPED_LIVE")),
+        )
+    )
+
+    # Test SBOMer release errata
+    with patch(
+        "corgi.monitor.consumer.slow_handle_pnc_errata_released.apply_async",
+    ) as slow_handle_pnc_errata_released_mock:
+        # No exception
+        with patch.object(handler, "accept") as mock_accept:
+            handler.on_message(mock_sbomer_event)
+            mock_accept.assert_called_once_with(mock_sbomer_event.delivery)
+            mock_accept.reset_mock()
+
+            # Make sure invalid statuses work in the SBOMer erratum handler as well
+            mock_sbomer_event.message.body = mock_sbomer_event.message.body.replace(
+                "SHIPPED_LIVE", "DROPPED_NO_SHIP"
+            )
+            handler.on_message(mock_sbomer_event)
+            mock_accept.assert_called_once_with(mock_sbomer_event.delivery)
+
+    # slow_handle_pnc_released_errata takes erratum_id, erratum_status as arguments
+    slow_handle_pnc_errata_released_mock.assert_has_calls(
+        (
+            call(args=(mock_id, "SHIPPED_LIVE")),
+            call(args=(mock_id, "DROPPED_NO_SHIP")),
         )
     )
 


### PR DESCRIPTION
Middleware errata don't have all their components attached, this change reads the purl of the root component of an already-processed SBOMer manifest to know which components were released.