### PR TITLE
CORGI-780: Handle private Quay images with no "latest" tag (image pull fails)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -479,3 +479,5 @@ PYXIS_KEY = UMB_KEY
 # Set to False to disable software composition analysis tasks.
 SCA_ENABLED = strtobool(os.getenv("CORGI_SCA_ENABLED", "true"))
 SCA_SCRATCH_DIR = os.getenv("CORGI_SCA_SCATCH_DIR", "/tmp")
+
+QUAY_TOKEN = os.getenv("CORGI_QUAY_TOKEN")

--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -63,8 +63,7 @@ def cpu_manifest_service(product_stream_id: str, service_components: list) -> No
 
         quay_repo = service_component.get("quay_repo_name")
         if quay_repo:
-            quay_repo_full = f"quay.io/{quay_repo}"
-            component_data, quay_scan_source = Syft.scan_repo_image(target_image=quay_repo_full)
+            component_data, quay_scan_source = Syft.scan_repo_image(target_image=quay_repo)
             component_version = quay_scan_source["target"]["imageID"]
             analyzed_components.extend(component_data)
 

--- a/tests/test_app_interface.py
+++ b/tests/test_app_interface.py
@@ -1,7 +1,12 @@
+import subprocess
+from contextlib import nullcontext
+from unittest.mock import call, patch
+
 import pytest
 from django.conf import settings
 
 from corgi.collectors.app_interface import AppInterface
+from corgi.collectors.syft import Syft
 
 from .factories import ProductStreamFactory
 
@@ -85,14 +90,98 @@ def test_metadata_fetch(requests_mock):
     result = AppInterface.fetch_service_metadata(services=[ps])
 
     assert ps in result
-    assert sorted(result[ps], key=lambda x: x["name"]) == sorted(
-        [
-            {"name": "hello-world", "quay_repo_name": "blue-org/hello-world"},
-            {"name": "hello-world-api", "quay_repo_name": "blue-org/hello-world-api"},
-            {"name": "hello", "git_repo_url": "https://github.com/red/hello"},
-            {"name": "example", "quay_repo_name": "blue-org/example"},
-            {"name": "example-ui", "quay_repo_name": "blue-org/example-ui"},
-            {"name": "blue-app", "git_repo_url": "https://github.com/blue/example"},
-        ],
-        key=lambda x: x["name"],
+    assert sorted(result[ps], key=lambda x: x["name"]) == [
+        {"name": "blue-app", "git_repo_url": "https://github.com/blue/example"},
+        {"name": "example", "quay_repo_name": "blue-org/example"},
+        {"name": "example-ui", "quay_repo_name": "blue-org/example-ui"},
+        {"name": "hello", "git_repo_url": "https://github.com/red/hello"},
+        {"name": "hello-world", "quay_repo_name": "blue-org/hello-world"},
+        {"name": "hello-world-api", "quay_repo_name": "blue-org/hello-world-api"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "quay_json,most_recent_tag,target_host,target_image,pytest_raises",
+    (
+        (
+            # Dict values aren't used and don't matter, we just need the first dict key
+            # Which is always the newest / most recently updated tag name
+            {"tags": {"t1": {"name": "t1", "date": 2}, "t2": {"name": "t2", "date": 1}}},
+            "t1",
+            "quay.io",
+            "repo/image",
+            nullcontext(),
+        ),
+        # If no tags, default to latest. nullcontext here means "no exception raised"
+        ({"tags": {}}, "latest", "quay.io", "repo2/image2", nullcontext()),
+        # Code works with public QUay.io instance or any internal Quay server
+        ({"tags": {}}, "latest", "internal.quay", "repo3/image3", nullcontext()),
+        # Fails with no retry if the image to pull already had a tag given explicitly
+        (
+            {"tags": {}},
+            "latest",
+            "internal.quay",
+            "repo4/image4:latest",
+            pytest.raises(subprocess.CalledProcessError),
+        ),
+        (
+            {"tags": {}},
+            "latest",
+            "internal.quay",
+            "repo5/image5:version",
+            pytest.raises(subprocess.CalledProcessError),
+        ),
+        (
+            {"tags": {}},
+            "latest",
+            "internal.quay",
+            "repo6/image6@sha256:digest",
+            pytest.raises(subprocess.CalledProcessError),
+        ),
+    ),
+)
+def test_image_pull_error_handling(
+    requests_mock, quay_json, most_recent_tag, target_host, target_image, pytest_raises
+):
+    """Test that Quay.io images can be pulled even if known errors occur"""
+    requests_mock.get(
+        f"https://{target_host}/api/v1/repository/{target_image}?includeTags=true", json=quay_json
     )
+
+    syft_args = [
+        "/usr/bin/syft",
+        "packages",
+        "-q",
+        "-o=syft-json",
+        "--exclude=**/vendor/**",
+        f"registry:{target_host}/{target_image}",
+    ]
+    syft_json = '{"source": "source_not_used"}'
+    side_effects = (subprocess.CalledProcessError(1, syft_args), syft_json)
+
+    with patch(
+        "corgi.collectors.syft.subprocess.check_output", side_effect=side_effects
+    ) as mock_scan:
+        with pytest_raises:
+            # pytest_raises is either a nullcontext manager, if no exception raised
+            # or a pytest.raises(CalledProcessError) context manager,
+            # if we should fail and not retry
+            result = Syft.scan_repo_image(target_image, target_host)
+
+    failed_call = call(syft_args, text=True)
+    if not isinstance(pytest_raises, nullcontext):
+        # One failed call, no retry or call to Quay API
+        calls = (failed_call,)
+        assert requests_mock.call_count == 0
+    else:
+        # One failed call, one successful retry that uses the Quay API
+        syft_args[-1] = f"{syft_args[-1]}:{most_recent_tag}"
+        retried_call = call(syft_args, text=True)
+        calls = (failed_call, retried_call)
+        assert requests_mock.call_count == 1
+
+        # The result is an empty list of components, plus the "source" key from the Syft JSON
+        # All we care about in this test is that we can pull the image and no exception is raised
+        assert result == ([], "source_not_used")
+
+    mock_scan.assert_has_calls(calls)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review when you have time (not urgent). I've confirmed this fixes the errors we're seeing when deployed to stage, and hopefully the pipeline won't fail overnight.