### PR TITLE
CORGI-879: Fix silly failure to actually set updated purl value

### DIFF
--- a/corgi/core/migrations/0100_fix_duplicate_sbomer_components.py
+++ b/corgi/core/migrations/0100_fix_duplicate_sbomer_components.py
@@ -56,6 +56,7 @@ def find_duplicate_sbomer_components(apps, schema_editor) -> None:
         # Now "?" and "type=" are both guaranteed to be in the purl
         # So prepend the "repository_url=" qualifier (to keep them in alphabetical order)
         good_purl = good_purl.replace("?", f"?repository_url={RED_HAT_MAVEN_REPOSITORY}&", 1)
+        component.purl = good_purl
         component.save()
 
         ComponentNode.objects.filter(type="SOURCE", parent=None, purl=bad_purl).update(


### PR DESCRIPTION
Very dumb mistake I should have caught. The migration won't run again in stage so I've manually fixed the affected components (using the same code as in the migration). Prod should run all the updated migration code together / automatically and not have any lingering data issues that need to be manually fixed.