### PR TITLE
CORGI-900: Don't treat "-or-" in SPDX license IDs as the SPDX "OR" operator

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1936,11 +1936,13 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
     def license_clean(license_str: str) -> str:
         """Take an SPDX license expression, and remove spaces from all identifiers
         so that PUBLIC DOMAIN becomes PUBLIC-DOMAIN, ASL 2.0 becomes ASL-2.0, etc."""
-        license_str = license_str.replace(" ", "-")
-        # Above fixed identifiers, but also the keywords "-AND-", "-OR-" and "-WITH-"
-        license_str = license_str.replace("-AND-", " AND ")
-        license_str = license_str.replace("-OR-", " OR ")
-        license_str = license_str.replace("-WITH-", " WITH ")
+        # We use underscores to avoid turning "GPL-V2-OR-LATER" into "GPL-V2 OR LATER"
+        license_str = license_str.replace(" ", "_")
+        # Above fixed identifiers, but also the keywords "_AND_", "_OR_" and "_WITH_"
+        license_str = license_str.replace("_AND_", " AND ")
+        license_str = license_str.replace("_OR_", " OR ")
+        license_str = license_str.replace("_WITH_", " WITH ")
+        license_str = license_str.replace("_", "-")
         return license_str
 
     @property

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1541,3 +1541,17 @@ def test_license_properties():
     # We should end up with an empty list, and not [""]
     assert c.license_concluded_list == []
     assert c.license_declared_list == []
+
+    c.license_concluded_raw = "GPL-v2-or-later WITH Alice-and-Bobs-Exception"
+    c.license_declared_raw = "GPL-v2-or-later WITH Alice-and-Bobs-Exception"
+    c.save()
+    # Make sure tht we don't accidentally split -operator- in a license ID
+    # into a standalone SPDX operator, like "GPL-v2 OR later WITH Alice AND Bobs-exception"
+    assert " LATER " not in c.license_concluded
+    assert " ALICE " not in c.license_concluded
+    assert " LATER " not in c.license_declared
+    assert " ALICE " not in c.license_declared
+    assert "LATER" not in c.license_concluded_list
+    assert "ALICE" not in c.license_concluded_list
+    assert "LATER" not in c.license_declared_list
+    assert "ALICE" not in c.license_declared_list


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Quick review please.