### PR TITLE
CORGI-666 update released_components filter to use the relations table

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1006,12 +1006,12 @@ class ComponentQuerySet(models.QuerySet):
 
     def released_components(self, include: bool = True) -> "ComponentQuerySet":
         """Show only released components by default, or unreleased components if include=False"""
-        empty_released_errata = Q(software_build__meta_attr__released_errata_tags=())
+        errata_relations = Q(software_build__relations__type=ProductComponentRelation.Type.ERRATA)
         if include:
-            # Truthy values return the excluded queryset (only released components)
-            return self.exclude(empty_released_errata)
-        # Falsey values return the filtered queryset (only unreleased components)
-        return self.filter(empty_released_errata)
+            # Truthy values return only released components
+            return self.filter(errata_relations)
+        # Falsey values return only unreleased components
+        return self.exclude(errata_relations)
 
     def root_components(self, include: bool = True) -> "ComponentQuerySet":
         """Show only root components by default, or only non-root components if include=False"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,13 +6,19 @@ from django.contrib.auth import get_user_model
 from rest_framework.authtoken.models import Token
 
 from corgi.collectors.appstream_lifecycle import AppStreamLifeCycleCollector
-from corgi.core.models import Component, ComponentNode, SoftwareBuild
+from corgi.core.models import (
+    Component,
+    ComponentNode,
+    ProductComponentRelation,
+    SoftwareBuild,
+)
 
 from .factories import (
     ChannelFactory,
     ComponentFactory,
     ComponentTagFactory,
     LifeCycleFactory,
+    ProductComponentRelationFactory,
     ProductFactory,
     ProductStreamFactory,
     ProductVariantFactory,
@@ -439,8 +445,11 @@ def test_latest_components_by_streams_filter(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_released_components_filter(client, api_path):
-    released_build = SoftwareBuildFactory(meta_attr={"released_errata_tags": ["RHBA-2023:1234"]})
-    unreleased_build = SoftwareBuildFactory(meta_attr={"released_errata_tags": []})
+    released_build = SoftwareBuildFactory()
+    unreleased_build = SoftwareBuildFactory()
+    ProductComponentRelationFactory(
+        type=ProductComponentRelation.Type.ERRATA, software_build=released_build
+    )
     ComponentFactory(name="released", software_build=released_build)
     ComponentFactory(name="unreleased", software_build=unreleased_build)
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -503,13 +503,12 @@ def setup_products_and_components_upstreams():
 
 def setup_products_and_components_provides(released=True, internal_component=False):
     stream, variant = setup_product()
-    meta_attr = {"released_errata_tags": []}
+    build = SoftwareBuildFactory(build_id=1)
     if released:
-        meta_attr["released_errata_tags"] = ["RHBA-2023:1234"]
-    build = SoftwareBuildFactory(
-        build_id=1,
-        meta_attr=meta_attr,
-    )
+        ProductComponentRelationFactory(
+            type=ProductComponentRelation.Type.ERRATA, software_build=build
+        )
+
     if internal_component:
         provided = ComponentFactory(name="gitlab.cee.redhat.com/", type=Component.Type.GOLANG)
         dev_provided = ComponentFactory(name="github.com/blah.redhat.com", type=Component.Type.NPM)
@@ -541,8 +540,8 @@ def setup_products_and_components_provides(released=True, internal_component=Fal
     # to generate the manifest
     ProductComponentRelationFactory(
         software_build=build,
-        product_ref=variant.name,
-        type=ProductComponentRelation.Type.ERRATA,
+        product_ref=stream.name,
+        type=ProductComponentRelation.Type.BREW_TAG,
     )
     # Link the components to the ProductModel instances
     build.save_product_taxonomy()


### PR DESCRIPTION
Switch from using brew tags stored in SoftwareBuild meta_attr to using 'relations' reverse foreign key of SoftwareBuild, with a check to make sure they are of Errata type.