### PR TITLE
CORGI-854: Fix hopefully last mangen bugs

### DIFF
--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -154,12 +154,15 @@ class Syft:
             # This may fail if we don't have access to the repository. GIT_TERMINAL_PROMPT=0
             # ensures that we don't hang the command on a prompt for a username and password.
             env = dict(os.environ, GIT_TERMINAL_PROMPT="0")
-            result = subprocess.run(
-                ["/usr/bin/git", "clone", target_url, scan_dir],
-                capture_output=True,
-                timeout=120,  # seconds
-                env=env,
-            )  # nosec B603
+            try:
+                result = subprocess.run(
+                    ["/usr/bin/git", "clone", target_url, scan_dir],
+                    capture_output=True,
+                    timeout=120,  # seconds
+                    env=env,
+                )  # nosec B603
+            except subprocess.TimeoutExpired as exc:
+                raise GitCloneError(f"git clone of {target_url} failed with: {exc}")
             if result.returncode != 0:
                 raise GitCloneError(
                     f"git clone of {target_url} failed with: {result.stderr.decode('utf-8')}"

--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -158,7 +158,9 @@ class Syft:
                 result = subprocess.run(
                     ["/usr/bin/git", "clone", target_url, scan_dir],
                     capture_output=True,
-                    timeout=120,  # seconds
+                    # ansible-hub-ui build repo is expected to time out
+                    # because it's 785 MB and only growing...
+                    timeout=300,  # seconds
                     env=env,
                 )  # nosec B603
             except subprocess.TimeoutExpired as exc:

--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -276,25 +276,7 @@ def cpu_manifest_service(stream_name: str, service_components: list[dict[str, st
                     f"Service component {service_component['name']} for service {stream_name} "
                     f"had a child component {component}"
                 )
-
-                try:
-                    obj_or_node_created = save_component(component, root_node)
-
-                except ValueError:
-                    # Sometimes a duplicate component already exists, but can't be found
-                    # e.g. when Syft's combined "version-release" doesn't match
-                    # a separate "version" and "release" we created using Brew data
-                    version_and_release = component["meta"]["version"].split("-", 1)
-
-                    if len(version_and_release) != 2:
-                        # We didn't have a combined version-release like we expected
-                        raise
-
-                    # Else we did have a combined version-release
-                    # Split these out into separate fields, then try again to save this component
-                    component["meta"]["version"], component["meta"]["release"] = version_and_release
-                    obj_or_node_created = save_component(component, root_node)
-
+                obj_or_node_created = save_component(component, root_node)
                 if obj_or_node_created:
                     created_count += 1
 

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -94,6 +94,15 @@ def find_duplicate_component(
     # TODO: check Parsley edge-case / error in monitoring email
     if same_name_different_case or dash_underscore_confusion:
         return possible_dupe
+
+    elif "-" in version and not release:
+        # Sometimes a duplicate component already exists, but can't be found
+        # e.g. when Syft's combined "version-release" doesn't match
+        # a separate "version" and "release" we created using Brew data
+        # Split these out into separate fields, then try again to save this component
+        version, release = version.split("-", 1)
+        return find_duplicate_component(component_type, name, version, release, arch)
+
     else:
         # Some other case we need to consider / handle in our code
         raise ValueError(


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI, I'm going to just merge this so I can see if the same error happens again in tomorrow's task. The error-handling logic I added before is almost correct, but needs to be in a different place because the dict of component data gets mutated (.pop() is called) by the save_component() function.

That means the try / except I added won't work, since the version and release have already been removed from the dict after we bail out of .save(). The actual logic itself of "how to find a duplicate component" doesn't need to change much, we just need this new version / release check to happen as part of the save_component() function.

This also increases the timeout when cloning large (over 100MB) Git repos, and treats "git clone" failures due to timeouts the same as "git clone" failures due to permissions. We'll note the error, continue analyzing the remaining components for the service, and then raise all applicable errors at the end.