### PR TITLE
CORGI-873 add missing_license_declared api filter

### DIFF
--- a/corgi/api/filters.py
+++ b/corgi/api/filters.py
@@ -126,9 +126,14 @@ class ComponentFilter(FilterSet):
         label="Show only unscanned components (where copyright text is empty)",
     )
 
-    missing_license = EmptyStringFilter(
+    missing_license_concluded = EmptyStringFilter(
         field_name="license_concluded_raw",
         label="Show only unscanned components (where license concluded is empty)",
+    )
+
+    missing_license_declared = EmptyStringFilter(
+        field_name="license_declared_raw",
+        label="Show only unscanned components (where license declared is empty)",
     )
 
     missing_scan_url = EmptyStringFilter(

--- a/openapi.yml
+++ b/openapi.yml
@@ -364,10 +364,15 @@ paths:
           type: boolean
         description: Show only unscanned components (where copyright text is empty)
       - in: query
-        name: missing_license
+        name: missing_license_concluded
         schema:
           type: boolean
         description: Show only unscanned components (where license concluded is empty)
+      - in: query
+        name: missing_license_declared
+        schema:
+          type: boolean
+        description: Show only unscanned components (where license declared is empty)
       - in: query
         name: missing_scan_url
         schema:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -531,20 +531,27 @@ def test_root_components_filter(client, api_path):
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_detail_unscanned_filter(client, api_path):
-    ComponentFactory(name="copyright", copyright_text="test", license_concluded_raw="")
-    ComponentFactory(name="license", license_concluded_raw="test")
-    ComponentFactory(name="unscanned", license_concluded_raw="")
+    ComponentFactory(
+        name="copyright", copyright_text="test", license_concluded_raw="", license_declared_raw=""
+    )
+    ComponentFactory(
+        name="license_concluded", license_concluded_raw="test", license_declared_raw=""
+    )
+    ComponentFactory(name="unscanned", license_concluded_raw="", license_declared_raw="")
+    ComponentFactory(name="license_declared", license_declared_raw="test", license_concluded_raw="")
 
     response = client.get(f"{api_path}/components")
     assert response.status_code == 200
-    assert response.json()["count"] == 3
+    assert response.json()["count"] == 4
 
     response = client.get(f"{api_path}/components?missing_copyright=True")
     assert response.status_code == 200
     response = response.json()
-    assert response["count"] == 2
-    assert response["results"][0]["name"] == "license"
-    assert response["results"][1]["name"] == "unscanned"
+    assert response["count"] == 3
+    results = [r["name"] for r in response["results"]]
+    assert "license_concluded" in results
+    assert "unscanned" in results
+    assert "license_declared" in results
 
     response = client.get(f"{api_path}/components?missing_copyright=False")
     assert response.status_code == 200
@@ -552,18 +559,35 @@ def test_component_detail_unscanned_filter(client, api_path):
     assert response["count"] == 1
     assert response["results"][0]["name"] == "copyright"
 
-    response = client.get(f"{api_path}/components?missing_license=True")
+    response = client.get(f"{api_path}/components?missing_license_concluded=True")
     assert response.status_code == 200
     response = response.json()
-    assert response["count"] == 2
-    assert response["results"][0]["name"] == "copyright"
-    assert response["results"][1]["name"] == "unscanned"
+    assert response["count"] == 3
+    results = [r["name"] for r in response["results"]]
+    assert "unscanned" in results
+    assert "license_declared" in results
+    assert "copyright" in results
 
-    response = client.get(f"{api_path}/components?missing_license=False")
+    response = client.get(f"{api_path}/components?missing_license_concluded=False")
     assert response.status_code == 200
     response = response.json()
     assert response["count"] == 1
-    assert response["results"][0]["name"] == "license"
+    assert response["results"][0]["name"] == "license_concluded"
+
+    response = client.get(f"{api_path}/components?missing_license_declared=True")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 3
+    results = [r["name"] for r in response["results"]]
+    assert "unscanned" in results
+    assert "license_concluded" in results
+    assert "copyright" in results
+
+    response = client.get(f"{api_path}/components?missing_license_declared=False")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+    assert response["results"][0]["name"] == "license_declared"
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)


### PR DESCRIPTION
I updated the existing filter name from missing_license to missing_license_concluded and added a new one for missing_license_declared.