### PR TITLE
CORGI-854 / CORGI-923: Fix mangen-related bugs

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -246,7 +246,25 @@ def cpu_manifest_service(stream_name: str, service_components: list) -> None:
                     f"Service component {service_component['name']} for service {stream_name} "
                     f"had a child component {component}"
                 )
-                obj_or_node_created = save_component(component, root_node)
+
+                try:
+                    obj_or_node_created = save_component(component, root_node)
+
+                except ValueError:
+                    # Sometimes a duplicate component already exists, but can't be found
+                    # e.g. when Syft's combined "version-release" doesn't match
+                    # a separate "version" and "release" we created using Brew data
+                    version_and_release = component["meta"]["version"].split("-", 1)
+
+                    if len(version_and_release) != 2:
+                        # We didn't have a combined version-release like we expected
+                        raise
+
+                    # Else we did have a combined version-release
+                    # Split these out into separate fields, then try again to save this component
+                    component["meta"]["version"], component["meta"]["release"] = version_and_release
+                    obj_or_node_created = save_component(component, root_node)
+
                 if obj_or_node_created:
                     created_count += 1
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review this fix for bad data in stage. Each day, we delete old managed service data, then rerun Syft on all Github repos and Quay images for each managed service. This change addresses the removed TODO comment, where we weren't fully cleaning up old data from previous runs of our managed services tasks.

There's (I think) another bug as well. Syft creates components like "@rails/actiontext" with a combined version string like "version-release" and an empty release string like "". I tried fixing this (a very long time ago) just for managed services, so that we'd get a version like "version" and a release like "release". This ended up causing odd failures I didn't have time to go investigate, so I reverted this change.

However, some components with the correct "version" and "release" were left behind. Now Syft fails to create the same e.g. "@rails/actiontext" component with a combined "version-release" string, due to unique constraints on the purl. So the second commit here fixes Syft again, so that the version and release are reported correctly in separate fields.

I hope this should avoid the errors we saw before, since now we only split Syft's version-release into separate fields if absolutely necessary (when we already had a separate version and release from another Syft scan, or from Brew). Thoughts welcome. I'd like to deploy this to stage (without merging) to confirm it really fixes the issue. If so I'll add tests for this.

Finally, I just added a commit that should fix manifest generation for managed services. Previously, we only generated a manifest locally if a stream had "released components" that are publicly available for customers. This required ProductComponentRelations with type "ERRATA" (for most products, including RHEL) or "COMPOSE" (a special case for RHEL only).

Now we consider "APP_INTERFACE" relations / components as always being released. I think this is correct, since we only manifest the production version of the services, so the components we discover should already be running in the service's environment.

We still won't publish manifests for services to the Customer Portal, since all the managed service streams always have the "no_manifest" tag. But generating the manifest locally means Griffon searches will start working, which unblocks the VM team from switching to Corgi and abandoning the legacy mangen.