### PR TITLE
remove order_by and distinct from pk_in part of latest_components query

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -960,10 +960,9 @@ class ComponentQuerySet(models.QuerySet):
         if latest_components_uuids:
             lookup = {"pk__in": latest_components_uuids}
             if include:
-                components = components.filter(**lookup)
+                return components.filter(**lookup)
             else:
-                components = components.exclude(**lookup)
-            return components.order_by().distinct()
+                return components.exclude(**lookup)
 
         else:
             if include:


### PR DESCRIPTION
This removes the costly unique/sort according the the query plan for latest_components filter:

before:
```
"Unique  (cost=5956.10..5956.28 rows=1 width=1670)
  ->  Sort  (cost=5956.10..5956.11 rows=1 width=1670)
        Sort Key: core_component.last_changed, core_component.created_at, core_component.uuid, core_component.name, core_component.description, core_component.meta_attr, core_component.type, core_component.namespace, core_component.epoch, core_component.version, core_component.release, core_component.arch, core_component.purl, core_component.nvr, core_component.nevra, core_component.software_build_uuid, core_component.copyright_text, core_component.license_concluded_raw, core_component.license_declared_raw, core_component.openlcs_scan_url, core_component.openlcs_scan_version, core_component.filename, core_component.related_url, core_component.el_match, core_softwarebuild.last_changed, core_softwarebuild.created_at, core_softwarebuild.uuid, core_softwarebuild.build_id, core_softwarebuild.build_type, core_softwarebuild.name, core_softwarebuild.source, core_softwarebuild.completion_time, core_softwarebuild.meta_attr
        ->  Nested Loop Left Join  (cost=3.37..5956.08 rows=1 width=1670)
              ->  Nested Loop  (cost=2.52..5953.06 rows=1 width=677)
                    Join Filter: (core_component_productstreams.productstream_id = core_productstream.uuid)
                    ->  Index Scan using core_produc_ofuri_e77387_idx on core_productstream  (cost=0.56..2.81 rows=1 width=16)
                          Index Cond: ((ofuri)::text = 'o:redhat:rhel:8.8.0.z'::text)
                    ->  Nested Loop  (cost=1.97..5933.24 rows=486 width=693)
                          ->  Index Scan using compon_latest_idx on core_component  (cost=0.84..5081.53 rows=301 width=677)
                                Index Cond: (uuid = ANY ('{6b9afc9c-642c-4fa6-98cd-d1a4303482b3,0bd30251-11c9-4885-bb3f-158df9c11bd4...))
                          ->  Index Only Scan using core_component_productst_component_id_productstre_10bd2bae_uniq on core_component_productstreams  (cost=1.12..2.62 rows=7 width=32)
                                Index Cond: (component_id = core_component.uuid)
              ->  Index Scan using core_softwarebuild_pkey on core_softwarebuild  (cost=0.84..3.02 rows=1 width=993)
                    Index Cond: (uuid = core_component.software_build_uuid)
```

after:
```
Nested Loop Left Join  (cost=3.37..5956.05 rows=1 width=1670)
  ->  Nested Loop  (cost=2.52..5953.03 rows=1 width=677)
        Join Filter: (core_component_productstreams.productstream_id = core_productstream.uuid)
        ->  Index Scan using core_produc_ofuri_e77387_idx on core_productstream  (cost=0.56..2.81 rows=1 width=16)
              Index Cond: ((ofuri)::text = 'o:redhat:rhel:8.8.0.z'::text)
        ->  Nested Loop  (cost=1.97..5933.24 rows=485 width=693)
              ->  Index Scan using compon_latest_idx on core_component  (cost=0.84..5081.53 rows=301 width=677)
                    Index Cond: (uuid = ANY ('{6b9afc9c-642c-4fa6-98cd-d1a4303482b3,0bd30251-11c9-4885-bb3f-158df9c11bd4...c56317d7-b21d-4249-a7c0-17191cde4d7f,2c55b1bc-4500-45cd-811c-45afbfa39188}'::uuid[]))
              ->  Index Only Scan using core_component_productst_component_id_productstre_10bd2bae_uniq on core_component_productstreams  (cost=1.12..2.62 rows=7 width=32)
                    Index Cond: (component_id = core_component.uuid)
  ->  Index Scan using core_softwarebuild_pkey on core_softwarebuild  (cost=0.84..3.02 rows=1 width=993)
        Index Cond: (uuid = core_component.software_build_uuid)"
```