### PR TITLE
CORGI-872: Report CPEs for root components in manifests

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1815,8 +1815,26 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         return ComponentNode.objects.filter(pk__in=root_node_pks).using(using)
 
     @property
-    def build_meta(self):
-        return self.software_build.meta_attr
+    def cpes(self) -> QuerySet:
+        """Build and return a list of CPEs from all Variants this Component relates to"""
+        # For each Variant-type relation, get the linked Variant's CPE directly
+        # Remove any duplicates, and return the CPEs in sorted order so manifests are stable
+        return (
+            self.productvariants.exclude(cpe="")
+            .values_list("cpe", flat=True)
+            .distinct()
+            .order_by("cpe")
+        )
+
+        # For Stream-type relations, we no longer link any Variants
+        # since this caused data quality issues, where Components were linked to Variants
+        # that didn't actually ship those Components
+        # We could look at all the linked streams to get CPEs from all their child Variants
+        # But this would cause the same problem - we'd report too many Variants / incorrect CPEs
+
+        # TODO: We return an empty QuerySet if no Variants are linked, or none have CPEs
+        #  But do we want to raise an error / make manifesting fail,
+        #  whenever we can't find CPEs for some root component?
 
     def _build_download_url_for_type(self) -> str:
         """Get a source code or binary download URL based on a purl"""

--- a/corgi/web/templates/component_manifest.json
+++ b/corgi/web/templates/component_manifest.json
@@ -45,7 +45,12 @@
     {
       "copyrightText": {% if obj.copyright_text %}"{{obj.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
       "downloadLocation": {% if obj.download_url %}"{{obj.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-      "externalRefs": [
+      "externalRefs": [{% for cpe in obj.cpes %}
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "{{cpe}}",
+          "referenceType": "cpe22Type"
+        },{% endfor %}
         {
           "referenceCategory": "PACKAGE_MANAGER",
           "referenceLocator": "{{obj.purl|safe}}",

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -3,7 +3,12 @@
     {
       "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
       "downloadLocation": {% if component.download_url %}"{{component.download_url|escapejs}}"{% else %}"NOASSERTION"{% endif %},
-      "externalRefs": [
+      "externalRefs": [{% for cpe in component.cpes %}
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "{{cpe}}",
+          "referenceType": "cpe22Type"
+        },{% endfor %}
         {
           "referenceCategory": "PACKAGE_MANAGER",
           "referenceLocator": "{{component.purl|safe}}",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -351,11 +351,15 @@ def test_product_manifest_properties(stored_proc):
     component_data = manifest["packages"][0]
     product_data = manifest["packages"][-1]
 
-    # UUID and PURL, for each component attached to product, should be included in manifest
+    # UUID, CPE, and PURL for each root component attached to product should be included in manifest
     assert component_data["SPDXID"] == f"SPDXRef-{component.uuid}"
     assert component_data["name"] == component.name
     assert component_data["packageFileName"] == f"{component.nevra}.rpm"
-    assert component_data["externalRefs"][0]["referenceLocator"] == component.purl
+    assert (
+        component_data["externalRefs"][0]["referenceLocator"]
+        == stream.productvariants.values_list("cpe", flat=True).get()
+    )
+    assert component_data["externalRefs"][-1]["referenceLocator"] == component.purl
 
     assert product_data["SPDXID"] == f"SPDXRef-{stream.uuid}"
     assert product_data["name"] == stream.name
@@ -434,6 +438,16 @@ def test_component_manifest_properties():
     num_provided = len(component.get_provides_pks())
 
     assert num_provided == 2
+
+    # Last component is the one we're manifesting
+    component_data = manifest["packages"][-1]
+
+    # UUID, CPE, and PURL for the component we're manifesting should be included in manifest
+    assert component_data["SPDXID"] == f"SPDXRef-{component.uuid}"
+    assert component_data["name"] == component.name
+    assert component_data["packageFileName"] == f"{component.nevra}.rpm"
+    assert component_data["externalRefs"][0]["referenceLocator"] == component.cpes.get()
+    assert component_data["externalRefs"][-1]["referenceLocator"] == component.purl
 
     document_describes_product = {
         "relatedSpdxElement": f"SPDXRef-{component.uuid}",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -98,6 +98,74 @@ def test_cpes():
     ]
 
 
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+def test_component_cpes():
+    """Test the CPEs property on the Component model finds CPEs for any Variant
+    linked directly to that Component, whenever the CPE is not empty"""
+    # Below Variant has an empty CPE, so we shouldn't discover it
+    empty_cpe_variant = ProductVariantFactory(
+        name="empty_cpe_variant",
+        cpe="",
+    )
+
+    rhel_7_variant = ProductVariantFactory(
+        name="rhel_7_variant",
+        cpe="cpe:/o:redhat:enterprise_linux:7",
+    )
+    rhel_8_variant = ProductVariantFactory(
+        name="rhel_8_variant",
+        cpe="cpe:/o:redhat:enterprise_linux:8",
+    )
+
+    # Below Variant has a duplicate CPE, so we shouldn't discover it twice
+    duplicate_variant = ProductVariantFactory(
+        name="duplicate_variant",
+        cpe="cpe:/o:redhat:enterprise_linux:8",
+    )
+    variants = (empty_cpe_variant, rhel_7_variant, rhel_8_variant, duplicate_variant)
+
+    # Below Variant is not linked, so we shouldn't discover it
+    unused_variant = ProductVariantFactory(
+        name="unused_variant",
+        cpe="cpe:/o:redhat:enterprise_linux:9",
+    )
+
+    index_container = ContainerImageComponentFactory()
+    child_container = ChildContainerImageComponentFactory(
+        name=index_container.name,
+        epoch=index_container.epoch,
+        version=index_container.version,
+        release=index_container.release,
+    )
+    binary_rpm = BinaryRpmComponentFactory()
+    upstream = UpstreamComponentFactory()
+
+    child_container.sources.set((index_container,))
+    binary_rpm.sources.set((index_container, child_container))
+    upstream.sources.set((index_container, child_container, binary_rpm))
+    components = (index_container, child_container, binary_rpm, upstream)
+
+    for component in components:
+        # Components with an unsaved taxonomy should not have any CPEs
+        assert not component.cpes.exists()
+        # Mocking up builds, relations, and nodes for a taxonomy
+        # would be a lot of work, so just set the variants directly instead
+        component.productvariants.set(variants)
+
+        cpes = component.cpes
+        # Now we've "saved this component's taxonomy" / linked it to above variants
+        # Both root and non-root components should have CPEs
+        assert len(cpes)
+
+        # Components should not have any empty or duplicate CPEs
+        assert "" not in cpes
+        assert len(cpes) == len(set(cpes))
+
+        # Components should give their CPEs in sorted order, to keep manifests stable
+        assert list(cpes) == [rhel_7_variant.cpe, rhel_8_variant.cpe]
+        assert unused_variant.cpe not in cpes
+
+
 def test_nevra():
     """Test that NEVRAs are formatted properly for certain known edge-cases"""
     for component_type in Component.Type.values:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This is a farily simple change to start reporting CPEs for root components in product-based manifests, and the component being manifested in component-based manifests.

For the latter case, "the component being manifested" may not actually be a root component, e.g. we support manifesting arch-specific containers and binary RPMs. As long as they "provide" some other component, we can report useful data about them in a manifest, so I made sure we support reporting their CPEs as well.

Given above, we can start reporting CPEs for all components in a manifest (provides and upstreams) if we want to, although for now I only added this logic to root components.