### PR TITLE
Allow SBOMer components with no license info

### DIFF
--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -56,7 +56,7 @@ class SbomerSbom:
 
             # License info
             licenses = []
-            for _license in component.get("licenses", []):
+            for _license in component.get("licenses", ()):
                 if _license["license"].get("id"):
                     licenses.append(_license["license"].get("id"))
                 if _license["license"].get("name"):

--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -56,7 +56,7 @@ class SbomerSbom:
 
             # License info
             licenses = []
-            for _license in component["licenses"]:
+            for _license in component.get("licenses", []):
                 if _license["license"].get("id"):
                     licenses.append(_license["license"].get("id"))
                 if _license["license"].get("name"):

--- a/tests/data/pnc/pnc_sbom.json
+++ b/tests/data/pnc/pnc_sbom.json
@@ -430,20 +430,6 @@
                 "bom-ref": "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@1.0.0.Final?type=jar",
                 "description": "JSR 322: Java(TM) EE Connector Architecture 1.7 API",
                 "group": "org.jboss.spec.javax.resource",
-                "licenses": [
-                    {
-                        "license": {
-                            "name": "Common Development and Distribution License",
-                            "url": "http://repository.jboss.org/licenses/cddl.txt"
-                        }
-                    },
-                    {
-                        "license": {
-                            "name": "GNU General Public License, Version 2 with the Classpath Exception",
-                            "url": "http://repository.jboss.org/licenses/gpl-2.0-ce.txt"
-                        }
-                    }
-                ],
                 "name": "jboss-connector-api_1.7_spec",
                 "properties": [
                     {

--- a/tests/test_pnc_collector.py
+++ b/tests/test_pnc_collector.py
@@ -33,6 +33,14 @@ def test_validate_sbom():
         == "1234567890"
     )
 
+    assert (
+        sbom.components[
+            "pkg:maven/org.jboss.spec.javax.resource/jboss-connector-api_1.7_spec@"
+            + "1.0.0.Final?type=jar"
+        ]["licenses"]
+        == []
+    )
+
     # A component with both PNC and Brew builds stores both
     assert (
         sbom.components["pkg:maven/io.smallrye.reactive/mutiny@1.7.0.redhat-00001?type=jar"][


### PR DESCRIPTION
Some components in SBOMer manifests may not have license information. This change prevents manifest processing from failing in those cases.