### PR TITLE
CORGI-854: Treat all subprocess errors as permission-related

### DIFF
--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -19,10 +19,6 @@ class GitCloneError(Exception):
     pass
 
 
-class QuayImagePullError(Exception):
-    pass
-
-
 class Syft:
     # Syft packages types: https://github.com/anchore/syft/blob/v0.72.0/syft/pkg/type.go
     SYFT_PKG_TYPE_MAPPING = {
@@ -126,12 +122,9 @@ class Syft:
 
         version = "latest"
         # Some images have no tags at all, so pulling the image will fail either way
-        tags = response.json()["tags"]
-        if not tags:
-            raise QuayImagePullError(
-                f"image pull of {target_host}/{target_image} failed because there were no tags"
-            )
-        for tag in tags:
+        # If empty, the for-loop below won't be entered, so we default version to "latest"
+        # to get a meaningful error when pulling instead of "NameError: version undefined" here
+        for tag in response.json()["tags"]:
             # The tags key is a nested dict and not a list, so we can't just grab tags[0]
             # The first key in the dict is always the newest / most recently updated tag name
             version = tag

--- a/corgi/core/migrations/0079_fix_component_variants.py
+++ b/corgi/core/migrations/0079_fix_component_variants.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-from corgi.tasks.brew import slow_save_taxonomy
+from corgi.tasks.common import slow_save_taxonomy
 
 
 def fix_variant_component_links(apps, schema_editor):

--- a/corgi/core/migrations/0083_set_build_fk_relations.py
+++ b/corgi/core/migrations/0083_set_build_fk_relations.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 # Non-historical model, i.e. if you change save_product_taxonomy() tomorrow
 # the migration will not run the same code as before (at the time the migration was written)
-from corgi.tasks.brew import slow_save_taxonomy as current_save_taxonomy
+from corgi.tasks.common import slow_save_taxonomy as current_save_taxonomy
 
 
 def set_build_fk_relations(apps, schema_editor):

--- a/corgi/core/migrations/0105_get_latest_repo_names_from_pyxis.py
+++ b/corgi/core/migrations/0105_get_latest_repo_names_from_pyxis.py
@@ -44,21 +44,21 @@ def get_latest_repo_names_from_pyxis(apps, schema_editor) -> None:
             nvr=nvr,
         ).update(meta_attr=meta_attr_func)
 
-    checked_containers = []
+    # checked_containers = []
     # Filtering on type + arch first makes below use an index
     # and excludes many unneeded results before doing expensive JSONField filtering
-    for container in Component.objects.filter(
-        type=Component.Type.CONTAINER_IMAGE, arch="noarch", meta_attr__name_checked=True
-    ).iterator():
-        del container.meta_attr["name_checked"]
-        checked_containers.append(container)
-    Component.objects.bulk_update(checked_containers, ["meta_attr"])
+    # for container in Component.objects.filter(
+    #     type=Component.Type.CONTAINER_IMAGE, arch="noarch", meta_attr__name_checked=True
+    # ).iterator():
+    #     del container.meta_attr["name_checked"]
+    #     checked_containers.append(container)
+    # Component.objects.bulk_update(checked_containers, ["meta_attr"])
+
     # The built-in Postgres jsonb_set function doesn't allow removing keys from a JSONField
     # This is possible in RawSQL, but I don't want to bother
-    # If doing bulk_update() in the migration still causes the pod to run out of memory
-    # we know that everything else is finished, and can just remove the name_checked keys ourselves
+    # Doing bulk_update() in the migration causes the DB query to time out
+    # We know that everything else is finished, so can just remove the name_checked keys ourselves
     # or maybe just leave the values in the meta_attr - they won't hurt anything
-    # I will comment out above if so, then finish off migration
 
 
 class Migration(migrations.Migration):

--- a/corgi/tasks/errata_tool.py
+++ b/corgi/tasks/errata_tool.py
@@ -46,7 +46,7 @@ def slow_save_errata_product_taxonomy(erratum_id: int) -> None:
     for build_id, build_type, _ in relation_builds:
         logger.info("Saving product taxonomy for build (%s, %s)", build_id, build_type)
         # once all build's components are ingested we must save product taxonomy
-        app.send_task("corgi.tasks.brew.slow_save_taxonomy", args=(build_id, build_type))
+        app.send_task("corgi.tasks.common.slow_save_taxonomy", args=(build_id, build_type))
 
 
 @app.task(base=Singleton, autoretry_for=RETRYABLE_ERRORS, retry_kwargs=RETRY_KWARGS, priority=3)

--- a/corgi/tasks/management/commands/updatecomponenttaxonomy.py
+++ b/corgi/tasks/management/commands/updatecomponenttaxonomy.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.core.models import SoftwareBuild
-from corgi.tasks.brew import slow_save_taxonomy
+from corgi.tasks.common import slow_save_taxonomy
 
 
 class Command(BaseCommand):

--- a/corgi/tasks/pnc.py
+++ b/corgi/tasks/pnc.py
@@ -14,8 +14,8 @@ from corgi.core.models import (
     ProductVariant,
     SoftwareBuild,
 )
-from corgi.tasks.brew import set_license_declared_safely, slow_save_taxonomy
-from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
+from corgi.tasks.brew import set_license_declared_safely
+from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, slow_save_taxonomy
 
 logger = get_task_logger(__name__)
 

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -24,8 +24,7 @@ from corgi.core.models import (
     ProductVersion,
     SoftwareBuild,
 )
-from corgi.tasks.brew import slow_save_taxonomy
-from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
+from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, slow_save_taxonomy
 
 logger = get_task_logger(__name__)
 # Find a substring that looks like a version (e.g. "3", "3.5", "3-5", "1.2.z") at the end of a

--- a/corgi/tasks/sca.py
+++ b/corgi/tasks/sca.py
@@ -240,7 +240,7 @@ def cpu_software_composition_analysis(build_uuid, force_process: bool = False):
                 "had child components that were not found in remote-sources.json!"
             )
         app.send_task(
-            "corgi.tasks.brew.slow_save_taxonomy",
+            "corgi.tasks.common.slow_save_taxonomy",
             args=(software_build.build_id, software_build.build_type),
         )
 

--- a/tests/test_app_interface.py
+++ b/tests/test_app_interface.py
@@ -1,4 +1,3 @@
-import subprocess
 from contextlib import nullcontext
 from subprocess import CalledProcessError
 from unittest.mock import call, patch
@@ -7,7 +6,7 @@ import pytest
 from django.conf import settings
 
 from corgi.collectors.app_interface import AppInterface
-from corgi.collectors.syft import GitCloneError, QuayImagePullError, Syft
+from corgi.collectors.syft import GitCloneError, Syft
 from corgi.tasks.managed_services import (
     MultiplePermissionExceptions,
     cpu_manifest_service,
@@ -121,7 +120,6 @@ def test_metadata_fetch(requests_mock):
         (
             # Dict values aren't used and don't matter, we just need the first dict key
             # Which is always the newest / most recently updated tag name
-            # nullcontext here means "no exception raised"
             {"tags": {"t1": {"name": "t1", "date": 2}, "t2": {"name": "t2", "date": 1}}},
             "t1",
             "quay.io",
@@ -130,29 +128,29 @@ def test_metadata_fetch(requests_mock):
         ),
         # Code works with public Quay.io instance or any internal Quay server
         ({"tags": {"t1": {}}}, "t1", "internal.quay", "repo2/image2", nullcontext()),
-        # If no tags, raise a QuayImagePullError
-        ({"tags": {}}, "latest", "quay.io", "repo3/image3", pytest.raises(QuayImagePullError)),
+        # If no tags, default to latest. nullcontext here means "no exception raised"
+        ({"tags": {}}, "latest", "quay.io", "repo3/image3", nullcontext()),
         # Fails with no retry if the image to pull already had a tag given explicitly
         (
             {"tags": {}},
             "latest",
             "internal.quay",
             "repo4/image4:latest",
-            pytest.raises(subprocess.CalledProcessError),
+            pytest.raises(CalledProcessError),
         ),
         (
             {"tags": {}},
             "latest",
             "internal.quay",
             "repo5/image5:version",
-            pytest.raises(subprocess.CalledProcessError),
+            pytest.raises(CalledProcessError),
         ),
         (
             {"tags": {}},
             "latest",
             "internal.quay",
             "repo6/image6@sha256:digest",
-            pytest.raises(subprocess.CalledProcessError),
+            pytest.raises(CalledProcessError),
         ),
     ),
 )
@@ -173,31 +171,22 @@ def test_image_pull_error_handling(
         f"registry:{target_host}/{target_image}",
     ]
     syft_json = '{"source": "source_not_used"}'
-    side_effects = (subprocess.CalledProcessError(1, syft_args), syft_json)
+    side_effects = (CalledProcessError(1, syft_args), syft_json)
 
     with patch(
         "corgi.collectors.syft.subprocess.check_output", side_effect=side_effects
     ) as mock_scan:
         with pytest_raises:
             # pytest_raises is either a nullcontext manager, if no exception raised
-            # or a pytest.raises context manager, if we should fail and not retry
+            # or a pytest.raises(CalledProcessError) context manager,
+            # if we should fail and not retry
             result = Syft.scan_repo_image(target_image, target_host)
 
     failed_call = call(syft_args, text=True)
     if not isinstance(pytest_raises, nullcontext):
-        # One failed call, no retry
+        # One failed call, no retry or call to Quay API
         calls = (failed_call,)
-        if pytest_raises.expected_exception == QuayImagePullError:
-            # One failed call was made to the Quay API
-            # because the image pull for an implicit "latest" tag failed
-            # and we wanted to find the other tags, but there were none
-            # We ignore this error since there are no tags / versions to analyze anyway
-            assert requests_mock.call_count == 1
-        else:
-            # No failed call was made to the Quay API
-            # because the image pull was for an explicitly-given tag
-            # so we just stop here and don't try to find the other tags
-            assert requests_mock.call_count == 0
+        assert requests_mock.call_count == 0
     else:
         # One failed call, one successful retry that uses the Quay API
         syft_args[-1] = f"{syft_args[-1]}:{most_recent_tag}"
@@ -263,7 +252,7 @@ def test_missing_github_quay_repo_names():
 
 
 @pytest.mark.django_db
-def test_private_github_quay_repo_names(requests_mock):
+def test_private_github_quay_repo_names():
     """Test that private images / repos we don't have permissions for are skipped"""
     # We should at least attempt to scan all components for a service
     # Known permission errors should not block us from checking the remaining components
@@ -295,49 +284,31 @@ def test_private_github_quay_repo_names(requests_mock):
             "registry:{target_host}/{target_image}",
         ),
     )
-    # No easy way to get the mock Response out of the mocker?
-    # So we just hardcode the error message below
-    # instead of making the request in the test, getting the response
-    # then raising and storing the error, to compare with the real error raised in code later
-    # and finally resetting the mock to do all that again in the real code
-    requests_mock.get(
-        "https://quay.io/api/v1/repository/red-org/hello-world?includeTags=true",
-        reason="FORBIDDEN",
-        status_code=403,
-    )
-    requests_mock.get(
-        "https://quay.io/api/v1/repository/red-org/hello-world-api?includeTags=true",
-        reason="FORBIDDEN",
-        status_code=403,
-    )
+    with patch("corgi.tasks.managed_services.Syft") as mock_syft:
+        mock_syft.scan_repo_image.side_effect = (podman_error, podman_error)
+        mock_syft.scan_git_repo.side_effect = (git_error, git_error)
 
-    with patch(
-        "corgi.tasks.managed_services.Syft.scan_git_repo", side_effect=(git_error, git_error)
-    ) as mock_git:
-        with patch(
-            "corgi.collectors.syft.subprocess.check_output",
-            side_effect=(podman_error, podman_error),
-        ) as mock_subprocess:
-            # Git clone and Syft both fail because all images above are not accessible
-            # For Quay images, we call subprocess to pull the image's implicit "latest" tag
-            # #hen this fails, we call requests / use the Quay API to list the tags
-            # We should try to pull a different tag if no "latest" tag exists
-            # But we'll fail due to 403 / no permissions to access this image (or its tags)
-            with pytest.raises(MultiplePermissionExceptions) as raised_e:
-                cpu_manifest_service(ps.name, ps.meta_attr["managed_service_components"])
-            assert str(raised_e.value) == (
-                f"Multiple exceptions raised:\n\n"
-                f"{type(git_error)}: {git_error.args}\n\n"
-                "<class 'requests.exceptions.HTTPError'>: "
-                "('403 Client Error: FORBIDDEN for url: "
-                "https://quay.io/api/v1/repository/red-org/hello-world?includeTags=true',)\n\n"
-                f"{type(git_error)}: {git_error.args}\n\n"
-                "<class 'requests.exceptions.HTTPError'>: "
-                "('403 Client Error: FORBIDDEN for url: "
-                "https://quay.io/api/v1/repository/red-org/hello-world-api?includeTags=true',)\n"
-            )
+        # Fails because all images above are not accessible
+        with pytest.raises(MultiplePermissionExceptions) as raised_e:
+            cpu_manifest_service(ps.name, ps.meta_attr["managed_service_components"])
+        assert str(raised_e.value) == (
+            f"Multiple exceptions raised:\n\n"
+            f"{type(git_error)}: {git_error.args}\n\n"
+            f"{type(podman_error)}: {podman_error.args}\n\n"
+            f"{type(git_error)}: {git_error.args}\n\n"
+            f"{type(podman_error)}: {podman_error.args}\n"
+        )
     # But only fails at the very end
     # we still try to scan other components, instead of stopping on the first error
-    assert requests_mock.call_count == 2
-    assert mock_git.call_count == 2
-    assert mock_subprocess.call_count == 2
+    mock_syft.scan_repo_image.assert_has_calls(
+        calls=(
+            call(target_image="red-org/hello-world"),
+            call(target_image="red-org/hello-world-api"),
+        )
+    )
+    mock_syft.scan_git_repo.assert_has_calls(
+        calls=(
+            call(target_url="https://github.com/blue/example"),
+            call(target_url="https://github.com/red/hello"),
+        )
+    )

--- a/tests/test_brew_collector.py
+++ b/tests/test_brew_collector.py
@@ -30,9 +30,8 @@ from corgi.tasks.brew import (
     save_component,
     slow_fetch_brew_build,
     slow_save_container_children,
-    slow_save_taxonomy,
 )
-from corgi.tasks.common import BUILD_TYPE
+from corgi.tasks.common import BUILD_TYPE, slow_save_taxonomy
 from tests.conftest import setup_product
 from tests.data.image_archive_data import (
     KOJI_LIST_RPMS,
@@ -1177,7 +1176,7 @@ def test_fetch_rpm_build(mock_load_brew_tags, mock_sca, mock_brew_constructor):
     with open("tests/data/brew/1705913/component_data.json", "r") as component_data_file:
         mock_brew_obj.get_component_data.return_value = json.load(component_data_file)
     with patch(
-        "corgi.tasks.brew.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
+        "corgi.tasks.common.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
     ) as wrapped_save_taxonomy:
         # Wrap the mocked object, and call its methods directly
         # So that doing task.delay(*args, **kwargs) becomes task(*args, **kwargs)
@@ -1284,7 +1283,7 @@ def test_fetch_container_build_rpms(
     stream.save()
 
     with patch(
-        "corgi.tasks.brew.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
+        "corgi.tasks.common.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
     ) as wrapped_save_taxonomy:
         # Wrap the mocked object, and call its methods directly
         # So that doing task.delay(*args, **kwargs) becomes task(*args, **kwargs)
@@ -1392,7 +1391,7 @@ def test_load_brew_tags(mock_fetch_modular_build, mock_fetch_brew_build):
 def test_new_software_build_relation(mock_save_prod_tax):
     sb = SoftwareBuildFactory()
     with patch(
-        "corgi.tasks.brew.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
+        "corgi.tasks.common.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
     ) as wrapped_save_taxonomy:
         # Wrap the mocked object, and call its methods directly
         # So that doing task.delay(*args, **kwargs) becomes task(*args, **kwargs)

--- a/tests/test_errata_data.py
+++ b/tests/test_errata_data.py
@@ -323,8 +323,8 @@ def test_slow_save_errata_product_taxonomy(mock_app):
     )
     slow_save_errata_product_taxonomy(1)
     send_task_calls = [
-        call("corgi.tasks.brew.slow_save_taxonomy", args=(sb.build_id, sb.build_type)),
-        call("corgi.tasks.brew.slow_save_taxonomy", args=(sb2.build_id, sb2.build_type)),
+        call("corgi.tasks.common.slow_save_taxonomy", args=(sb.build_id, sb.build_type)),
+        call("corgi.tasks.common.slow_save_taxonomy", args=(sb2.build_id, sb2.build_type)),
     ]
     # Calls happen based on build ID / UUID ordering, which is random
     mock_app.send_task.assert_has_calls(send_task_calls, any_order=True)

--- a/tests/test_pyxis_task.py
+++ b/tests/test_pyxis_task.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.mark.django_db
-@patch("corgi.tasks.brew.slow_save_taxonomy.delay")
+@patch("corgi.tasks.common.slow_save_taxonomy.delay")
 @patch("corgi.tasks.sca.cpu_software_composition_analysis.delay")
 @patch("corgi.collectors.pyxis.session.post")
 def test_slow_fetch_pyxis_manifest(post, sca, taxonomy):
@@ -135,7 +135,7 @@ def test_slow_fetch_pyxis_manifest(post, sca, taxonomy):
 
 
 @pytest.mark.django_db
-@patch("corgi.tasks.brew.slow_save_taxonomy.delay")
+@patch("corgi.tasks.common.slow_save_taxonomy.delay")
 @patch("corgi.tasks.sca.cpu_software_composition_analysis.delay")
 @patch("corgi.collectors.pyxis.session.post")
 def test_slow_fetch_empty_pyxis_manifest(post, sca, taxonomy):

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -620,7 +620,7 @@ def test_slow_software_composition_analysis(
     with patch("corgi.tasks.sca.app") as mock_app:
         cpu_software_composition_analysis(str(sb.pk))
         mock_app.send_task.assert_called_once_with(
-            "corgi.tasks.brew.slow_save_taxonomy", args=(str(sb.build_id), sb.build_type)
+            "corgi.tasks.common.slow_save_taxonomy", args=(str(sb.build_id), sb.build_type)
         )
 
     mock_clone_source.assert_called_once_with(package_name, str(sb.pk))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -19,9 +19,9 @@ from corgi.core.models import (
 from corgi.tasks.brew import (
     slow_delete_brew_build,
     slow_refresh_brew_build_tags,
-    slow_save_taxonomy,
     slow_update_brew_tags,
 )
+from corgi.tasks.common import slow_save_taxonomy
 from corgi.tasks.errata_tool import slow_handle_shipped_errata
 from corgi.tasks.pnc import slow_fetch_pnc_sbom, slow_handle_pnc_errata_released
 
@@ -540,7 +540,7 @@ def test_slow_fetch_pnc_sbom():
     response.json.return_value = sbom_contents
 
     with patch(
-        "corgi.tasks.brew.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
+        "corgi.tasks.common.slow_save_taxonomy.delay", wraps=slow_save_taxonomy
     ) as wrapped_save_taxonomy:
         with patch("requests.get", return_value=response) as get_mock:
             slow_fetch_pnc_sbom(purl, product_config, sbom)


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI. This is needed because we can't actually tell which subprocess errors are really permissions issues. I thought private images would always try to list tags, so we could treat a failure to list tags as an indicator of "not having access". This is usually true, but...

In some cases the tag is given explicitly as part of the image name, so we just try to pull that and immediately fail, without trying to find "which tag to pull". That approach is correct - if a tag was specified explicitly, we want to either scan that tag only, or fail. We definitely don't want to scan a different tag than what the user requested. So there's no need to / we don't bother to list the tags on failure, and doing so anyway would just risk more errors.

Handling all this mess would complicate the code, and trying to distinguish different subprocess errors was just an attempted enhancement anyway. Subprocess errors that aren't related to permissions should be rare, so I think it's relatively safe to just assume they're all permission-related and ignore them.