### PR TITLE
CORGI-557: Add migration to fix duplicate module data (in production only)

### DIFF
--- a/corgi/core/migrations/0091_fix_duplicate_modules.py
+++ b/corgi/core/migrations/0091_fix_duplicate_modules.py
@@ -1,0 +1,91 @@
+from django.db import migrations
+
+from corgi.tasks.brew import slow_fetch_modular_build
+
+
+def fix_module_data(apps, schema_editor):
+    """Clean up duplicate modules / nodes with bad purls
+    and ensure the non-duplicated modules / nodes have all the same data"""
+    Component = apps.get_model("core", "Component")
+    ComponentNode = apps.get_model("core", "ComponentNode")
+    module_purl = "pkg:rpmmod/"
+    red_hat_module_purl = f"{module_purl}redhat/"
+
+    # Ignore RPM module components which already have the correct REDHAT namespace in their purl
+    # Fix modules which are missing the REDHAT namespace in their purl (only 15)
+    # All of them have a duplicate module with the correct purl
+    for bad_module in Component.objects.filter(purl__startswith=module_purl).exclude(
+        purl__startswith=red_hat_module_purl
+    ):
+        good_purl = bad_module.purl.replace(module_purl, red_hat_module_purl, 1)
+        good_module = Component.objects.get(purl=good_purl)
+
+        # Bad modules have either 0 or 1 cnode, good modules have exactly 1 cnode
+        bad_node = ComponentNode.objects.filter(
+            type="SOURCE", parent=None, purl=bad_module.purl
+        ).first()
+        if not bad_node:
+            # No nodes means no descendants to check for dupes / missing data
+            # So we can just delete it
+            bad_module.delete()
+            continue
+        good_node = ComponentNode.objects.get(type="SOURCE", parent=None, purl=good_purl)
+
+        bad_descendants = bad_node.get_descendants().values_list("purl", flat=True).distinct()
+        good_descendants = set(
+            good_node.get_descendants().values_list("purl", flat=True).distinct()
+        )
+
+        for descendant_purl in bad_descendants:
+            # Check to make sure the new / good module
+            # has the same (or more) data as the old / bad one
+            # If not, reprocess the good module to complete its data
+            if descendant_purl not in good_descendants:
+                slow_fetch_modular_build.delay(
+                    good_module.software_build.build_id, force_process=True
+                )
+                break
+        # Either both modules have all the same data
+        # Or the good module will have the same data, after it finishes reprocessing
+        bad_module.delete()
+
+    # Ignore component nodes for modules
+    # which already have the correct REDHAT namespace in their purl
+    # Fix nodes which are missing the REDHAT namespace in their purl (several hundred)
+    # Duplicate data prevents us from saving these nodes / updating their purls
+    # Because another node already exists with the correct / updated purl
+    # Find the duplicate node with the good purl
+    # Then reprocess the linked module, if needed, so that it has a complete set of data
+    for bad_node in ComponentNode.objects.filter(
+        type="SOURCE", parent=None, purl__startswith=module_purl
+    ).exclude(purl__startswith=red_hat_module_purl):
+        good_purl = bad_node.purl.replace(module_purl, red_hat_module_purl, 1)
+        good_node = ComponentNode.objects.get(type="SOURCE", parent=None, purl=good_purl)
+
+        bad_descendants = bad_node.get_descendants().values_list("purl", flat=True).distinct()
+        good_descendants = set(
+            good_node.get_descendants().values_list("purl", flat=True).distinct()
+        )
+
+        for descendant_purl in bad_descendants:
+            # Check to make sure the new / good module
+            # has the same (or more) data as the old / bad one
+            # If not, reprocess the good module to complete its data
+            if descendant_purl not in good_descendants:
+                slow_fetch_modular_build.delay(
+                    good_node.obj.software_build.build_id, force_process=True
+                )
+                break
+        # Either both root nodes / modules have all the same children
+        # Or the good node will have the same children, after it finishes reprocessing
+        bad_node.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0090_auto_20230926_1727"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_module_data),
+    ]

--- a/corgi/tasks/brew.py
+++ b/corgi/tasks/brew.py
@@ -219,13 +219,15 @@ def slow_fetch_modular_build(
     node, node_created = save_node(ComponentNode.ComponentNodeType.SOURCE, None, obj)
 
     any_child_created = False
-    for c in rhel_module_data.get("components", []):
+    for component in rhel_module_data.get("components", ()):
         # Request fetch of the SRPM build_ids here to ensure software_builds are created and linked
         # to the RPM components. We don't link the SRPM into the tree because some of it's RPMs
         # might not be included in the module
-        if "brew_build_id" in c:
-            slow_fetch_brew_build.delay(c["brew_build_id"])
-        any_child_created |= save_component(c, node)
+        if "brew_build_id" in component:
+            slow_fetch_brew_build.delay(
+                component["brew_build_id"], save_product=save_product, force_process=force_process
+            )
+        any_child_created |= save_component(component, node)
     slow_fetch_brew_build.delay(build_id, save_product=save_product, force_process=force_process)
     logger.info("Finished fetching modular build: %s", build_id)
     return created or node_created or any_child_created


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. I was rather dumb when I first started working on this ticket, and started exploring the data manually, then did the cleanup by hand (typing commands into a Python shell) in stage due to how many exceptions my script kept hitting. I got interrupted before I could write down the code I used, and of course I haven't had time to get back to this until now...

I think based on my memory of what I did, this migration is very similar - the implementation may be slightly different, but the affected data and the final result should be the same. I've also checked in prod (using print() statements instead of actual code) just to see what would be affected.

In prod right now, there are 15 modules (components) with no `/redhat/` in their purls. All of these appear to have almost-duplicate modules which do include `/redhat/` in their purls. 13 of the bad modules all have the same descendants as their duplicate / good modules, so they can just be deleted - we won't lose any data.

2 of the bad modules have no nodes / descendants at all, so they can also just be deleted and we don't need to worry about checking their descendants / reprocessing to avoid any missing data.

There are a few hundred root nodes (not components) for a module component which don't have `/redhat/` in their purls. But I think all of these have duplicate nodes linked to the same module. The duplicate nodes have the same parent (`None`), type (`"SOURCE"`), and almost the same purl except for the missing `/redhat/`. So we can't just fix the purl on the old / bad node and save it, because then the purl would be a duplicate of the new / good node. Two nodes with the same parent, type, and purl are not allowed and will raise an IntegrityError when you try to call `.save()`.

Most of the bad nodes have the same descendants as the good nodes, so no action is needed - the bad nodes can just be deleted and we won't lose any data.

A few of the bad nodes have descendants that the good nodes don't. In this case, I don't want to relink the missing descendants to the good nodes. It's difficult to easily tell what level of the tree they're on (connected to the root, or to a child of the root, or grandchild, etc.). So relinking them to the right node / level in the new tree is tricky. It's also possible these "missing" descendants in the new tree are really just stale data in the old tree and should be deleted.

So instead, we'll just force-reprocess the module that the good / new root node is linked to, then delete the bad / old root node. Then all the data should be correct according to the current version of our code, and we shouldn't need to worry about missing or incorrect data for any modules. Let me know if that sounds sane...

I thought we were also excluding modules from our manifests, but I was mistaken - they're only excluded from SCA. So I'm not sure why Tomas Hoger reported modules are missing in our manifests, but that's a separate bug either way (CORGI-823).