### PR TITLE
Latest filter regressions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ sonarqube:
 test:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1
@@ -105,7 +105,7 @@ test:
 test-migrations:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1
@@ -131,7 +131,7 @@ test-migrations:
 test-performance:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   before_script:
     - *common_ci_setup
     - *common_test_setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi:9.2
+FROM registry.redhat.io/ubi9/ubi
 
 ARG PIP_INDEX_URL="https://pypi.org/simple"
 ENV PYTHONUNBUFFERED=1 \

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -254,6 +254,7 @@ class ComponentFilter(FilterSet):
         return queryset.root_components().latest_components(
             model_type=model_type,
             ofuri=value,
+            include_inactive_streams=True,
         )
 
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -2,7 +2,7 @@ import logging
 import re
 import uuid as uuid
 from abc import abstractmethod
-from typing import Any, Iterator, Union
+from typing import Any, Iterable, Iterator, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -902,35 +902,14 @@ def get_product_details(variant_names: tuple[str], stream_names: list[str]) -> d
 class ComponentQuerySet(models.QuerySet):
     """Helper methods to filter QuerySets of Components"""
 
-    def latest_components(
-        self,
-        model_type: str = "ProductStream",
-        ofuri: str = "",
-        include: bool = True,
-        include_inactive_streams=False,
-        include_non_root_components=False,
-    ) -> "ComponentQuerySet":
-        """Return an ofuri's components from latest builds across all product streams."""
-
-        # the concept of 'latest component' is only relevent within product boundaries
-        # we want to constrain by product type/ofuri which is why we pass in model_type and ofuri
-        # into the get_latest_component stored proc annotation
-
-        components = self
-        if not (include_non_root_components):
-            components = (
-                components.select_related("software_build")
-                .prefetch_related("productstreams")
-                .root_components()
-                .using("read_only")
-            )
-        if ofuri:
-            components = components.filter(productstreams__ofuri=ofuri).distinct()
-
-        latest_components_uuids = set(
+    @staticmethod
+    def _latest_components_func(
+        components: "ComponentQuerySet", model_type: str, ofuri: str, include_inactive_streams: bool
+    ) -> Iterable[str]:
+        return (
             components.values("name", "namespace")
-            .order_by("name")  # required to avoid cross-join fun
-            .distinct("name", "namespace")
+            .order_by()  # required to avoid cross-join fun
+            .distinct()
             .annotate(
                 latest_version=Func(
                     Value(model_type),
@@ -943,102 +922,97 @@ class ComponentQuerySet(models.QuerySet):
                 )
             )
             .values_list("latest_version", flat=True)
-            .using("read_only")
+        )
+
+    def latest_components(
+        self,
+        ofuri: str,
+        model_type: str = "ProductStream",
+        include: bool = True,
+        include_inactive_streams=False,
+    ) -> "ComponentQuerySet":
+        """Return components from latest builds in a single stream."""
+
+        # the concept of 'latest component' is only relevant within product boundaries
+        # we want to constrain by product type/ofuri which is why we pass in model_type and ofuri
+        # into the get_latest_component stored proc annotation
+
+        components = (
+            self.root_components()
+            .select_related("software_build")
+            # TODO: What if model_type isn't ProductStream?
+            .prefetch_related("productstreams")
+            .filter(productstreams__ofuri=ofuri)
+        )
+
+        latest_components_uuids = set(
+            self._latest_components_func(components, model_type, ofuri, include_inactive_streams)
         )
 
         if latest_components_uuids:
+            lookup = {"pk__in": latest_components_uuids}
             if include:
-                return (
-                    components.filter(pk__in=latest_components_uuids)
-                    .order_by("name", "type", "arch", "version", "release")
-                    .distinct()
-                    .using("read_only")
-                )
+                components = components.filter(**lookup)
             else:
-                return (
-                    components.exclude(pk__in=latest_components_uuids)
-                    .order_by("name")
-                    .distinct()
-                    .using("read_only")
-                )
+                components = components.exclude(**lookup)
+            return components.order_by().distinct()
+
         else:
-            # Don't modify the ComponentQuerySet
-            return self
+            if include:
+                # no latest components, don't do any further filtering
+                return Component.objects.none()
+            else:
+                # Show only the older / non-latest components
+                # But there are no latest components to hide??
+                # So show everything / return unfiltered queryset
+                return self
 
     def latest_components_by_streams(
         self,
         include: bool = True,
         include_inactive_streams=False,
-        include_non_root_components=False,
     ) -> "ComponentQuerySet":
         """Return only root components from latest builds for each product stream."""
-        components = self
-        if not (include_non_root_components):
-            components = (
-                components.select_related("software_build")
-                .prefetch_related("productstreams")
-                .root_components()
-                .using("read_only")
-            )
-        if not (include_inactive_streams):
-            components = (
-                components.filter(productstreams__active=True).distinct().using("read_only")
-            )
+        components = (
+            self.root_components()
+            .select_related("software_build")
+            .prefetch_related("productstreams")
+        )
+        if not include_inactive_streams:
+            components = components.filter(productstreams__active=True).order_by().distinct()
         product_stream_ofuris = set(
             (
                 components.values_list("productstreams__ofuri", flat=True)
                 # Clear ordering inherited from parent Queryset, if any
                 # So .distinct() works properly and doesn't have duplicates
-                .order_by()
-                .distinct()
-                .using("read_only")
+                .order_by().distinct()
             )
         )
         # aggregate up all latest component uuids across all matched product streams
-        latest_components_uuids = set()
+        latest_components_uuids: set[str] = set()
         for ps_ofuri in product_stream_ofuris:
             latest_components_uuids.update(
-                components.filter(productstreams__ofuri=ps_ofuri)
-                .values("name", "namespace")
-                .order_by("name")  # required to avoid cross-join fun
-                .distinct("name", "namespace")
-                .annotate(
-                    latest_version=Func(
-                        Value("ProductStream"),  # always ProductStream model type
-                        Value(ps_ofuri),
-                        F("namespace"),
-                        F("name"),
-                        Value(include_inactive_streams),
-                        function="get_latest_component",
-                        output_field=models.UUIDField(),
-                    )
+                self._latest_components_func(
+                    components.filter(productstreams__ofuri=ps_ofuri),
+                    "ProductStream",  # always ProductStream model type
+                    ps_ofuri,
+                    include_inactive_streams,
                 )
-                .values_list("latest_version", flat=True)
-                .using("read_only")
             )
+        lookup = {"pk__in": latest_components_uuids}
         if include:
             # Show only the latest components
             if not latest_components_uuids:
                 # no latest components, don't do any further filtering
                 return Component.objects.none()
-            return (
-                components.filter(pk__in=latest_components_uuids)
-                .order_by("name", "type", "arch", "version", "release")
-                .distinct()
-                .using("read_only")
-            )
+            return components.filter(**lookup).order_by().distinct()
         else:
             # Show only the older / non-latest components
             if not latest_components_uuids:
                 # No latest components to hide??
                 # So show everything / return unfiltered queryset
                 return self
-            return (
-                components.exclude(pk__in=latest_components_uuids)
-                .order_by("name")
-                .distinct()
-                .using("read_only")
-            )
+            return components.exclude(**lookup).order_by().distinct()
 
     def released_components(self, include: bool = True) -> "ComponentQuerySet":
         """Show only released components by default, or unreleased components if include=False"""
@@ -1075,7 +1049,7 @@ class ComponentQuerySet(models.QuerySet):
         # Falsey values return the filtered queryset (only internal components)
         return self.filter(redhat_com_query)
 
-    def manifest_components(self, ofuri: str = "", quick=False) -> "ComponentQuerySet":
+    def manifest_components(self, ofuri: str, quick=False) -> "ComponentQuerySet":
         """filter latest components takes a long time, dont bother with that if we're just
         checking there is anything to manifest"""
         non_container_source_components = self.exclude(name__endswith="-container-source").using(
@@ -1089,16 +1063,9 @@ class ComponentQuerySet(models.QuerySet):
         if not quick:
             # Only filter when we're actually generating a manifest
             # not when checking if there are components to manifest, since it's slow
-            if ofuri:
-                roots = (
-                    roots.latest_components(
-                        model_type="ProductStream", ofuri=ofuri, include_inactive_streams=True
-                    )
-                    .order_by("pk")
-                    .distinct("pk")
-                )
-            else:
-                roots = roots.latest_components()
+            roots = roots.latest_components(
+                model_type="ProductStream", ofuri=ofuri, include_inactive_streams=True
+            )
 
         # Order by UUID to give stable results in manifests
         # Other querysets should not define an ordering

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -37,7 +37,7 @@ def cpu_update_ps_manifest(product_stream: str):
     # file has been modified before obtaining the updated copy.
     # collectstatic does not modify a file in staticfiles directory if it
     # hasn't been updated in outputfiles.
-    if ps.components.manifest_components(quick=True).exists():
+    if ps.components.manifest_components(quick=True, ofuri=ps.ofuri).exists():
         logger.info(f"Generating manifest for {product_stream}")
         with open(f"{settings.STATIC_ROOT}/{product_stream}-{ps.pk}.json", "w") as fh:
             fh.write(ps.manifest)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,7 +224,7 @@ def test_latest_components_by_streams_filter(client, api_path, stored_proc):
     # plus 2 non-RPMs components per name for src architecture only, 4 PyPI packages total
     # Overall 20 components, and latest filter should show 10 (newer, when on or older, when off)
     components = {}
-    stream = ProductStreamFactory(active=True)
+    stream = ProductStreamFactory()
     for name in "red", "blue":
         for arch in "aarch64", "x86_64", "src":
             older_component = ComponentFactory(
@@ -406,17 +406,9 @@ def test_latest_components_by_streams_filter(client, api_path, stored_proc):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_by_streams_filter_with_multiple_products(client, api_path, stored_proc):
-    ps1 = ProductStreamFactory(
-        name="rhel-7",
-        version="7",
-        active=True,
-    )
+    ps1 = ProductStreamFactory(name="rhel-7", version="7")
     assert ps1.ofuri == "o:redhat:rhel:7"
-    ps2 = ProductStreamFactory(
-        name="rhel-8",
-        version="8",
-        active=True,
-    )
+    ps2 = ProductStreamFactory(name="rhel-8", version="8")
     assert ps2.ofuri == "o:redhat:rhel:8"
 
     # Only belongs to RHEL7 stream
@@ -1183,23 +1175,11 @@ def test_api_component_400(client, api_path):
 def test_product_components_ofuri(client, api_path, stored_proc):
     """test 'latest' filter on components"""
 
-    ps1 = ProductStreamFactory(
-        name="rhel-8.6.0",
-        version="8.6.0",
-        active=True,
-    )
+    ps1 = ProductStreamFactory(name="rhel-8.6.0", version="8.6.0")
     assert ps1.ofuri == "o:redhat:rhel:8.6.0"
-    ps2 = ProductStreamFactory(
-        name="rhel-8.6.0.z",
-        version="8.6.0.z",
-        active=True,
-    )
+    ps2 = ProductStreamFactory(name="rhel-8.6.0.z", version="8.6.0.z")
     assert ps2.ofuri == "o:redhat:rhel:8.6.0.z"
-    ps3 = ProductStreamFactory(
-        name="rhel-8.5.0",
-        version="8.5.0",
-        active=True,
-    )
+    ps3 = ProductStreamFactory(name="rhel-8.5.0", version="8.5.0")
     assert ps3.ofuri == "o:redhat:rhel:8.5.0"
 
     old_openssl = SrpmComponentFactory(name="openssl", version="1.1.1k", release="5.el8_5")
@@ -1243,9 +1223,9 @@ def test_product_components_ofuri(client, api_path, stored_proc):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_components_versions(client, api_path, stored_proc):
-    ps1 = ProductStreamFactory(name="rhel-7", version="7", active=True)
+    ps1 = ProductStreamFactory(name="rhel-7", version="7")
     assert ps1.ofuri == "o:redhat:rhel:7"
-    ps2 = ProductStreamFactory(name="rhel-8", version="8", active=True)
+    ps2 = ProductStreamFactory(name="rhel-8", version="8")
     assert ps2.ofuri == "o:redhat:rhel:8"
 
     openssl = ComponentFactory(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -459,6 +459,7 @@ def test_latest_components_by_streams_filter_with_multiple_products(client, api_
     # Report newest_component as the latest for the RHEL8 stream
     # Even though both have the same name / only one is latest overall
     assert response["results"][0]["nevra"] == newer_component.nevra
+    assert response["results"][1]["nevra"] == newest_component.nevra
 
     response = client.get(f"{api_path}/components?latest_components_by_streams=False")
     assert response.status_code == 200

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -210,7 +210,7 @@ def test_product_manifest_excludes_unreleased_components(stored_proc):
     manifest = json.loads(stream.manifest)
 
     # No released components linked to this product
-    num_components = len(stream.components.manifest_components())
+    num_components = len(stream.components.manifest_components(ofuri=stream.ofuri))
     assert num_components == 0
 
     num_provided = len(stream.provides_queryset)
@@ -272,7 +272,9 @@ def test_manifest_no_duplicate_released_components():
 
     unique_components = set()
 
-    for purl in stream.components.manifest_components().values_list("purl", flat=True):
+    for purl in stream.components.manifest_components(ofuri=stream.ofuri).values_list(
+        "purl", flat=True
+    ):
         assert purl not in unique_components
         unique_components.add(purl)
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review (probably commit-by-commit is easiest). There are several changes here:

1. Make sure that the ?ofuri= parameter in the API continues to work, even when the stream the user gave is inactive

2. Make the ofuri= parameter in the latest_components() queryset and manifest_components() queryset required, since we no longer support calling these without a stream

3. Reuse code between the latest_components() and latest_components_by_streams() querysets

4. Return the correct number of results in the latest_components() queryset when the include= parameter is set to True but there are no latest components

5. Fix usages of .using(), .order_by(), and .distinct() that could give incorrect results. DB routing and ordering should generally be applied in the API at the ViewSet level.

These parameters should not be defined as part of individual QuerySets, since they are reused in multiple places with different ordering / DB requirements. For example, read-only API code vs. writable API code and Celery task code require different DBs.

There are also some notes I've added to tests:
1. Unshipped components not part of any stream no longer appear in the "latest_components" queryset, even when the ofuri given is an empty "" string and the include_inactive_streams= parameter is set to True.

This may or may not impact OpenLCS and certain other users. If this is expected and not a bug, please let me know and I'll add a note to the CHANGELOG.md

2. We hide results or choose the wrong result (wrong 1 of N choices) in the API when two components have the same namespace and name. This can happen e.g. for source RPMs and their related RPM modules, which have two different type=RPM&arch=src / type=RPMMOD&arch=noarch type / arch pairs, respectively, for the same name.

In the previous latest filter code, we grouped by type, namespace, name, and arch first to avoid showing incorrect results, then picked the latest epoch + version + release from each group.