### PR TITLE
dont recheck container names from pyxis on failed migration

### DIFF
--- a/corgi/core/migrations/0105_get_latest_repo_names_from_pyxis.py
+++ b/corgi/core/migrations/0105_get_latest_repo_names_from_pyxis.py
@@ -11,16 +11,39 @@ def get_latest_repo_names_from_pyxis(apps, schema_editor) -> None:
         Component.objects.filter(
             type=Component.Type.CONTAINER_IMAGE, software_build__build_type=SoftwareBuild.Type.BREW
         )
+        # These containers should have pyxis names set since they were processed after we updated
+        # the brew collector to check pyxis for names which differ from Brew
         .exclude(meta_attr__has_key="name_from_label_raw")
+        # This allows the migration to be re-run in case of failure.
+        .exclude(meta_attr__has_key="name_checked")
         .values_list("nvr", flat=True)
         .iterator()
     )
     for nvr in brew_container_nvrs:
         slow_update_name_for_container_from_pyxis.delay(nvr)
 
+        # Set this so they are not re-processed next run
+        containers_to_update = Component.objects.filter(
+            type=Component.Type.CONTAINER_IMAGE,
+            software_build__build_type=SoftwareBuild.Type.BREW,
+            nvr=nvr,
+        )
+        checked_containers = []
+        for container in containers_to_update:
+            container.meta_attr["name_checked"] = True
+            container.save()
+            checked_containers.append(container)
+        Component.objects.bulk_update(checked_containers, ["meta_attr"])
+
+    checked_containers = []
+    for container in Component.objects.filter(meta_attr__name_checked=True):
+        del container.meta_attr["name_checked"]
+        checked_containers.append(container)
+    Component.objects.bulk_update(checked_containers, ["meta_attr"])
+
 
 class Migration(migrations.Migration):
-
+    atomic = False
     dependencies = [("core", "0104_fix_root_components_condition")]
 
     operations = [


### PR DESCRIPTION
If a migration takes longer than the timeout period for an init-container in OpenShift we have to run it again manually. That means that if a migration takes longer than 10 min it fail. This change prevents the 0105_get_latest_repo_names_from_pyxis migration from rechecking the same containers if it's run more than once.

