### PR TITLE
avoid runtime warning and failing tests/test_sca.py because of changes in Python3.11 to avoid CVE-2007-4559

### DIFF
--- a/corgi/collectors/go_list.py
+++ b/corgi/collectors/go_list.py
@@ -26,7 +26,11 @@ class GoList:
             if not target_path.is_dir():
                 with tempfile.TemporaryDirectory() as extract_dir:
                     try:
-                        unpack_archive(target_path, extract_dir)
+                        # Added the filter argument as recommended by
+                        # https://access.redhat.com/articles/7004769#specify-when-calling
+                        unpack_archive(
+                            target_path, extract_dir=extract_dir, filter="data"
+                        )  # type: ignore[call-arg]
                     except ReadError:
                         logger.debug("Cannot unpack file: %s", target_path)
                         continue


### PR DESCRIPTION
This change should be compatible with future Python versions.