### PR TITLE
CORGI-818: Add back type arch latest filters

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ sonarqube:
 test:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1
@@ -103,7 +103,7 @@ test:
 test-migrations:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   services:
     # Keep in sync with OpenShift
     - name: registry.redhat.io/rhel8/postgresql-13:1
@@ -129,7 +129,7 @@ test-migrations:
 test-performance:
   stage: test
   # Keep in sync with Dockerfile
-  image: registry.redhat.io/ubi9/ubi:9.2
+  image: registry.redhat.io/ubi9/ubi
   before_script:
     - *common_ci_setup
     - *common_test_setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * added exclude_components to /api/v1/product_streams
 * include_inactive_streams to /api/v1/components
+* added provides_name to /api/v1/components
+* added upstreams_name to /api/v1/components
+* added sources_name to /api/v1/components
+* added re_provides_name to /api/v1/components
+* added re_upstreams_name to /api/v1/components
+* added re_sources_name to /api/v1/components

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi:9.2
+FROM registry.redhat.io/ubi9/ubi
 
 ARG PIP_INDEX_URL="https://pypi.org/simple"
 ENV PYTHONUNBUFFERED=1 \

--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -254,6 +254,7 @@ class ComponentFilter(FilterSet):
         return queryset.root_components().latest_components(
             model_type=model_type,
             ofuri=value,
+            include_inactive_streams=True,
         )
 
 

--- a/corgi/core/migrations/0099_add_type_arch_stored_proc_filter.py
+++ b/corgi/core/migrations/0099_add_type_arch_stored_proc_filter.py
@@ -1,0 +1,151 @@
+# flake8: noqa W291 E501
+from django.db import migrations
+
+# NOTE - we are using Postgres functions instead of pure stored procedures
+
+# NOTE - these constants should escape \d sequences to ensure migration is applied
+#        correctly. Manual insertion of these functions will need to unescape.
+#
+GET_LATEST_COMPONENT_STOREDPROC_SQL = """
+CREATE OR REPLACE FUNCTION get_latest_component( model_type text, ps_ofuri text, component_type text, component_ns text, component_name text, component_arch text, include_inactive_streams boolean) RETURNS uuid AS $$  
+  DECLARE
+    product_component_cursor CURSOR FOR
+        SELECT core_component.uuid, core_component.epoch, core_component.version, core_component.release from core_component
+            INNER JOIN "core_component_products"
+            ON ("core_component"."uuid" = "core_component_products"."component_id")
+            INNER JOIN "core_product"
+            ON ("core_component_products"."product_id" = "core_product"."uuid")
+            WHERE core_component.name=component_name 
+            AND core_component.namespace=component_ns 
+            AND core_component.type=component_type 
+            AND core_component.arch=component_arch
+            AND (include_inactive_streams OR core_productstream.active)
+            AND (ps_ofuri IS NOT NULL AND core_product.ofuri = ps_ofuri)
+            AND ((core_component.type='RPM' and core_component.arch='src') 
+              OR ( core_component.type='RPMMOD')
+              OR (core_component.type='OCI' and core_component.arch='noarch') 
+              OR ("core_component"."arch" = 'noarch' AND "core_component"."namespace" = 'REDHAT' AND "core_component"."type" = 'GITHUB'));
+                      
+    product_version_component_cursor CURSOR FOR
+        SELECT core_component.uuid, core_component.epoch, core_component.version, core_component.release from core_component
+            INNER JOIN "core_component_productversions"
+            ON ("core_component"."uuid" = "core_component_productversions"."component_id")
+            INNER JOIN "core_productversion"
+            ON ("core_component_productversions"."productversion_id" = "core_productversion"."uuid")
+            WHERE core_component.name=component_name 
+            AND core_component.namespace=component_ns 
+            AND core_component.type=component_type 
+            AND core_component.arch=component_arch
+            AND (include_inactive_streams OR core_productstream.active)
+            AND (ps_ofuri IS NOT NULL AND core_productversion.ofuri = ps_ofuri)
+            AND ((core_component.type='RPM' and core_component.arch='src') 
+              OR ( core_component.type='RPMMOD')
+              OR (core_component.type='OCI' and core_component.arch='noarch') 
+              OR ("core_component"."arch" = 'noarch' AND "core_component"."namespace" = 'REDHAT' AND "core_component"."type" = 'GITHUB'));
+              
+    product_stream_component_cursor CURSOR FOR
+        SELECT core_component.uuid, core_component.epoch, core_component.version, core_component.release from core_component
+            INNER JOIN "core_component_productstreams"
+            ON ("core_component"."uuid" = "core_component_productstreams"."component_id")
+            INNER JOIN "core_productstream"
+            ON ("core_component_productstreams"."productstream_id" = "core_productstream"."uuid")
+            WHERE core_component.name=component_name 
+            AND core_component.namespace=component_ns 
+            AND core_component.type=component_type 
+            AND core_component.arch=component_arch
+            AND (include_inactive_streams OR core_productstream.active)
+            AND (ps_ofuri IS NOT NULL AND core_productstream.ofuri = ps_ofuri)
+            AND ((core_component.type='RPM' and core_component.arch='src') 
+                OR ( core_component.type='RPMMOD')
+                OR (core_component.type='OCI' and core_component.arch='noarch') 
+                OR ("core_component"."arch" = 'noarch' AND "core_component"."namespace" = 'REDHAT' AND "core_component"."type" = 'GITHUB'));
+
+    product_variant_component_cursor CURSOR FOR
+        SELECT core_component.uuid, core_component.epoch, core_component.version, core_component.release from core_component
+            INNER JOIN "core_component_productvariants"
+            ON ("core_component"."uuid" = "core_component_productvariants"."component_id")
+            INNER JOIN "core_productvariant"
+            ON ("core_component_productvariants"."productvariant_id" = "core_productvariant"."uuid")
+            WHERE core_component.name=component_name 
+            AND core_component.namespace=component_ns 
+            AND core_component.type=component_type 
+            AND core_component.arch=component_arch
+            AND (include_inactive_streams OR core_productstream.active)
+            AND (ps_ofuri IS NOT NULL AND core_productvariant.ofuri = ps_ofuri)
+            AND ((core_component.type='RPM' and core_component.arch='src') 
+              OR ( core_component.type='RPMMOD')
+              OR (core_component.type='OCI' and core_component.arch='noarch') 
+              OR ("core_component"."arch" = 'noarch' AND "core_component"."namespace" = 'REDHAT' AND "core_component"."type" = 'GITHUB'));
+
+    component_uuid text;
+    component_epoch int;
+    component_version text;
+    component_release text;
+    latest_uuid text;
+    latest_epoch int;
+    latest_version text;
+    latest_release text;
+  BEGIN
+    IF model_type = 'ProductVariant' THEN
+        OPEN product_variant_component_cursor;    
+        LOOP
+            FETCH NEXT FROM product_variant_component_cursor INTO component_uuid,component_epoch,component_version,component_release;
+            EXIT WHEN NOT FOUND;    
+            IF rpmvercmp_epoch(component_epoch,component_version,component_release,latest_epoch,latest_version,latest_release) >= 0 THEN
+                latest_uuid := component_uuid;
+                latest_epoch := component_epoch;
+                latest_version := component_version;
+                latest_release := component_release;
+            END IF;
+        END LOOP;    
+        CLOSE product_variant_component_cursor;
+    ELSIF model_type = 'ProductVersion' THEN
+        OPEN product_version_component_cursor;    
+        LOOP
+            FETCH NEXT FROM product_version_component_cursor INTO component_uuid,component_epoch,component_version,component_release;
+            EXIT WHEN NOT FOUND;    
+            IF rpmvercmp_epoch(component_epoch,component_version,component_release,latest_epoch,latest_version,latest_release) >= 0 THEN
+                latest_uuid := component_uuid;
+                latest_epoch := component_epoch;
+                latest_version := component_version;
+                latest_release := component_release;
+            END IF;
+        END LOOP;    
+        CLOSE product_version_component_cursor;
+    ELSIF model_type = 'Product' THEN
+        OPEN product_component_cursor;    
+        LOOP
+            FETCH NEXT FROM product_component_cursor INTO component_uuid,component_epoch,component_version,component_release;
+            EXIT WHEN NOT FOUND;    
+            IF rpmvercmp_epoch(component_epoch,component_version,component_release,latest_epoch,latest_version,latest_release) >= 0 THEN
+                latest_uuid := component_uuid;
+                latest_epoch := component_epoch;
+                latest_version := component_version;
+                latest_release := component_release;
+            END IF;
+        END LOOP;    
+        CLOSE product_component_cursor;
+    ELSE 
+        OPEN product_stream_component_cursor;    
+        LOOP
+            FETCH NEXT FROM product_stream_component_cursor INTO component_uuid,component_epoch,component_version,component_release;
+            EXIT WHEN NOT FOUND;    
+            IF rpmvercmp_epoch(component_epoch,component_version,component_release,latest_epoch,latest_version,latest_release) >= 0 THEN
+                latest_uuid := component_uuid;
+                latest_epoch := component_epoch;
+                latest_version := component_version;
+                latest_release := component_release;
+            END IF;
+        END LOOP;    
+        CLOSE product_stream_component_cursor;
+    END IF;    
+    RETURN latest_uuid;
+  END;
+  $$ LANGUAGE plpgsql;    
+"""  # noqa: E501
+
+
+class Migration(migrations.Migration):
+    dependencies = (("core", "0098_fix_duplicate_containers"),)
+
+    operations = (migrations.RunSQL(GET_LATEST_COMPONENT_STOREDPROC_SQL),)

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -907,15 +907,17 @@ class ComponentQuerySet(models.QuerySet):
         components: "ComponentQuerySet", model_type: str, ofuri: str, include_inactive_streams: bool
     ) -> Iterable[str]:
         return (
-            components.values("name", "namespace")
+            components.values("type", "namespace", "name", "arch")
             .order_by()  # required to avoid cross-join fun
             .distinct()
             .annotate(
                 latest_version=Func(
                     Value(model_type),
                     Value(ofuri),
+                    F("type"),
                     F("namespace"),
                     F("name"),
+                    F("arch"),
                     Value(include_inactive_streams),
                     function="get_latest_component",
                     output_field=models.UUIDField(),

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -2,7 +2,7 @@ import logging
 import re
 import uuid as uuid
 from abc import abstractmethod
-from typing import Any, Iterator, Union
+from typing import Any, Iterable, Iterator, Union
 
 from django.apps import apps
 from django.conf import settings
@@ -902,35 +902,14 @@ def get_product_details(variant_names: tuple[str], stream_names: list[str]) -> d
 class ComponentQuerySet(models.QuerySet):
     """Helper methods to filter QuerySets of Components"""
 
-    def latest_components(
-        self,
-        model_type: str = "ProductStream",
-        ofuri: str = "",
-        include: bool = True,
-        include_inactive_streams=False,
-        include_non_root_components=False,
-    ) -> "ComponentQuerySet":
-        """Return an ofuri's components from latest builds across all product streams."""
-
-        # the concept of 'latest component' is only relevent within product boundaries
-        # we want to constrain by product type/ofuri which is why we pass in model_type and ofuri
-        # into the get_latest_component stored proc annotation
-
-        components = self
-        if not (include_non_root_components):
-            components = (
-                components.select_related("software_build")
-                .prefetch_related("productstreams")
-                .root_components()
-                .using("read_only")
-            )
-        if ofuri:
-            components = components.filter(productstreams__ofuri=ofuri).distinct()
-
-        latest_components_uuids = set(
+    @staticmethod
+    def _latest_components_func(
+        components: "ComponentQuerySet", model_type: str, ofuri: str, include_inactive_streams: bool
+    ) -> Iterable[str]:
+        return (
             components.values("name", "namespace")
-            .order_by("name")  # required to avoid cross-join fun
-            .distinct("name", "namespace")
+            .order_by()  # required to avoid cross-join fun
+            .distinct()
             .annotate(
                 latest_version=Func(
                     Value(model_type),
@@ -943,102 +922,97 @@ class ComponentQuerySet(models.QuerySet):
                 )
             )
             .values_list("latest_version", flat=True)
-            .using("read_only")
+        )
+
+    def latest_components(
+        self,
+        ofuri: str,
+        model_type: str = "ProductStream",
+        include: bool = True,
+        include_inactive_streams=False,
+    ) -> "ComponentQuerySet":
+        """Return components from latest builds in a single stream."""
+
+        # the concept of 'latest component' is only relevant within product boundaries
+        # we want to constrain by product type/ofuri which is why we pass in model_type and ofuri
+        # into the get_latest_component stored proc annotation
+
+        components = (
+            self.root_components()
+            .select_related("software_build")
+            # TODO: What if model_type isn't ProductStream?
+            .prefetch_related("productstreams")
+            .filter(productstreams__ofuri=ofuri)
+        )
+
+        latest_components_uuids = set(
+            self._latest_components_func(components, model_type, ofuri, include_inactive_streams)
         )
 
         if latest_components_uuids:
+            lookup = {"pk__in": latest_components_uuids}
             if include:
-                return (
-                    components.filter(pk__in=latest_components_uuids)
-                    .order_by("name", "type", "arch", "version", "release")
-                    .distinct()
-                    .using("read_only")
-                )
+                components = components.filter(**lookup)
             else:
-                return (
-                    components.exclude(pk__in=latest_components_uuids)
-                    .order_by("name")
-                    .distinct()
-                    .using("read_only")
-                )
+                components = components.exclude(**lookup)
+            return components.order_by().distinct()
+
         else:
-            # Don't modify the ComponentQuerySet
-            return self
+            if include:
+                # no latest components, don't do any further filtering
+                return Component.objects.none()
+            else:
+                # Show only the older / non-latest components
+                # But there are no latest components to hide??
+                # So show everything / return unfiltered queryset
+                return self
 
     def latest_components_by_streams(
         self,
         include: bool = True,
         include_inactive_streams=False,
-        include_non_root_components=False,
     ) -> "ComponentQuerySet":
         """Return only root components from latest builds for each product stream."""
-        components = self
-        if not (include_non_root_components):
-            components = (
-                components.select_related("software_build")
-                .prefetch_related("productstreams")
-                .root_components()
-                .using("read_only")
-            )
-        if not (include_inactive_streams):
-            components = (
-                components.filter(productstreams__active=True).distinct().using("read_only")
-            )
+        components = (
+            self.root_components()
+            .select_related("software_build")
+            .prefetch_related("productstreams")
+        )
+        if not include_inactive_streams:
+            components = components.filter(productstreams__active=True).order_by().distinct()
         product_stream_ofuris = set(
             (
                 components.values_list("productstreams__ofuri", flat=True)
                 # Clear ordering inherited from parent Queryset, if any
                 # So .distinct() works properly and doesn't have duplicates
-                .order_by()
-                .distinct()
-                .using("read_only")
+                .order_by().distinct()
             )
         )
         # aggregate up all latest component uuids across all matched product streams
-        latest_components_uuids = set()
+        latest_components_uuids: set[str] = set()
         for ps_ofuri in product_stream_ofuris:
             latest_components_uuids.update(
-                components.filter(productstreams__ofuri=ps_ofuri)
-                .values("name", "namespace")
-                .order_by("name")  # required to avoid cross-join fun
-                .distinct("name", "namespace")
-                .annotate(
-                    latest_version=Func(
-                        Value("ProductStream"),  # always ProductStream model type
-                        Value(ps_ofuri),
-                        F("namespace"),
-                        F("name"),
-                        Value(include_inactive_streams),
-                        function="get_latest_component",
-                        output_field=models.UUIDField(),
-                    )
+                self._latest_components_func(
+                    components.filter(productstreams__ofuri=ps_ofuri),
+                    "ProductStream",  # always ProductStream model type
+                    ps_ofuri,
+                    include_inactive_streams,
                 )
-                .values_list("latest_version", flat=True)
-                .using("read_only")
             )
+        lookup = {"pk__in": latest_components_uuids}
         if include:
             # Show only the latest components
             if not latest_components_uuids:
                 # no latest components, don't do any further filtering
                 return Component.objects.none()
-            return (
-                components.filter(pk__in=latest_components_uuids)
-                .order_by("name", "type", "arch", "version", "release")
-                .distinct()
-                .using("read_only")
-            )
+            return components.filter(**lookup).order_by().distinct()
         else:
             # Show only the older / non-latest components
             if not latest_components_uuids:
                 # No latest components to hide??
                 # So show everything / return unfiltered queryset
                 return self
-            return (
-                components.exclude(pk__in=latest_components_uuids)
-                .order_by("name")
-                .distinct()
-                .using("read_only")
-            )
+            return components.exclude(**lookup).order_by().distinct()
 
     def released_components(self, include: bool = True) -> "ComponentQuerySet":
         """Show only released components by default, or unreleased components if include=False"""
@@ -1075,7 +1049,7 @@ class ComponentQuerySet(models.QuerySet):
         # Falsey values return the filtered queryset (only internal components)
         return self.filter(redhat_com_query)
 
-    def manifest_components(self, ofuri: str = "", quick=False) -> "ComponentQuerySet":
+    def manifest_components(self, ofuri: str, quick=False) -> "ComponentQuerySet":
         """filter latest components takes a long time, dont bother with that if we're just
         checking there is anything to manifest"""
         non_container_source_components = self.exclude(name__endswith="-container-source").using(
@@ -1089,16 +1063,9 @@ class ComponentQuerySet(models.QuerySet):
         if not quick:
             # Only filter when we're actually generating a manifest
             # not when checking if there are components to manifest, since it's slow
-            if ofuri:
-                roots = (
-                    roots.latest_components(
-                        model_type="ProductStream", ofuri=ofuri, include_inactive_streams=True
-                    )
-                    .order_by("pk")
-                    .distinct("pk")
-                )
-            else:
-                roots = roots.latest_components()
+            roots = roots.latest_components(
+                model_type="ProductStream", ofuri=ofuri, include_inactive_streams=True
+            )
 
         # Order by UUID to give stable results in manifests
         # Other querysets should not define an ordering

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -939,11 +939,17 @@ class ComponentQuerySet(models.QuerySet):
         # we want to constrain by product type/ofuri which is why we pass in model_type and ofuri
         # into the get_latest_component stored proc annotation
 
+        product_prefetch = "productstreams"
+        if model_type == "Product":
+            product_prefetch = "products"
+        if model_type == "ProductVersion":
+            product_prefetch = "productversions"
+        if model_type == "ProductVariant":
+            product_prefetch = "productvariants"
         components = (
             self.root_components()
             .select_related("software_build")
-            # TODO: What if model_type isn't ProductStream?
-            .prefetch_related("productstreams")
+            .prefetch_related(product_prefetch)
             .filter(productstreams__ofuri=ofuri)
         )
 

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -37,7 +37,7 @@ def cpu_update_ps_manifest(product_stream: str):
     # file has been modified before obtaining the updated copy.
     # collectstatic does not modify a file in staticfiles directory if it
     # hasn't been updated in outputfiles.
-    if ps.components.manifest_components(quick=True).exists():
+    if ps.components.manifest_components(quick=True, ofuri=ps.ofuri).exists():
         logger.info(f"Generating manifest for {product_stream}")
         with open(f"{settings.STATIC_ROOT}/{product_stream}-{ps.pk}.json", "w") as fh:
             fh.write(ps.manifest)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,15 +36,12 @@ def stored_proc(django_db_setup, django_db_blocker):
     # depends on corgi/core/migration/0092_install_stored_proc.py data migration
     stored_proc = importlib.import_module("corgi.core.migrations.0092_install_stored_proc")
     updated_stored_proc = importlib.import_module(
-        "corgi.core.migrations.0094_fix_stored_proc_inactive_filter"
+        "corgi.core.migrations.0099_add_type_arch_stored_proc_filter"
     )
     with django_db_blocker.unblock():
         with connection.cursor() as c:
-            c.execute("DROP FUNCTION if exists rpmvercmp;"),
             c.execute(stored_proc.RPMVERCMP_STOREDPROC_SQL)
-            c.execute("DROP FUNCTION if exists rpmvercmp_epoch;"),
             c.execute(stored_proc.RPMVERCMP_EPOCH_STOREDPROC_SQL),
-            c.execute("DROP FUNCTION if exists get_latest_component;"),
             c.execute(updated_stored_proc.GET_LATEST_COMPONENT_STOREDPROC_SQL)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -451,6 +451,7 @@ def test_latest_components_by_streams_filter_with_multiple_products(client, api_
     # Report newest_component as the latest for the RHEL8 stream
     # Even though both have the same name / only one is latest overall
     assert response["results"][0]["nevra"] == newer_component.nevra
+    assert response["results"][1]["nevra"] == newest_component.nevra
 
     response = client.get(f"{api_path}/components?latest_components_by_streams=False")
     assert response.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,7 +224,7 @@ def test_latest_components_by_streams_filter(client, api_path, stored_proc):
     # plus 2 non-RPMs components per name for src architecture only, 4 PyPI packages total
     # Overall 20 components, and latest filter should show 10 (newer, when on or older, when off)
     components = {}
-    stream = ProductStreamFactory(active=True)
+    stream = ProductStreamFactory()
     for name in "red", "blue":
         for arch in "aarch64", "x86_64", "src":
             older_component = ComponentFactory(
@@ -406,17 +406,9 @@ def test_latest_components_by_streams_filter(client, api_path, stored_proc):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_by_streams_filter_with_multiple_products(client, api_path, stored_proc):
-    ps1 = ProductStreamFactory(
-        name="rhel-7",
-        version="7",
-        active=True,
-    )
+    ps1 = ProductStreamFactory(name="rhel-7", version="7")
     assert ps1.ofuri == "o:redhat:rhel:7"
-    ps2 = ProductStreamFactory(
-        name="rhel-8",
-        version="8",
-        active=True,
-    )
+    ps2 = ProductStreamFactory(name="rhel-8", version="8")
     assert ps2.ofuri == "o:redhat:rhel:8"
 
     # Only belongs to RHEL7 stream
@@ -1182,23 +1174,11 @@ def test_api_component_400(client, api_path):
 def test_product_components_ofuri(client, api_path, stored_proc):
     """test 'latest' filter on components"""
 
-    ps1 = ProductStreamFactory(
-        name="rhel-8.6.0",
-        version="8.6.0",
-        active=True,
-    )
+    ps1 = ProductStreamFactory(name="rhel-8.6.0", version="8.6.0")
     assert ps1.ofuri == "o:redhat:rhel:8.6.0"
-    ps2 = ProductStreamFactory(
-        name="rhel-8.6.0.z",
-        version="8.6.0.z",
-        active=True,
-    )
+    ps2 = ProductStreamFactory(name="rhel-8.6.0.z", version="8.6.0.z")
     assert ps2.ofuri == "o:redhat:rhel:8.6.0.z"
-    ps3 = ProductStreamFactory(
-        name="rhel-8.5.0",
-        version="8.5.0",
-        active=True,
-    )
+    ps3 = ProductStreamFactory(name="rhel-8.5.0", version="8.5.0")
     assert ps3.ofuri == "o:redhat:rhel:8.5.0"
 
     old_openssl = SrpmComponentFactory(name="openssl", version="1.1.1k", release="5.el8_5")
@@ -1242,9 +1222,9 @@ def test_product_components_ofuri(client, api_path, stored_proc):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_product_components_versions(client, api_path, stored_proc):
-    ps1 = ProductStreamFactory(name="rhel-7", version="7", active=True)
+    ps1 = ProductStreamFactory(name="rhel-7", version="7")
     assert ps1.ofuri == "o:redhat:rhel:7"
-    ps2 = ProductStreamFactory(name="rhel-8", version="8", active=True)
+    ps2 = ProductStreamFactory(name="rhel-8", version="8")
     assert ps2.ofuri == "o:redhat:rhel:8"
 
     openssl = ComponentFactory(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -105,7 +105,7 @@ def test_get_latest_component_stored_proc(stored_proc):
 
     with connection.cursor() as cursor:
         cursor.execute(
-            "select * from get_latest_component('ProductStream','o:redhat:openshift-enterprise:3.11.z','REDHAT','ansible-runner',True);"  # noqa: E501
+            "select * from get_latest_component('ProductStream','o:redhat:openshift-enterprise:3.11.z','RPM','REDHAT','ansible-runner','src',True);"  # noqa: E501
         )
         row = cursor.fetchone()
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -210,7 +210,7 @@ def test_product_manifest_excludes_unreleased_components(stored_proc):
     manifest = json.loads(stream.manifest)
 
     # No released components linked to this product
-    num_components = len(stream.components.manifest_components())
+    num_components = len(stream.components.manifest_components(ofuri=stream.ofuri))
     assert num_components == 0
 
     num_provided = len(stream.provides_queryset)
@@ -272,7 +272,9 @@ def test_manifest_no_duplicate_released_components():
 
     unique_components = set()
 
-    for purl in stream.components.manifest_components().values_list("purl", flat=True):
+    for purl in stream.components.manifest_components(ofuri=stream.ofuri).values_list(
+        "purl", flat=True
+    ):
         assert purl not in unique_components
         unique_components.add(purl)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1179,13 +1179,11 @@ def test_latest_components_queryset(client, api_path, stored_proc):
         # A NEVRA like "PyYAML version 1.2.3 with no release or architecture"
         # could be a PyPI package, or an upstream RPM
         # We want to see the latest version of both components
-        # Create PyPI components once per loop, like src architecture components
+        # Create RPMMOD components once per loop, like src architecture components
         # with the same namespace, name and version as UPSTREAM noarch components
-        # and no release, arch, or software_build
-        # TODO: We should use RPMMOD instead of PyPI here, but then the test fails
-        #  because we reintroduced a bug we fixed previously
-        #  Whe hide results if two components have the same name and namespace
-        #  but different types or arches, for example a source RPM and its related RPM module
+        # and no release, arch, or software_build. Otherwise we hide results if two
+        # components have the same name and namespace but different types or arches,
+        # for example a source RPM and its related RPM module
         older_unrelated_component = ComponentFactory(
             type=Component.Type.RPMMOD,
             namespace=older_component.namespace,
@@ -1218,11 +1216,6 @@ def test_latest_components_queryset(client, api_path, stored_proc):
         ofuri=stream.ofuri,
         include=True,
     )
-    # Latest_components is now really "latest_root_components" for a particular stream
-    # We no longer show latest versions of non-root components
-    # or latest versions of unshipped components, which are not linked to any stream
-    # This may have implications for OpenLCS
-    # As well as other users of the ?latest_components_by_streams= filter / API parameter
     assert len(latest_components) == 4
     for component in latest_components:
         assert (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1223,7 +1223,7 @@ def test_latest_components_queryset(client, api_path, stored_proc):
     # or latest versions of unshipped components, which are not linked to any stream
     # This may have implications for OpenLCS
     # As well as other users of the ?latest_components_by_streams= filter / API parameter
-    assert len(latest_components) == 2
+    assert len(latest_components) == 4
     for component in latest_components:
         assert (
             component.purl == components[(component.type, component.name, component.arch)][1].purl


### PR DESCRIPTION
have taken the good work of @juspence ( in https://github.com/RedHatProductSecurity/component-registry/pull/648) and enhanced stored proc with **type** and **arch** to avoid collision - we can generalise this filter more as we can now narrow down with _active_streams=True_

**Note**: I could just as easily add [0f85669](https://github.com/RedHatProductSecurity/component-registry/pull/651/commits/0f85669222e01bba64a11fd72d8e2d2711eac3e5) to https://github.com/RedHatProductSecurity/component-registry/pull/648