### PR TITLE
CORGI-871, CORGI-879: Fix sbomer code and historical data

### DIFF
--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -75,12 +75,19 @@ class SbomerSbom:
                 if "expression" in _license:  # SPDX string
                     licenses.append(_license["expression"])
                 elif "license" in _license:  # Individual license
+                    # Prefer license IDs, only fallback to names if no ID is available
                     if _license["license"].get("id"):
                         licenses.append(_license["license"].get("id"))
-                    if _license["license"].get("name"):
+                    elif _license["license"].get("name"):
                         licenses.append(_license["license"].get("name"))
+                    else:
+                        raise NotImplementedError(
+                            "Unsupported license type (no ID or name) in SBOMer manifest"
+                        )
                 else:  # bomref
-                    raise NotImplementedError("Unsupported license type in SBOMer manifest")
+                    raise NotImplementedError(
+                        "Unsupported license type (bomref) in SBOMer manifest"
+                    )
 
             component["licenses"] = licenses
 

--- a/corgi/core/constants.py
+++ b/corgi/core/constants.py
@@ -17,7 +17,7 @@ CORGI_COMPONENT_TAXONOMY_VERSION = "v1"
 # There's also an Early Access repo: https://maven.repository.redhat.com/earlyaccess/all
 # But anything in there should become GA eventually
 # and we don't want the purls to change over time / we don't know when GA will happen
-RED_HAT_MAVEN_REPOSITORY = "https://maven.repository.redhat.com/ga"
+RED_HAT_MAVEN_REPOSITORY = "https://maven.repository.redhat.com/ga/"
 
 # Map MPTT node levels in our product taxonomy to model names as defined in models.py
 NODE_LEVEL_MODEL_MAPPING = {

--- a/corgi/core/migrations/0100_fix_duplicate_sbomer_components.py
+++ b/corgi/core/migrations/0100_fix_duplicate_sbomer_components.py
@@ -1,0 +1,74 @@
+from django.db import migrations
+from django.db.models import F, Value, functions
+
+from corgi.core.constants import RED_HAT_MAVEN_REPOSITORY
+
+LICENSE_DECLARED_RAW_FIELD = F("license_declared_raw")
+SEMICOLON_VALUE = Value(";")
+SPDX_OR_VALUE = Value(" OR ")
+
+
+def find_duplicate_sbomer_components(apps, schema_editor) -> None:
+    """Find duplicate quarkus-bom components"""
+    Component = apps.get_model("core", "Component")
+    ComponentNode = apps.get_model("core", "ComponentNode")
+
+    # We create and link nodes using relationships in SBOMer manifests
+    # Maven-type quarkus-bom components are the first in a list of components
+    # They have no nodes or links at all, so they must have no relationships in the manifest
+
+    # Generic-type quarkus-bom components are the root (outside the list) in the manifest
+    # They have nodes and provide all other components
+    # So all the relationships in the manifest must refer to the root component,
+    # AKA the generic-type quarkus-bom component which we artificially create,
+    # and nothing refers to the first component in the list,
+    # AKA the Maven-type quarkus-bom component which is identical to the root
+
+    # Delete the unused / duplicated Maven-type components,
+    # so we can make the root component use Maven type instead
+    # so the root component purls in Corgi match the CVE-mapping tool / purls in ET
+    # so SDEngine can easily find and manifest the Quarkus components
+    Component.objects.filter(type="MAVEN", name="quarkus-bom").delete()
+
+    for component in Component.objects.filter(type="GENERIC", name="quarkus-bom").iterator():
+        component.type = "MAVEN"
+        if ";" in component.license_declared_raw:
+            component.license_declared_raw = component.license_declared_raw.replace(";", " OR ")
+
+        if "type" not in component.meta_attr:
+            component.meta_attr["type"] = "pom"
+        if "group_id" not in component.meta_attr:
+            component.meta_attr["group_id"] = "com.redhat.quarkus.platform"
+
+        bad_purl = component.purl
+        good_purl = bad_purl.replace("pkg:generic/", "pkg:maven/com.redhat.quarkus.platform/", 1)
+
+        if "type=" not in good_purl:
+            if "?" not in good_purl:
+                good_purl = f"{good_purl}?type=pom"
+            else:
+                good_purl = f"{good_purl}&type=pom"
+        # Now "?" and "type=" are both guaranteed to be in the purl
+        # So prepend the "repository_url=" qualifier (to keep them in alphabetical order)
+        good_purl = good_purl.replace("?", f"?repository_url={RED_HAT_MAVEN_REPOSITORY}&", 1)
+        component.save()
+
+        ComponentNode.objects.filter(type="SOURCE", parent=None, purl=bad_purl).update(
+            purl=good_purl
+        )
+
+        component.provides.filter(license_declared_raw__contains=";").update(
+            license_declared_raw=functions.Replace(
+                LICENSE_DECLARED_RAW_FIELD, SEMICOLON_VALUE, SPDX_OR_VALUE
+            )
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0099_add_type_arch_stored_proc_filter"),
+    ]
+
+    operations = [
+        migrations.RunPython(find_duplicate_sbomer_components),
+    ]

--- a/corgi/core/migrations/0101_fix_duplicate_rpms.py
+++ b/corgi/core/migrations/0101_fix_duplicate_rpms.py
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
     # and will take forever, so we need to pick up where we left off after timeouts
     atomic = False
     dependencies = [
-        ("core", "0099_add_type_arch_stored_proc_filter"),
+        ("core", "0100_fix_duplicate_sbomer_components"),
     ]
 
     operations = [

--- a/corgi/core/migrations/0102_fix_duplicate_remote_source_components.py
+++ b/corgi/core/migrations/0102_fix_duplicate_remote_source_components.py
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
     # and will take forever, so we need to pick up where we left off after timeouts
     atomic = False
     dependencies = [
-        ("core", "0100_fix_duplicate_rpms"),
+        ("core", "0101_fix_duplicate_rpms"),
     ]
 
     operations = [

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1532,7 +1532,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         # Red Hat components use the repository_url from their purl
         # Upstream components use the default repository_url from the purl spec
         repository_url = (
-            purl_data.qualifiers.get("repository_url") or "https://repo.maven.apache.org/maven2"
+            purl_data.qualifiers.get("repository_url") or "https://repo.maven.apache.org/maven2/"
         )
 
         namespace = purl_data.namespace
@@ -1549,12 +1549,12 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
 
         if namespace and name and version and extension:
             return (
-                f"{repository_url}/{namespace}/{name}/{version}/"
+                f"{repository_url}{namespace}/{name}/{version}/"
                 f"{name}-{version}{classifier}.{extension}"
             )
 
         elif namespace and name and version:
-            return f"{repository_url}/{namespace}/{name}/{version}"
+            return f"{repository_url}{namespace}/{name}/{version}"
 
         else:
             return ""

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -80,7 +80,7 @@ def slow_fetch_pnc_sbom(purl: str, product_data: dict, sbom_data: dict) -> None:
             defaults=defaults,
         )
 
-        set_license_declared_safely(components[bomref], ";".join(component["licenses"]))
+        set_license_declared_safely(components[bomref], " OR ".join(component["licenses"]))
 
     # Link dependencies
     nodes = {}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -566,17 +566,18 @@ def test_slow_fetch_pnc_sbom():
 
         # Test with an SBOM available message that has a PV that
         # doesn't exist in ET. An sbom object shouldn't be created,
-        # because the fetch task should log that the PV doesn't exist
+        # because the fetch task should raise an error that the PV doesn't exist
         # and end early.
         with patch("corgi.collectors.pnc.SbomerSbom.__init__") as parse_sbom_mock:
             with open("tests/data/pnc/sbom_no_variant.json") as complete_file:
                 complete_data = json.load(complete_file)["msg"]
 
-            slow_fetch_pnc_sbom(
-                complete_data["purl"],
-                complete_data["productConfig"]["errataTool"],
-                complete_data["sbom"],
-            )
+            with pytest.raises(CollectorErrataProductVariant.DoesNotExist):
+                slow_fetch_pnc_sbom(
+                    complete_data["purl"],
+                    complete_data["productConfig"]["errataTool"],
+                    complete_data["sbom"],
+                )
 
             parse_sbom_mock.assert_not_called()
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review. This should:

1. Ensure we always create valid SPDX license expressions (CORGI-871)
2. Fix historical data for quarkus-bom root components
3. Make sure new quarkus-bom root components are Maven-type
4. Stop adding a ?repository_url= qualifier to Red Hat Maven component purls
5. Make certain errors a little more visible and clean up some code

I hope that 2, 3, and 4 are enough to keep Corgi purls identical to SBOMer purls. That should allow SDEngine to find quarkus-bom root components / new Quarkus versions in Corgi, using just the SBOMer purl as given in the Notes field of some SHIPPED_LIVE erratum. Then SDEngine doesn't have to write any complex code to find which quarkus-bom component / Quarkus version needs to get manifested.

For number 4, I didn't add a migration to fix all the existing Maven-type purls. Thanks to the bugfix in COGI-557, these should get automatically updated the next time we call save() on the component, AND the purls on the nodes will be updated as well / data will not get out of sync. Updating both the component and node purls in a migration is very fiddly, but I'm happy to write one if people prefer.

I'm definitely not as familiar with this part of the code, so please let me know if I've missed something or a change here doesn't look quite right. Thank you!