### PR TITLE
CORGI-843 container errata builds

### DIFF
--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -262,13 +262,6 @@ class ErrataTool:
         shipped_live = errata_type_details[0]["status"] == "SHIPPED_LIVE"
         return erratum_id, shipped_live
 
-    def get_builds_for_errata(self, errata_id: int) -> list[int]:
-        build_ids = set()
-        for variant in self.get_erratum_components(str(errata_id)).values():
-            for component in variant:
-                build_ids.update(component.keys())
-        return list(build_ids)
-
     def _parse_module(
         self,
         module_name: str,

--- a/corgi/collectors/errata_tool.py
+++ b/corgi/collectors/errata_tool.py
@@ -26,6 +26,7 @@ class ErrataTool:
     """Interface to the Errata Tool APIs."""
 
     GSSAPI_AUTH = HTTPSPNEGOAuth()
+    SHIPPED_LIVE_SEARCH = "show_state_SHIPPED_LIVE=1"
 
     def __init__(self):
         self.session = requests.Session()
@@ -45,7 +46,7 @@ class ErrataTool:
     def get_paged(
         self, path: str, page_data_attr: str = "data", pager: str = "page[number]"
     ) -> list[dict[str, Any]]:
-        """Generator to iterate over data from paged Errata Tool API endpoint."""
+        """Iterate over data from paged Errata Tool API endpoint."""
         params = {pager: 1}
         data: list[dict[str, Any]] = []
         while True:
@@ -321,13 +322,41 @@ class ErrataTool:
             product["product_versions"] = product_versions
         return products
 
+    def _do_errata_search(
+        self, search_values: str, product_variants: list[str], container_only: bool = False
+    ) -> list[int]:
+        if not search_values:
+            raise ValueError("search_values cannot be an empty string")
+        if container_only:
+            search_values += "&content_type[]=docker"
+        product_errata = self.get_paged(f"api/v1/erratum/search?{search_values}")
+        all_errata: set[int] = set()
+        for erratum in product_errata:
+            logger.debug(f"Found shipped erratum {erratum['id']}")
+            # If we are passed a list of variants, check that there are builds matching those
+            # variants on the erratum before returning that erratum_id
+            if not product_variants:
+                all_errata.add(erratum["id"])
+                continue
+            is_rpm = "rpm" in erratum["content_types"]
+            builds_url = self._get_url_by_erratum_type(erratum["id"], is_rpm)
+            builds = self.get(builds_url)
+            for product_version in builds.values():
+                for build in product_version["builds"]:
+                    for build_data in build.values():
+                        for variant in build_data["variant_arch"].keys():
+                            if variant in product_variants:
+                                logger.info(f"Found variant {variant} in {erratum['id']}")
+                                all_errata.add(erratum["id"])
+        return list(all_errata)
+
     def get_errata_matching_variants(
         self, product_variants: list[str], container_only: bool = False
-    ) -> set[str]:
-        """Given a list of variants in a single ET product, find all errata shipping builds to those
+    ) -> list[int]:
+        """Given a list of variants in a single ET product, load all errata shipping builds to those
         variants"""
         if not product_variants:
-            return set()
+            return []
         product_ids = set()
         for et_variant in CollectorErrataProductVariant.objects.filter(name__in=product_variants):
             variant_version = et_variant.product_version
@@ -336,28 +365,22 @@ class ErrataTool:
         # make sure there is only 1 product id for the given variants
         if len(product_ids) > 1:
             raise ValueError(f"Variants had more than 1 product id. Found: {product_ids}")
-
+        elif len(product_ids) == 0:
+            raise ValueError(f"Variants passed do not exist in DB: {product_variants}")
         product_id = product_ids.pop()
         logger.info(f"Searching shipped errata for product with id {product_id}")
         # Unfortunately we can't use the variant id directly here
-        search_values = f"show_state_SHIPPED_LIVE=1&product[]={product_id}"
-        if container_only:
-            search_values += "&content_type[]=docker"
-        product_errata = self.get_paged(
-            f"api/v1/erratum/search?{search_values}",
-            page_data_attr="data",
-        )
+        search_values = f"{self.SHIPPED_LIVE_SEARCH}&product[]={product_id}"
+        return self._do_errata_search(search_values, product_variants, container_only)
 
-        all_errata: set[str] = set()
-        for erratum in product_errata:
-            logger.info(f"Found shipped erratum {erratum['id']}")
-            is_rpm = "rpm" in erratum["content_types"]
-            builds = self.get(self._get_url_by_erratum_type(erratum["id"], is_rpm))
-            for product_version in builds.values():
-                for build in product_version["builds"]:
-                    for _, build_data in build.items():
-                        for variant in build_data["variant_arch"].keys():
-                            if variant in product_variants:
-                                logger.info(f"Found variant {variant} in {erratum['id']}")
-                                all_errata.add(str(erratum["id"]))
-        return all_errata
+    def get_errata_for_releases(
+        self, releases: list[int], container_only: bool = False
+    ) -> set[int]:
+        all_errata: set[int] = set()
+        if not releases:
+            return all_errata
+        search = self.SHIPPED_LIVE_SEARCH
+        for release in releases:
+            search += f"&release[]={release}"
+        # When doing a search for errata by releases, don't filter by product_variants
+        return set(self._do_errata_search(search, [], container_only))

--- a/corgi/core/migrations/0101_load_missing_container_errata_builds.py
+++ b/corgi/core/migrations/0101_load_missing_container_errata_builds.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+from corgi.tasks.errata_tool import (
+    slow_load_stream_errata as current_load_stream_errata,
+)
+from corgi.tasks.prod_defs import update_products
+from corgi.tasks.tagging import NO_MANIFEST_TAG
+
+
+def load_missing_container_errata_build(apps, schema_editor):
+    ProductStream = apps.get_model("core", "ProductStream")
+
+    # pre-load products to make sure variants_from_brew_tags and releases_from_brew_tags are updated
+    update_products()
+
+    for stream_name in (
+        ProductStream.objects.exclude(components__isnull=True)
+        .exclude(tags__name=NO_MANIFEST_TAG)
+        .exclude(brew_tags={})
+        .values_list("name", flat=True)
+    ):
+        current_load_stream_errata.delay(stream_name, container_only=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0100_fix_duplicate_sbomer_components"),
+    ]
+
+    operations = [
+        migrations.RunPython(load_missing_container_errata_build),
+    ]

--- a/corgi/core/migrations/0102_fix_duplicate_rpms.py
+++ b/corgi/core/migrations/0102_fix_duplicate_rpms.py
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
     # and will take forever, so we need to pick up where we left off after timeouts
     atomic = False
     dependencies = [
-        ("core", "0100_fix_duplicate_sbomer_components"),
+        ("core", "0101_load_missing_container_errata_builds"),
     ]
 
     operations = [

--- a/corgi/core/migrations/0103_fix_duplicate_remote_source_components.py
+++ b/corgi/core/migrations/0103_fix_duplicate_remote_source_components.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
     # and will take forever, so we need to pick up where we left off after timeouts
     atomic = False
     dependencies = [
-        ("core", "0101_fix_duplicate_rpms"),
+        ("core", "0102_fix_duplicate_rpms"),
     ]
 
     operations = [

--- a/corgi/tasks/management/commands/loaderratadata.py
+++ b/corgi/tasks/management/commands/loaderratadata.py
@@ -3,7 +3,6 @@ import sys
 from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.collectors.errata_tool import ErrataTool
-from corgi.collectors.models import CollectorErrataProductVariant
 from corgi.tasks.errata_tool import slow_load_errata
 from corgi.tasks.pulp import update_cdn_repo_channels
 
@@ -58,48 +57,9 @@ class Command(BaseCommand):
                 update_cdn_repo_channels.delay()
         elif options["product_variants"]:
             et = ErrataTool()
-            product_ids = set()
-            for et_variant in CollectorErrataProductVariant.objects.filter(
-                name__in=options["product_variants"]
-            ):
-                variant_version = et_variant.product_version
-                if variant_version:
-                    product_ids.add(variant_version.product.et_id)
-            # make sure there is only 1 product id for the names
-            if len(product_ids) > 1:
-                self.stderr.write(
-                    self.style.ERROR(f"Variants had more than 1 product id. Found: {product_ids}")
-                )
-                sys.exit(1)
 
-            product_id = product_ids.pop()
-            self.stdout.write(
-                self.style.SUCCESS(f"Searching shipped errata for product with id {product_id}")
-            )
-            # TODO switch this to use releases instead of Product
-            product_errata = et.get_paged(
-                f"api/v1/erratum/search?show_state_SHIPPED_LIVE=1&product[]={product_id}",
-                page_data_attr="data",
-            )
-            all_errata: set[str] = set()
-            for product_erratum in product_errata:
-                self.stdout.write(
-                    self.style.SUCCESS(f"Found shipped erratum {product_erratum['id']}")
-                )
-                builds = et.get(f"api/v1/erratum/{product_erratum['id']}/builds_list.json")
-                for product_version in builds.values():
-                    for build in product_version["builds"]:
-                        for _, build_data in build.items():
-                            for variant in build_data["variant_arch"].keys():
-                                if variant in options["product_variants"]:
-                                    self.stdout.write(
-                                        self.style.SUCCESS(
-                                            f"Found variant {variant} in {product_erratum['id']}"
-                                        )
-                                    )
-                                    all_errata.add(str(product_erratum["id"]))
-
-            for erratum in all_errata:
+            errata = et.get_errata_matching_variants(options["product_variants"])
+            for erratum in errata:
                 self.stdout.write(self.style.SUCCESS(f"Loading erratum: {erratum}"))
                 slow_load_errata.delay(erratum, force_process=options["force"])
 

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -12,6 +12,7 @@ from corgi.collectors.errata_tool import BREW_TAG_CANDIDATE_SUFFIX
 from corgi.collectors.models import (
     CollectorErrataProductVariant,
     CollectorErrataProductVersion,
+    CollectorErrataRelease,
 )
 from corgi.collectors.prod_defs import ProdDefs
 from corgi.core.models import (
@@ -214,6 +215,37 @@ def parse_product_version(
         _match_and_save_stream_cpes(product_version)
 
 
+def _parse_variants_from_brew_tags(brew_tags) -> list[str]:
+    """We don't link core ProductVariant models to streams via brew_tags because it results in too
+    many builds being linked to the stream. These variants should include all possible builds that
+    could match the stream. We use them for finding which errata match this stream, so it's OK to
+    find too many errata"""
+    variant_names: set[str] = set()
+    for brew_tag in brew_tags:
+        trimmed_brew_tag, sans_container_released = brew_tag_to_et_prefixes(brew_tag)
+        variants = CollectorErrataProductVersion.objects.filter(
+            brew_tags__overlap=[trimmed_brew_tag, sans_container_released]
+        ).values_list("variants__name", flat=True)
+        variant_names.update(variants)
+    return list(variant_names)
+
+
+def _parse_releases_from_brew_tags(brew_tags) -> list[int]:
+    """Match releases using stream brew tags"""
+    release_ids: set[int] = set()
+    for brew_tag in brew_tags:
+        trimmed_brew_tag, sans_container_released = brew_tag_to_et_prefixes(brew_tag)
+        releases = (
+            CollectorErrataRelease.objects.filter(
+                brew_tags__overlap=[trimmed_brew_tag, sans_container_released]
+            )
+            .values_list("et_id", flat=True)
+            .distinct()
+        )
+        release_ids.update(releases)
+    return list(release_ids)
+
+
 def parse_product_stream(
     pd_product_stream: dict[str, Any],
     product: Product,
@@ -239,6 +271,10 @@ def parse_product_stream(
         version = match_version.group()
 
     cpes_from_brew_tags = _parse_cpes_from_brew_tags(brew_tags_dict, name, product_version.name)
+    brew_tag_names = brew_tags_dict.keys()
+    # TODO move these to ProductStream attributes?
+    pd_product_stream["variants_from_brew_tags"] = _parse_variants_from_brew_tags(brew_tag_names)
+    pd_product_stream["releases_from_brew_tags"] = _parse_releases_from_brew_tags(brew_tag_names)
 
     logger.debug("Creating or updating Product Stream: name=%s", name)
 
@@ -270,7 +306,7 @@ def parse_product_stream(
     parse_errata_info(errata_info, product, product_stream, product_stream_node, product_version)
     if not stream_created:
         _clean_orphaned_relations_and_builds(
-            set(brew_tags_dict.keys()),
+            set(brew_tag_names),
             name,
             str(product_stream.pk),
             ProductComponentRelation.Type.BREW_TAG,

--- a/corgi/tasks/tagging.py
+++ b/corgi/tasks/tagging.py
@@ -5,6 +5,8 @@ from config.celery import app
 from corgi.core.models import Product, ProductStream, ProductStreamTag, ProductVersion
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
+NO_MANIFEST_TAG = "no_manifest"
+
 logger = get_task_logger(__name__)
 
 
@@ -14,11 +16,9 @@ logger = get_task_logger(__name__)
     retry_kwargs=RETRY_KWARGS,
 )
 def apply_stream_no_manifest_tags():
-    tag_name = "no_manifest"
-    tag_value = ""
-    apply_middleware_stream_no_manifest_tags(tag_name, tag_value)
-    apply_rhel_8_9_z_stream_no_manifest_tags(tag_name, tag_value)
-    apply_managed_services_no_manifest_tags(tag_name, tag_value)
+    apply_middleware_stream_no_manifest_tags(NO_MANIFEST_TAG, "")
+    apply_rhel_8_9_z_stream_no_manifest_tags(NO_MANIFEST_TAG, "")
+    apply_managed_services_no_manifest_tags(NO_MANIFEST_TAG, "")
 
 
 def apply_middleware_stream_no_manifest_tags(tag_name: str, tag_value: str) -> None:

--- a/tests/data/errata/errata_container_builds.json
+++ b/tests/data/errata/errata_container_builds.json
@@ -1,0 +1,25 @@
+{
+  "RHEL-8-RHACM-2.4": {
+    "name": "RHEL-8-RHACM-2.4",
+    "description": "Red Hat Advanced Cluster Management for Kubernetes 2.4 for RHEL 8",
+    "builds": [
+      {
+        "multiclusterhub-repo-container-v2.4.6-7": {
+          "nvr": "multiclusterhub-repo-container-v2.4.6-7",
+          "nevr": "multiclusterhub-repo-container-0:v2.4.6-7",
+          "id": 2177946,
+          "is_module": false,
+          "variant_arch": {
+            "8Base-RHACM-2.4": {
+              "multi": [
+                "docker-image-sha256:79c31323551c48813ad5fadfabfa164450422148098343b4d6122f7d6c22fd7b.x86_64.tar.gz",
+                "docker-image-sha256:3132fbf348680f0196db5967d206480ee90748174eace7131ea92ed52a6f8df5.s390x.tar.gz",
+                "docker-image-sha256:add9b314e46ac6b6604cdb5b745d3124562a651124be81f6a5d7938b002e7f8e.ppc64le.tar.gz"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/data/errata/search_results.json
+++ b/tests/data/errata/search_results.json
@@ -1,0 +1,21 @@
+{
+  "data": [
+    {
+      "id": 121542,
+      "content_types": [
+        "docker"
+      ]
+    },
+    {
+      "id": 122119,
+      "content_types": [
+        "rpm"
+      ]
+    }
+  ],
+  "page": {
+    "current_page": 1,
+    "total_pages": 1,
+    "result_count": 2
+  }
+}

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -1,6 +1,7 @@
 import pytest
 
 from corgi.tasks.tagging import (
+    NO_MANIFEST_TAG,
     apply_managed_services_no_manifest_tags,
     apply_middleware_stream_no_manifest_tags,
     apply_rhel_8_9_z_stream_no_manifest_tags,
@@ -13,9 +14,9 @@ pytestmark = pytest.mark.unit
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_rhel_8_9_no_manifest_tagging():
     stream, _ = setup_product(version_name="rhel-8", stream_name="rhel-8.1.0.z")
-    apply_rhel_8_9_z_stream_no_manifest_tags("no_manifest", True)
+    apply_rhel_8_9_z_stream_no_manifest_tags(NO_MANIFEST_TAG, True)
     stream.refresh_from_db()
-    assert "no_manifest" in stream.tags.values_list("name", flat=True)
+    assert NO_MANIFEST_TAG in stream.tags.values_list("name", flat=True)
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -24,9 +25,9 @@ def test_middleware_no_manifest_tag():
     product = stream.products
     product.meta_attr["business_unit"] = "Core Middleware"
     product.save()
-    apply_middleware_stream_no_manifest_tags("no_manifest", True)
+    apply_middleware_stream_no_manifest_tags(NO_MANIFEST_TAG, True)
     stream.refresh_from_db()
-    assert "no_manifest" in stream.tags.values_list("name", flat=True)
+    assert NO_MANIFEST_TAG in stream.tags.values_list("name", flat=True)
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
@@ -34,6 +35,6 @@ def test_managed_service_no_manifest_tag():
     stream, _ = setup_product()
     stream.meta_attr["managed_service_components"] = {"name": "test"}
     stream.save()
-    apply_managed_services_no_manifest_tags("no_manifest", True)
-    stream.refresh_from_db
-    assert "no_manifest" in stream.tags.values_list("name", flat=True)
+    apply_managed_services_no_manifest_tags(NO_MANIFEST_TAG, True)
+    stream.refresh_from_db()
+    assert NO_MANIFEST_TAG in stream.tags.values_list("name", flat=True)


### PR DESCRIPTION
This might be easier to review commit-wise. It's a fairly small change to the ErrataTool collector to use a different url for non-rpm Errata. It also adds a migration which finds all streams with brew_tags and tries reloads their errata. I limited it to streams with brew_tags as they are the ones with released container errata.

I wanted to reuse some existing code from the prod_defs task and loaderratadata management command so I refactored some functions there so I could call them from the migration.