### PR TITLE
CORGI-557: Fix error seen when running migration / failure to check duplicate nodes

### DIFF
--- a/corgi/core/migrations/0100_fix_duplicate_rpms.py
+++ b/corgi/core/migrations/0100_fix_duplicate_rpms.py
@@ -1,5 +1,5 @@
 from django.db import migrations
-from django.db.models import F, Value, functions
+from django.db.models import F, Manager, Value, functions
 
 # Must use non-historical model which supports cnodes
 from corgi.core.models import Component
@@ -14,6 +14,7 @@ RED_HAT_PURL_PREFIX = f"{PURL_PREFIX}redhat/"
 
 def find_duplicate_rpms(apps, schema_editor) -> None:
     """Find duplicate RPMs / nodes with bad purls, NEVRAs, arches, or namespaces"""
+    ComponentNode = apps.get_model("core", "ComponentNode")
     arches = (
         "ia64",
         "ppc64le",
@@ -54,15 +55,15 @@ def find_duplicate_rpms(apps, schema_editor) -> None:
                 good_purl = bad_rpm.purl.replace("?", f"?arch={arch}&", 1)
             else:
                 good_purl = f"{bad_rpm.purl}?arch={arch}"
-            clean_duplicate_rpms(good_purl, bad_rpm)
+            clean_duplicate_rpms(good_purl, bad_rpm, ComponentNode)
 
         # Fix binary RPM purls which are missing a namespace value
         for bad_rpm in rpms_for_arch.exclude(purl__startswith=RED_HAT_PURL_PREFIX).iterator():
             good_purl = bad_rpm.purl.replace(PURL_PREFIX, RED_HAT_PURL_PREFIX, 1)
-            clean_duplicate_rpms(good_purl, bad_rpm)
+            clean_duplicate_rpms(good_purl, bad_rpm, ComponentNode)
 
 
-def clean_duplicate_rpms(good_purl: str, bad_rpm: Component):
+def clean_duplicate_rpms(good_purl: str, bad_rpm: Component, ComponentNode: Manager):
     """Clean up binary RPM purls, NEVRAs, nodes, etc. that may or may not have duplicates"""
     # We don't reuse this code in other migrations because we have to make assumptions
     # about what to check and which fields / values to update, based on component type
@@ -71,10 +72,11 @@ def clean_duplicate_rpms(good_purl: str, bad_rpm: Component):
     bad_rpm_qs = Component.objects.filter(purl=bad_rpm.purl)
 
     # No duplicate RPM is present
-    # So we can just fix the bad RPM / node purls
+    # So we can just fix the bad RPM's purl
+    # As well as the bad node purls, after we check for duplicates
     if not good_rpm:
         bad_rpm_qs.update(purl=good_purl)
-        bad_rpm.cnodes.update(purl=good_purl)
+        fix_bad_nodes(good_purl, bad_rpm, ComponentNode)
         return
 
     # Else both RPMs exist, we assume the old / bad one should just be deleted
@@ -85,6 +87,24 @@ def clean_duplicate_rpms(good_purl: str, bad_rpm: Component):
     # There shouldn't be too much data on the old / bad node
     # Which is lost / not present on the duplicate / good node
     bad_rpm_qs.delete()
+
+
+def fix_bad_nodes(good_purl: str, bad_rpm: Component, ComponentNode: Manager):
+    """Helper method to find and clean up RPM nodes with bad purls"""
+    for bad_node in bad_rpm.cnodes.iterator():
+        bad_node_qs = ComponentNode.objects.filter(
+            type=bad_node.type, parent=bad_node.parent, purl=bad_node.purl
+        )
+        if ComponentNode.objects.filter(
+            type=bad_node.type, parent=bad_node.parent, purl=good_purl
+        ).exists():
+            # Duplicate exists, just delete the old node
+            # We don't reprocess here since we can't easily tell which build needs it
+            bad_node_qs.delete()
+        else:
+            # No duplicate exists, so we can just update the current node
+            # No need to delete or reprocess anything, we won't lose data
+            bad_node_qs.update(purl=good_purl)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, this is the same fix as needed for migration number 98. When we find an old / bad obect (then a container, now an RPM) which has an incorrect purl, we want to fix it. If no new / good object with a correct purl exists, we can just update the purl on the old / bad object directly - there is no duplicate data so no IntegrityError will occur.

We also need to fix the nodes, so that the purls match between the object and all its nodes, and none of the nodes have an incorrect purl. But even if there is no duplicate object, there may still be duplicate nodes. For example, after reprocessing, new / good nodes with the correct purl will have already been created for the same object. These nodes have the same type and parent as the old / bad nodes, so we cannot just update the purl on the old / bad node directly - there is duplicate data so an IntegrityError will occur.

To fix this, we just check for a new / good node with a correct purl before trying to update the old / bad node with an incorrect purl. If we find a duplicate, we delete the old / bad node. We either shouldn't lose any data, or the data we lose is old / stale and we probably didn't want it anyway (e.g. test dependencies discovered by Syft). If there is no duplicate, we can just update the purl on the old / bad node directly - there is no duplicate data so no IntegrityError will occur.