### PR TITLE
CORGI-621: Fix NEVRA, NVR formatting when version, release both empty "" strings

### DIFF
--- a/corgi/core/migrations/0096_fix_nevra_formatting.py
+++ b/corgi/core/migrations/0096_fix_nevra_formatting.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+from django.db.models import F, Value, functions
+
+
+def fix_nevra_nvr_data(apps, schema_editor):
+    """Clean up components where the NEVRA or NVR ends with a dash, or a dash then dot"""
+    Component = apps.get_model("core", "Component")
+
+    # arch is not present in the NEVRA for this component type (whatever it may be)
+    # This returns results, but shouldn't, since our code always adds arch to the NEVRA
+    # even when arch="noarch", regardless of component type. I don't "fix" this here
+    # to preserve the original NEVRA in case there's a reason for this (maybe a Syft NEVRA?)
+    Component.objects.filter(
+        nevra__endswith="-", epoch=0, version="", release="", arch="noarch"
+    ).update(nvr=F("name"), nevra=F("name"))
+
+    # arch is present in the NEVRA for this component type (whatever it may be)
+    Component.objects.filter(
+        nevra__endswith="-.noarch", epoch=0, version="", release="", arch="noarch"
+    ).update(nvr=F("name"), nevra=functions.Concat(F("name"), Value(".noarch")))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0095_clean_rpmlint_invalid_syft_deps"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_nevra_nvr_data),
+    ]

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1630,15 +1630,21 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return self.type == Component.Type.RPM and self.arch == "src"
 
     def get_nvr(self) -> str:
+        # Many GOLANG components don't have a version or release set
+        # so don't return an oddly formatted NVR, like f"{name}-"
+        version = f"-{self.version}" if self.version else ""
         release = f"-{self.release}" if self.release else ""
-        return f"{self.name}-{self.version}{release}"
+        return f"{self.name}{version}{release}"
 
     def get_nevra(self) -> str:
         epoch = f":{self.epoch}" if self.epoch else ""
+        # Many GOLANG components don't have a version or release set
+        # so don't return an oddly formatted NEVRA, like f"{name}-.{arch}"
+        version = f"-{self.version}" if self.version else ""
         release = f"-{self.release}" if self.release else ""
         arch = f".{self.arch}" if self.arch else ""
 
-        return f"{self.name}{epoch}-{self.version}{release}{arch}"
+        return f"{self.name}{epoch}{version}{release}{arch}"
 
     def _build_repo_url_for_type(self) -> str:
         """Get an upstream repo URL based on a purl"""


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review this nice, simple fix for a formatting error. There's also a migration that should fix the existing data, but I'm not sure about the logic in one query.