### PR TITLE
Fix component lookup failure due to using wrong purl field

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,9 @@ mypy:
   image: $PYTHON_TOX_IMAGE_LATEST
   before_script:
     - *common_ci_setup
+    - *common_test_setup
   script:
+    - $DNF_WITH_OPTIONS install python3.11-devel python3-wheel
     - tox -e mypy
   except:
     refs:
@@ -155,7 +157,9 @@ schema:
   image: $PYTHON_TOX_IMAGE_LATEST
   before_script:
     - *common_ci_setup
+    - *common_test_setup
   script:
+    - $DNF_WITH_OPTIONS install python3.11-devel python3-wheel
     - tox -e schema
   except:
     refs:

--- a/tests/data/pnc/erratum_notes.json
+++ b/tests/data/pnc/erratum_notes.json
@@ -2,7 +2,7 @@
   "manifest" : {
     "refs" : [ {
       "type" : "purl",
-      "uri" : "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.SP2-redhat-00001?type=pom"
+      "uri" : "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.SP2-redhat-00001?repository_url=https://maven.repository.redhat.com/ga/&type=pom"
     } ]
   },
   "simple-mapper" : {

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -560,7 +560,7 @@ def test_slow_fetch_pnc_sbom():
 
         # The root component and all its children should have MAVEN type
         maven_components = Component.objects.filter(type=Component.Type.MAVEN)
-        assert maven_components.count() == 6
+        assert len(maven_components) == 6
 
         # One component is only available upstream, the rest are built at Red Hat / in PNC
         red_hat_maven_components = maven_components.filter(namespace=Component.Namespace.REDHAT)
@@ -621,7 +621,7 @@ def test_slow_handle_pnc_errata_released():
         "corgi.collectors.errata_tool.ErrataTool.get_erratum_notes", return_value=notes
     ) as get_notes_mock:
         # Well-formed notes data with no matching Corgi component
-        with pytest.raises(ValueError):
+        with pytest.raises(Component.DoesNotExist):
             slow_handle_pnc_errata_released(120325, "SHIPPED_LIVE")
 
         get_notes_mock.assert_called_once_with(120325)


### PR DESCRIPTION
@kgrant-rh FYI. I'm going to go ahead and merge since I'm reasonably confident this is correct, and of course the very next thing I'll do is test this code in stage. But please let me know if you see any issues with the logic here.

I think this slow_handle_pnc_errata_released() task is using purls from Errata Tool, specifically in the "Notes" field of some middleware erratum. These are generated by Alexey's CVE-mapping generator for Quarkus components and CVEs.

Per my understanding, the tool will always add the `?repository_url=` qualifier to the SBOMer / PNC purls, just like Corgi does. So I think this will continue to work in the future, for newly-released Quarkus errata. It should also work for all existing Quarkus errata, since Alexey already updated the purls manually to include this qualifier and match the Corgi purls.