### PR TITLE
CORGI-904: Fix weird bug due to comparing historical and non-historical models

### DIFF
--- a/corgi/core/migrations/0103_fix_duplicate_remote_source_components.py
+++ b/corgi/core/migrations/0103_fix_duplicate_remote_source_components.py
@@ -2,13 +2,11 @@ from django.db import migrations
 from django.db.models import F, Q
 
 # Must use non-historical model which supports cnodes
-from corgi.core.models import Component
+from corgi.core.models import Component, ComponentNode
 
 
 def find_duplicate_remote_source_components(apps, schema_editor) -> None:
     """Find duplicate Maven, NPM, PyPI, etc. nodes with bad purls"""
-    ComponentNode = apps.get_model("core", "ComponentNode")
-
     # We could do this without the for loop, but checking type / arch pairs individually
     # means the query hits an index and should be faster
     for component_type in Component.REMOTE_SOURCE_COMPONENT_TYPES:


### PR DESCRIPTION
This was already fixed for migration number 102 a while ago, but I forgot to fix it for migration number 103 as well back then.