### PR TITLE
Store correct group ID and type for SBOMer purls

### DIFF
--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any
 
+from packageurl import PackageURL
+
 from corgi.core.constants import SBOMER_PRODUCT_MAP
 from corgi.core.models import Component
 
@@ -55,6 +57,10 @@ class SbomerSbom:
 
             # Declared purl
             meta_attr["purl_declared"] = component["purl"]
+
+            # Purl qualifiers
+            for qualifier, value in PackageURL.from_string(component["purl"]).qualifiers.items():
+                meta_attr[qualifier] = value
 
             # License info
             licenses = []

--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -51,6 +51,8 @@ class SbomerSbom:
             else:
                 component["namespace"] = Component.Namespace.UPSTREAM
 
+            meta_attr["group_id"] = component["group"]
+
             # Declared purl
             meta_attr["purl_declared"] = component["purl"]
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1237,18 +1237,13 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return PackageURL(type=str(self.type).lower(), **purl_data)
 
     def _build_maven_purl(self) -> dict[str, Union[str, dict[str, str]]]:
-        # Prefer some declared qualifiers to inferred qualifiers
-        declared_qualifiers = {}
-        if "purl_declared" in self.meta_attr:
-            declared_qualifiers = PackageURL.from_string(self.meta_attr["purl_declared"]).qualifiers
-
         qualifiers = {}
 
         classifier = self.meta_attr.get("classifier")
         if classifier:
             qualifiers["classifier"] = classifier
 
-        extension = declared_qualifiers.get("type") or self.meta_attr.get("type")
+        extension = self.meta_attr.get("type")
         if extension:
             qualifiers["type"] = extension
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1237,13 +1237,18 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return PackageURL(type=str(self.type).lower(), **purl_data)
 
     def _build_maven_purl(self) -> dict[str, Union[str, dict[str, str]]]:
+        # Prefer some declared qualifiers to inferred qualifiers
+        declared_qualifiers = {}
+        if "purl_declared" in self.meta_attr:
+            declared_qualifiers = PackageURL.from_string(self.meta_attr["purl_declared"]).qualifiers
+
         qualifiers = {}
 
         classifier = self.meta_attr.get("classifier")
         if classifier:
             qualifiers["classifier"] = classifier
 
-        extension = self.meta_attr.get("type")
+        extension = declared_qualifiers.get("type") or self.meta_attr.get("type")
         if extension:
             qualifiers["type"] = extension
 


### PR DESCRIPTION
A simple fix, more substantial changes to Maven purl handling to follow in CORGI-840.