### PR TITLE
CORGI-915: Fix "quarkus-bom" component providing itself / duplicate data in manifests

### DIFF
--- a/corgi/collectors/pnc.py
+++ b/corgi/collectors/pnc.py
@@ -31,8 +31,14 @@ class SbomerSbom:
         # separately for each dependency they have or fulfill.
         # FIXME ------
         # Temporary workaround for component purl conflicts
+        root_component = data["metadata"]["component"]
         self.components = {}
-        created_nvrs = set()
+        # A set of tuples, pre-populated with the root component's name and version
+        created_nvrs = {(root_component["name"], root_component["version"])}
+        # The first entry should be a duplicate of the root component
+        # Don't create an extra node for it, otherwise quarkus-bom will provide quarkus-bom
+        # so it will appear twice in our manifeats, and IDs will not be unique
+        # this breaks parsing of SPDX manifests by clients
         for component in data["components"]:
             if (component["name"], component["version"]) in created_nvrs:
                 continue
@@ -42,7 +48,7 @@ class SbomerSbom:
         # self.components = {c["bom-ref"]: c for c in data["components"]}
         # FIXME -------
         # The root component is listed separately in metadata
-        self.components["root"] = data["metadata"]["component"]
+        self.components["root"] = root_component
         for component in self.components.values():
             meta_attr = {}
 

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -6,12 +6,12 @@ from celery_singleton import Singleton
 
 from config.celery import app
 from corgi.collectors.errata_tool import ErrataTool
-from corgi.collectors.models import CollectorErrataProductVariant
 from corgi.collectors.pnc import SbomerSbom
 from corgi.core.models import (
     Component,
     ComponentNode,
     ProductComponentRelation,
+    ProductVariant,
     SoftwareBuild,
 )
 from corgi.tasks.brew import set_license_declared_safely, slow_save_taxonomy
@@ -26,7 +26,7 @@ def slow_fetch_pnc_sbom(purl: str, product_data: dict, sbom_data: dict) -> None:
     logger.info(f"Fetching PNC SBOM {sbom_data['id']} for purl {purl} from {sbom_data['link']}")
 
     # Validate the supplied product information
-    CollectorErrataProductVariant.objects.get(name=product_data["productVariant"])
+    ProductVariant.objects.get(name=product_data["productVariant"])
 
     # Fetch and parse the SBOM
     response = requests.get(sbom_data["link"])

--- a/tests/data/pnc/pnc_sbom.json
+++ b/tests/data/pnc/pnc_sbom.json
@@ -156,6 +156,99 @@
                     ]
                 },
                 "publisher": "Red Hat",
+                "group": "com.redhat.quarkus.platform",
+                "name": "quarkus-bom",
+                "version": "2.13.8.Final-redhat-00003",
+                "description": "Red Hat Build of Quarkus - Kubernetes Native Java stack tailored for OpenJDK HotSpot and GraalVM",
+                "licenses": [
+                    {
+                        "license": {
+                            "id": "Apache-2.0"
+                        }
+                    }
+                ],
+                "purl": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00003?type=pom",
+                "pedigree": {
+                    "commits": [
+                        {
+                            "uid": "370253ca4fca2c2f5c4b86b3c7febd94193dc16c",
+                            "url": "https://example.com/gerrit/quarkusio/quarkus-platform.git#2.13.8.Final-redhat-00003"
+                        }
+                    ]
+                },
+                "externalReferences": [
+                    {
+                        "type": "distribution",
+                        "url": "https://maven.repository.redhat.com/ga/"
+                    },
+                    {
+                        "type": "build-system",
+                        "url": "https://example.com/v2/builds/AZL76RACCHQAA",
+                        "comment": "pnc-build-id"
+                    },
+                    {
+                        "type": "build-meta",
+                        "url": "quay.io/rh-newcastle/builder-rhel-8-j11-mvn3.8.6-gradle7.5.1-gcc-cpp-make:1.0.0",
+                        "comment": "pnc-environment-image"
+                    },
+                    {
+                        "type": "vcs",
+                        "url": "https://github.com/quarkusio/quarkus-platform.git",
+                        "comment": ""
+                    }
+                ],
+                "properties": [
+                    {
+                        "name": "product-id",
+                        "value": "quarkus-2"
+                    },
+                    {
+                        "name": "product-stream",
+                        "value": "quarkus-2.13"
+                    },
+                    {
+                        "name": "errata-tool-product-name",
+                        "value": "RHBQ"
+                    },
+                    {
+                        "name": "errata-tool-product-version",
+                        "value": "RHEL-8-RHBQ-2.13"
+                    },
+                    {
+                        "name": "errata-tool-product-variant",
+                        "value": "8Base-RHBQ-2.13"
+                    }
+                ],
+                "releaseNotes": {
+                    "type": "Patch",
+                    "title": "Red Hat Build of Quarkus 2.13.8.Final-redhat-00003",
+                    "aliases": [
+                        "RHBQ",
+                        "Quarkus",
+                        "Fireball"
+                    ],
+                    "properties": [
+                        {
+                            "name": "product-name",
+                            "value": "Red Hat Build of Quarkus"
+                        },
+                        {
+                            "name": "product-version",
+                            "value": "2.13.8.Final-redhat-00003"
+                        }
+                    ]
+                },
+                "type": "framework",
+                "bom-ref": "pkg:maven/com.redhat.quarkus.platform/quarkus-bom@2.13.8.Final-redhat-00003?type=pom"
+            },
+            {
+                "supplier": {
+                    "name": "Red Hat",
+                    "url": [
+                        "https://www.redhat.com"
+                    ]
+                },
+                "publisher": "Red Hat",
                 "group": "io.agroal",
                 "name": "agroal-narayana",
                 "version": "1.17.0.redhat-00001",


### PR DESCRIPTION
@kgrant-rh Quick review please. I still need to regenerate Quarkus data in prod after migration number 100 ran, and I think this fix will solve the issue Jens Reimann reported.

I think the existing tests would have covered this issue, except that the sample data we load only has the root component once. It doesn't duplicate the root component into the first entry in the list of components. I changed it to match what I think SBOMer really sends us, but please let me know if that isn't right.