### PR TITLE
CORGI-836 populate errata relation software_build fk

### DIFF
--- a/scripts/kinit_in_container.sh
+++ b/scripts/kinit_in_container.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [[ -z "$1" ]]; then
-    user=$(whoami)@REDHAT.COM
+    user=$(whoami)@IPA.REDHAT.COM
 else
-    user="$1"@REDHAT.COM
+    user="$1"@IPA.REDHAT.COM
 fi
 
 # Only ask the password one time here and reuse in each pod


### PR DESCRIPTION
Since we changed the way the released_components filter works many streams are having their components filtered out by that filter. The cause of that seems to be be many missing ERRATA relations. 

I've got a script which looks for all streams which should have an SBOM, gets their root components and the release_errata_tags of those components software builds. It then calls slow_load_errata on those to create the ERRATA relations. However I noticed when testing this that the software_build foreign key of the ERRATA relation was not being populated. Most the time the SoftwareBuild object does exist, in that case we should populate the foreign key so that the new released_components filter will work correctly.

I filled a follow up task CORGI-837 to load missing SoftwareBuilds of all ERRATA relations as a scheduled task.

@RedHatProductSecurity/corgi-devs please review.