### PR TITLE
CORGI-780: Fix DoesNotExist errors when manifesting services

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -480,4 +480,4 @@ PYXIS_KEY = UMB_KEY
 SCA_ENABLED = strtobool(os.getenv("CORGI_SCA_ENABLED", "true"))
 SCA_SCRATCH_DIR = os.getenv("CORGI_SCA_SCATCH_DIR", "/tmp")
 
-QUAY_TOKEN = os.getenv("CORGI_QUAY_TOKEN")
+QUAY_TOKEN = os.getenv("CORGI_QUAY_TOKEN", "")

--- a/corgi/collectors/app_interface.py
+++ b/corgi/collectors/app_interface.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from typing import Iterable
 
 import requests
 from django.conf import settings
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 class AppInterface:
     @staticmethod
     def fetch_service_metadata(
-        services: list[ProductStream],
+        services: Iterable[ProductStream],
     ) -> dict[ProductStream, list[dict[str, str]]]:
         # TODO: Check parentApp / childrenApps / dependencies / statusPageComponents as well?
         repo_query = """
@@ -87,6 +88,7 @@ class AppInterface:
                 app_interface_component = component.get("app_interface_name")
                 if app_interface_component:
                     if app_interface_component not in service_component_map:
+                        # TODO: Raise an error once prod-defs data is cleaned up
                         logger.error(
                             f"Prod-def component {component} for service {service.name} includes a "
                             "component name that does not exist in app-interface!"

--- a/corgi/tasks/common.py
+++ b/corgi/tasks/common.py
@@ -1,8 +1,8 @@
-import logging
 import subprocess
 from datetime import datetime, timedelta
 from typing import Optional
 
+from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db.utils import InterfaceError as DjangoInterfaceError
 from django.utils import timezone
@@ -13,6 +13,8 @@ from requests.exceptions import RequestException
 
 from config.celery import app
 from corgi.core.models import ProductComponentRelation, SoftwareBuild
+
+logger = get_task_logger(__name__)
 
 BACKOFF_KWARGS = {"max_tries": 5, "jitter": None}
 
@@ -34,8 +36,6 @@ RETRY_KWARGS = {
 }
 
 BUILD_TYPE = SoftwareBuild.Type.KOJI if settings.COMMUNITY_MODE_ENABLED else SoftwareBuild.Type.BREW
-
-logger = logging.getLogger(__name__)
 
 
 def fatal_code(e):

--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -208,7 +208,8 @@ def cpu_manifest_service(stream_name: str, service_components: list) -> None:
                 type=ProductComponentRelation.Type.APP_INTERFACE,
             )
 
-            slow_save_taxonomy.delay(build.build_id, build.build_type)
+        # Give the transaction time to commit, before looking up the build we just created
+        slow_save_taxonomy.apply_async(args=(build.build_id, build.build_type), countdown=10)
 
         logger.info(
             f"Finished processing service component {service_component['name']} "

--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -20,8 +20,10 @@ from corgi.tasks.sca import save_component
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
 def refresh_service_manifests() -> None:
-    services = ProductStream.objects.filter(meta_attr__managed_service_components__isnull=False)
-    service_metadata = AppInterface.fetch_service_metadata(list(services))
+    services = ProductStream.objects.filter(
+        meta_attr__managed_service_components__isnull=False
+    ).distinct()
+    service_metadata = AppInterface.fetch_service_metadata(services)
 
     # Find previous builds and delete them and their components, so we can create a fresh
     # manifest structure for each "new" build. This is done specifically because we don't

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -1,6 +1,5 @@
-import logging
-
 import requests
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 
 from config.celery import app
@@ -16,20 +15,20 @@ from corgi.core.models import (
 from corgi.tasks.brew import set_license_declared_safely, slow_save_taxonomy
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)
 def slow_fetch_pnc_sbom(purl: str, product_data, build_data, sbom_data) -> None:
-    logger.info("Fetching PNC SBOM %s for purl %s", sbom_data["id"], purl)
     """Fetch a PNC SBOM from sbomer"""
+    logger.info("Fetching PNC SBOM %s for purl %s", sbom_data["id"], purl)
 
     # Validate the supplied product information
     try:
         CollectorErrataProductVariant.objects.get(name=product_data["productVariant"])
     except CollectorErrataProductVariant.DoesNotExist:
         logger.warning(
-            "PNC SBOM provided for nonexistant product variant: %s", product_data["productVariant"]
+            "PNC SBOM provided for nonexistent product variant: %s", product_data["productVariant"]
         )
         return
 

--- a/corgi/tasks/pyxis.py
+++ b/corgi/tasks/pyxis.py
@@ -1,8 +1,8 @@
-import logging
 import urllib.parse
 from collections.abc import Mapping
 from typing import Any, Optional
 
+from celery.utils.log import get_task_logger
 from celery_singleton import Singleton
 from django.conf import settings
 from django.utils import dateparse
@@ -20,7 +20,7 @@ from corgi.tasks.brew import slow_save_taxonomy
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 from corgi.tasks.sca import cpu_software_composition_analysis
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -586,9 +586,9 @@ uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
     # via drf-spectacular
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.17 \
+    --hash=sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21 \
+    --hash=sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b
     # via requests
 vine==5.0.0 \
     --hash=sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1237,9 +1237,9 @@ uritemplate==4.1.1 \
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   drf-spectacular
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.17 \
+    --hash=sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21 \
+    --hash=sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b
     # via
     #   -r requirements/base.txt
     #   -r requirements/lint.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -141,7 +141,7 @@ typing-extensions==4.5.0 \
     --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
     --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
     # via black
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.17 \
+    --hash=sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21 \
+    --hash=sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b
     # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -958,9 +958,9 @@ uritemplate==4.1.1 \
     # via
     #   -r requirements/base.txt
     #   drf-spectacular
-urllib3==1.26.7 \
-    --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
-    --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
+urllib3==1.26.17 \
+    --hash=sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21 \
+    --hash=sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b
     # via
     #   -r requirements/base.txt
     #   requests

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -189,6 +189,7 @@ class SrpmComponentFactory(ComponentFactory):
     type = models.Component.Type.RPM
     namespace = models.Component.Namespace.REDHAT
     arch = "src"
+    epoch = random.randint(0, 10)
 
 
 class BinaryRpmComponentFactory(SrpmComponentFactory):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -448,11 +448,25 @@ def test_latest_components_by_streams_filter(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_released_components_filter(client, api_path):
+    """Test that the released components filter
+    gives the correct results with no duplicates in the API"""
     released_build = SoftwareBuildFactory()
     unreleased_build = SoftwareBuildFactory()
     ProductComponentRelationFactory(
-        type=ProductComponentRelation.Type.ERRATA, software_build=released_build
+        type=ProductComponentRelation.Type.ERRATA,
+        software_build=released_build,
+        build_id=released_build.build_id,
+        build_type=released_build.build_type,
     )
+    # Duplicate relations for the same build
+    # shouldn't give duplicate results in the API
+    ProductComponentRelationFactory(
+        type=ProductComponentRelation.Type.ERRATA,
+        software_build=released_build,
+        build_id=released_build.build_id,
+        build_type=released_build.build_type,
+    )
+
     ComponentFactory(name="released", software_build=released_build)
     ComponentFactory(name="unreleased", software_build=unreleased_build)
 

--- a/tests/test_app_interface.py
+++ b/tests/test_app_interface.py
@@ -112,10 +112,10 @@ def test_metadata_fetch(requests_mock):
             "repo/image",
             nullcontext(),
         ),
+        # Code works with public Quay.io instance or any internal Quay server
+        ({"tags": {"t1": {}}}, "t1", "internal.quay", "repo2/image2", nullcontext()),
         # If no tags, default to latest. nullcontext here means "no exception raised"
-        ({"tags": {}}, "latest", "quay.io", "repo2/image2", nullcontext()),
-        # Code works with public QUay.io instance or any internal Quay server
-        ({"tags": {}}, "latest", "internal.quay", "repo3/image3", nullcontext()),
+        ({"tags": {}}, "latest", "quay.io", "repo3/image3", nullcontext()),
         # Fails with no retry if the image to pull already had a tag given explicitly
         (
             {"tags": {}},

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -252,20 +252,23 @@ def test_product_manifest_excludes_internal_components():
 
 
 def test_manifest_no_duplicate_released_components():
+    """Test that the released components queryset
+    doesn't give duplicate results in manifests"""
     component, stream, _, _ = setup_products_and_components_provides()
     # Add another Errata relation type for the same build (one already created in
     # setup_product_and_components_provides)
     ProductComponentRelationFactory(
-        software_build=component.software_build, type=ProductComponentRelation.Type.ERRATA
+        software_build=component.software_build,
+        build_id=component.software_build.build_id,
+        build_type=component.software_build.build_type,
+        type=ProductComponentRelation.Type.ERRATA,
     )
 
     unique_components = set()
 
-    for c in stream.components.manifest_components():
-        if c.purl not in unique_components:
-            unique_components.add(c.purl)
-        else:
-            assert False
+    for purl in stream.components.manifest_components().values_list("purl", flat=True):
+        assert purl not in unique_components
+        unique_components.add(purl)
 
 
 def test_manifest_cpes_from_variants():

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -139,13 +139,13 @@ def test_slim_rpm_in_containers_manifest():
     assert num_components == 2, released_components
 
     provided = set()
-    # Each component has 1 node each
+    # Each released component has 1 provided component each
     for released_component in released_components:
-        component_nodes = released_component.get_provides_pks()
-        assert len(component_nodes) == 1
-        provided.update(component_nodes)
+        provided_components = released_component.get_provides_pks()
+        assert len(provided_components) == 1
+        provided.update(provided_components)
 
-    # Here we are checking that the components share a single provided component
+    # Here we are checking that all the released components share a single provided component
     num_provided = len(provided)
     assert num_provided == 1
 
@@ -160,14 +160,15 @@ def test_slim_rpm_in_containers_manifest():
     # Plus one package for the stream itself
     assert len(manifest["packages"]) == num_components + num_provided + 1
 
-    # For each provided in component, one "provided contained by component"
-    # For each provided in component, one "provided contains none" indicating a leaf node
     # For each component, one "component is package of product" relationship
+    # For each provided in component, one "provided contained by component"
+    # (only one unique provided component, but two relationships for two parent components)
     # Plus one "document describes product" relationship for the whole document at the end
     assert len(manifest["relationships"]) == num_components + (num_provided + 1) + 1
 
     provided_uuid = provided.pop()
     component = containers[0]
+    # Manifest packages are ordered by UUID, so make sure we assert on the right container
     if containers[0].uuid > containers[1].uuid:
         component = containers[1]
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This definitely fixes the Component.DoesNotExist errors we currently see in our monitoring email (confirmed by deploying to stage), and should fix the SoftwareBuild.DoesNotExist errors as well (added this commit after I had already deployed).

We still see failing tasks / can't manifest services due to other errors, which these now-fixed errors were hiding. I'll continue working on the other errors in separate PRs, but this one should be complete enough to merge.

I also have a test written for some of the new logic to parse and save component metadata that Syft discovers. I still need to write tests for the overall mangen logic. Please let me know if we should discuss our use of purls / the information we save from a Syft scan, or if I've missed anything here.