### PR TITLE
CORGI-818: add active product stream filter to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* refactored latest component filter into a pgsql stored proc
 
 ### Changed
-* added exclude_components to product_stream
-* 
+* refactored latest component filter into a pgsql stored proc
+
+### Added
+* added exclude_components to /api/v1/product_streams
+* include_inactive_streams to /api/v1/components

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -120,6 +120,11 @@ class ComponentFilter(FilterSet):
         method="filter_gomod_components",
     )
 
+    active_streams = BooleanFilter(
+        label="Show components from active streams",
+        method="filter_active_streams",
+    )
+
     @staticmethod
     def filter_gomod_components(
         qs: QuerySet[Component], _name: str, value: bool
@@ -194,6 +199,16 @@ class ComponentFilter(FilterSet):
         # Truthy values return the filtered queryset (only latest components)
         # Falsey values return the excluded queryset (only older components)
         return queryset.latest_components_by_streams(include=value)
+
+    @staticmethod
+    def filter_active_streams(
+        queryset: ComponentQuerySet, _name: str, value: bool
+    ) -> QuerySet["Component"]:
+        """Show only components from active streams when True"""
+        if value in EMPTY_VALUES:
+            # User gave an empty ?param= so return the unfiltered queryset
+            return queryset
+        return queryset.active_streams(include=value)
 
 
 class ProductDataFilter(FilterSet):

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1111,6 +1111,14 @@ class ComponentQuerySet(models.QuerySet):
         # Falsey values return the excluded queryset (only non-SRPM components)
         return self.exclude(SRPM_CONDITION)
 
+    def active_streams(self, include: bool = True) -> "ComponentQuerySet":
+        """Show only components in active product streams"""
+        if include:
+            # Truthy values return the filtered queryset (only components in active streams)
+            return self.filter(productstreams__active=True).distinct()
+        # Falsey values return the excluded queryset (only components in no active streams)
+        return self.exclude(productstreams__active=True).distinct()
+
 
 class Component(TimeStampedModel, ProductTaxonomyMixin):
     class Type(models.TextChoices):

--- a/openapi.yml
+++ b/openapi.yml
@@ -301,6 +301,11 @@ paths:
       description: View for api/v1/components
       parameters:
       - in: query
+        name: active_streams
+        schema:
+          type: boolean
+        description: Show components from active streams
+      - in: query
         name: arch
         schema:
           type: string


### PR DESCRIPTION
Filtering components to just those components in active product streams makes the search domain smaller and the first step in addressing CORGI-818. 

A few open questions:

* Is **active** the right url param name (alternately we could make it more explicit eg. **active_product_streams**)
* Do we want to match semantics of product_streams ex. _product_streams?active=all_  though it seems odd to union boolean with scalar value 'all'
* Do we want to emulate latest components semantics when set to False (eg. exclude active components) ? 
* What sort do we impose ?
