### PR TITLE
CORGI-923: Fix unsaved taxonomies

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -237,8 +237,7 @@ def cpu_manifest_service(stream_name: str, service_components: list) -> None:
                 type=ProductComponentRelation.Type.APP_INTERFACE,
             )
 
-        # Give the transaction time to commit, before looking up the build we just created
-        slow_save_taxonomy.apply_async(args=(build.build_id, build.build_type), countdown=10)
+        slow_save_taxonomy(build.build_id, build.build_type)
 
         logger.info(
             f"Finished processing service component {service_component['name']} "


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Currently we have over 120,000 tasks in our slow queue in stage, and over 30,000 slow tasks in production. This is causing issues because each day, we try to:

1. Delete all the existing managed services components (which might be stale / no longer used by some service), one task in the fast queue for all services
2. Add back all the components which are still being used by each service, one task in the CPU queue for each service
3. Save the taxonomies so each service's components are linked to that service's stream, one task in the slow queue for each root component / build for each service

Parts 1 and 2 work well, but part 3 is getting stuck behind all the other slow tasks that have yet to run. This means that Griffon searches for managed service components fail, because the components aren't correctly linked to the streams. Even if they were linked OK yesterday, or if I manually fix the links today, the Griffon search will still start failing tomorrow. As long as the queue is clogged, the data we recreate tomorrow won't be properly linked after it's recreated.

We could fiddle with Celery priorities for our queue, so that more important tasks jump in line ahead of less-important ones. But this feature seems complex, hacky and poorly-supported for Redis brokers.

Or we could run the "delete and recreate mangen data" tasks only once a week instead of once a day. Then we'd have less risk of queues being clogged while the task is running, and we'd be recreating the data less often so there's less risk of things going wrong. But I don't think "data may be stale for up to one week" would be acceptable to the VM team.

So the simple solution here is probably just to run the taxonomy-saving task inline, as part of the "manifest this service" task, instead of separately. That way, either a service's components will be created and linked to streams all at once, or they won't be created at all. Then we won't have to worry about data that's created but not linked yet. This may cause timeouts since the task will now take longer to finish - we can raise the task timeout if so.