### PR TITLE
CORGI-557: Fix duplicate RPMs which may have bad namespace, arch, NEVRA, or purl

### DIFF
--- a/corgi/api/urls.py
+++ b/corgi/api/urls.py
@@ -5,8 +5,8 @@ from rest_framework import routers
 from .views import (
     ChannelViewSet,
     ComponentViewSet,
-    ProductStreamViewSetSet,
-    ProductVariantViewSetSet,
+    ProductStreamViewSet,
+    ProductVariantViewSet,
     ProductVersionViewSet,
     ProductViewSet,
     SoftwareBuildViewSet,
@@ -36,8 +36,8 @@ router.register(r"components", ComponentViewSet)
 # router.register(r"lifecycles", AppStreamLifeCycleView)
 router.register(r"products", ProductViewSet)
 router.register(r"product_versions", ProductVersionViewSet)
-router.register(r"product_streams", ProductStreamViewSetSet)
-router.register(r"product_variants", ProductVariantViewSetSet)
+router.register(r"product_streams", ProductStreamViewSet)
+router.register(r"product_variants", ProductVariantViewSet)
 # Comment out until we start loading Channels and tying them to products/errata
 router.register(r"channels", ChannelViewSet)
 router.register(r"status", StatusViewSet, basename="status")

--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -366,7 +366,7 @@ def get_component_taxonomy(
 class SoftwareBuildViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled until auth is added
     """View for api/v1/builds"""
 
-    queryset = SoftwareBuild.objects.order_by("build_type", "build_id").using("read_only")
+    queryset = SoftwareBuild.objects.order_by("build_id", "build_type").using("read_only")
     serializer_class = SoftwareBuildSerializer
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend, filters.SearchFilter]
     filterset_class = SoftwareBuildFilter
@@ -453,7 +453,7 @@ class ProductVersionViewSet(ProductDataViewSet):
 
 
 @INCLUDE_EXCLUDE_FIELDS_SCHEMA
-class ProductStreamViewSetSet(ProductDataViewSet):
+class ProductStreamViewSet(ProductDataViewSet):
     """View for api/v1/product_streams"""
 
     queryset = (
@@ -509,7 +509,7 @@ class ProductStreamViewSetSet(ProductDataViewSet):
 
 
 @INCLUDE_EXCLUDE_FIELDS_SCHEMA
-class ProductVariantViewSetSet(ProductDataViewSet):
+class ProductVariantViewSet(ProductDataViewSet):
     """View for api/v1/product_variants"""
 
     queryset = ProductVariant.objects.order_by(ProductDataViewSet.ordering_field).using("read_only")

--- a/corgi/core/migrations/0099_fix_duplicate_rpms.py
+++ b/corgi/core/migrations/0099_fix_duplicate_rpms.py
@@ -1,0 +1,100 @@
+from django.db import migrations
+from django.db.models import F, Value, functions
+
+# Must use non-historical model which supports cnodes
+from corgi.core.models import Component
+
+NEVRA_FIELD = F("nevra")
+NOARCH_VALUE = Value(".noarch")
+
+PURL_FIELD = F("purl")
+PURL_PREFIX = "pkg:rpm/"
+RED_HAT_PURL_PREFIX = f"{PURL_PREFIX}redhat/"
+
+
+def find_duplicate_rpms(apps, schema_editor) -> None:
+    """Find duplicate RPMs / nodes with bad purls, NEVRAs, arches, or namespaces"""
+    arches = (
+        "ia64",
+        "ppc64le",
+        "src",
+        "noarch",
+        "s390x",
+        "ppc64",
+        "i686",
+        "s390",
+        "ppc",
+        "x86_64",
+        "i386",
+        "aarch64",
+        "",
+    )
+
+    # We could do this without the for loop, but checking type / arch pairs individually
+    # means the query hits an index and should be faster
+    for arch in arches:
+        rpms_for_arch = Component.objects.filter(type="RPM", arch=arch)
+
+        # Fix binary RPM arch / nevra values when the RPM doesn't have arch set at all
+        if arch == "":
+            arch = "noarch"
+            # Changing an empty "" string arch to "noarch" might fail
+            # due to the type + NVRA constraint, so we handle the "" arch last
+            for bad_rpm in rpms_for_arch.iterator():
+                # Fixing each RPM individually is less risky than fixing all of them at once
+                # Using .filter().update() means this is still atomic
+                Component.objects.filter(purl=bad_rpm.purl).update(
+                    arch=arch, nevra=functions.Concat(NEVRA_FIELD, NOARCH_VALUE)
+                )
+
+        # Fix binary RPM purls which are missing an arch value
+        for bad_rpm in rpms_for_arch.exclude(purl__contains="arch=").iterator():
+            # PackageURL library alphabetizes qualifiers (by key only), so just put arch key first
+            if "?" in bad_rpm.purl:
+                good_purl = bad_rpm.purl.replace("?", f"?arch={arch}&", 1)
+            else:
+                good_purl = f"{bad_rpm.purl}?arch={arch}"
+            clean_duplicate_rpms(good_purl, bad_rpm)
+
+        # Fix binary RPM purls which are missing a namespace value
+        for bad_rpm in rpms_for_arch.exclude(purl__startswith=RED_HAT_PURL_PREFIX).iterator():
+            good_purl = bad_rpm.purl.replace(PURL_PREFIX, RED_HAT_PURL_PREFIX, 1)
+            clean_duplicate_rpms(good_purl, bad_rpm)
+
+
+def clean_duplicate_rpms(good_purl: str, bad_rpm: Component):
+    """Clean up binary RPM purls, NEVRAs, nodes, etc. that may or may not have duplicates"""
+    # We don't reuse this code in other migrations because we have to make assumptions
+    # about what to check and which fields / values to update, based on component type
+    good_rpm = Component.objects.filter(purl=good_purl).first()
+    # .delete() and .update() functions on querysets are atomic, even outside transactions
+    bad_rpm_qs = Component.objects.filter(purl=bad_rpm.purl)
+
+    # No duplicate RPM is present
+    # So we can just fix the bad RPM / node purls
+    if not good_rpm:
+        bad_rpm_qs.update(purl=good_purl)
+        bad_rpm.cnodes.update(purl=good_purl)
+        return
+
+    # Else both RPMs exist, we assume the old / bad one should just be deleted
+    # There's no easy way to know which nodes we should compare / are in the same tree
+    # and no easy way to know which build ID should be reprocessed / is the SRPM
+    # or if the SRPM even exists at all, since this may be a binary RPM in container trees only
+    # So just delete this node without checking descendants or reprocessing
+    # There shouldn't be too much data on the old / bad node
+    # Which is lost / not present on the duplicate / good node
+    bad_rpm_qs.delete()
+
+
+class Migration(migrations.Migration):
+    # Code above should be safe to run outside a transaction / already atomic
+    # and will take forever, so we need to pick up where we left off after timeouts
+    atomic = False
+    dependencies = [
+        ("core", "0098_fix_duplicate_containers"),
+    ]
+
+    operations = [
+        migrations.RunPython(find_duplicate_rpms),
+    ]

--- a/corgi/core/migrations/0100_fix_duplicate_remote_source_components.py
+++ b/corgi/core/migrations/0100_fix_duplicate_remote_source_components.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+from django.db.models import F, Q
+
+# Must use non-historical model which supports cnodes
+from corgi.core.models import Component
+
+
+def find_duplicate_remote_source_components(apps, schema_editor) -> None:
+    """Find duplicate Maven, NPM, PyPI, etc. nodes with bad purls"""
+    ComponentNode = apps.get_model("core", "ComponentNode")
+
+    # We could do this without the for loop, but checking type / arch pairs individually
+    # means the query hits an index and should be faster
+    for component_type in Component.REMOTE_SOURCE_COMPONENT_TYPES:
+        if component_type == "GOLANG":
+            # Too many components to check without crashing the DB
+            continue
+        # All remote-source component types use "noarch"
+        components_for_type = Component.objects.filter(type=component_type, arch="noarch")
+
+        # Fix node purls which don't match their linked component
+        for component in components_for_type.filter(~Q(cnodes__purl=F("purl"))).iterator():
+            # There are too many reasons why a purl may differ between a component and its node
+            # So we can't just directly update to the correct value like we did in other migrations
+            # Instead, try to fix each node's purl atomically, but handle duplicates if any
+            # TODO: Recheck all of this, verify data in stage
+            for bad_node in component.cnodes.exclude(purl=component.purl).iterator():
+                bad_node_qs = ComponentNode.objects.filter(
+                    type=bad_node.type, parent=bad_node.parent, purl=bad_node.purl
+                )
+                if ComponentNode.objects.filter(
+                    type=bad_node.type, parent=bad_node.parent, purl=component.purl
+                ).exists():
+                    # if a duplicate exists with the good purl, delete the node with the bad purl
+                    bad_node_qs.delete()
+                else:
+                    # No duplicate exists, so we can just fix the bad node's purl directly
+                    bad_node_qs.update(purl=component.purl)
+
+
+class Migration(migrations.Migration):
+    # Code above should be safe to run outside a transaction / already atomic
+    # and will take forever, so we need to pick up where we left off after timeouts
+    atomic = False
+    dependencies = [
+        ("core", "0099_fix_duplicate_rpms"),
+    ]
+
+    operations = [
+        migrations.RunPython(find_duplicate_remote_source_components),
+    ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -65,10 +65,18 @@ def test_cpes():
         productversions=pv2,
     )
     pvariant1 = ProductVariantFactory(
-        cpe="cpe:/o:redhat:enterprise_linux:7", products=p1, productversions=pv1, productstreams=ps1
+        name=ps1.name,
+        cpe="cpe:/o:redhat:enterprise_linux:7",
+        products=p1,
+        productversions=pv1,
+        productstreams=ps1,
     )
     pvariant2 = ProductVariantFactory(
-        cpe="cpe:/o:redhat:Brantabernicla:8", products=p1, productversions=pv2, productstreams=ps3
+        name=ps3.name,
+        cpe="cpe:/o:redhat:Brantabernicla:8",
+        products=p1,
+        productversions=pv2,
+        productstreams=ps3,
     )
 
     p1node = ProductNode.objects.create(parent=None, obj=p1)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. The modules and containers have finished being cleaned up in stage, so I've moved onto RPMs in the first migration here:

1. There are 40,000-ish "noarch" binary RPMs which have their namespace set to "REDHAT" correctly, but are missing "/redhat/" in their purls.
2. There are 40,000-ish binary RPMs with an empty "" string arch. This was an old bug in our ingestion code which is now fixed. They need to have their arch changed to "noarch", then the NEVRA and purl must be updated to match.
3. Almost all of the components in point 2 also have their namespace set to "REDHAT" correctly, but are missing "/redhat/" in their purls.

The components in point 2 are likely duplicates of the components in the point 1. If this is correct (the migration checks), we just delete them instead of trying to merge their descendant nodes. Merging the data for RPMs is more complicated for reasons noted in the migration, and I've spent enough time on this already.

The second migration here fixes duplicate nodes for remote-source components, for example MAVEN, NPM, and PYPI packages. Every single remote-source component type has nodes where the purl doesn't match the linked component. The migration looks to see if there is a duplicate node (same type and parent, purl matches linked component like we expect). If a duplicate is present, we just delete the bad node. Otherwise, we update the bad node so that the purl matches the component.

Again, we don't check the descendant counts or do any reprocessing here if the bad node has a duplicate. The logic to do this correctly would be even more complicated than in the previous PRs. Any descendants we lose are either legacy data from a bug we've already fixed, so we don't want to keep them around anyway (e.g. test dependencies from Syft). Or the missing descendants will get recreated the next time we run SCA on a root that uses this remote-source component.

I still need to recheck the exact numbers of components that will be affected, and try to identify why the purls don't match, but in the meantime this is ready for review. And I hope this is the last PR for this issue.