### PR TITLE
CORGI-854: Fix settings to avoid timeouts in managed services tasks

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -345,7 +345,11 @@ CELERY_RESULT_EXTENDED = True
 # @app.task(soft_time_limit=<TIME_IN_SECONDS>)
 CELERY_TASK_SOFT_TIME_LIMIT = 900
 # CELERY_SINGLETON_LOCK_EXPIRY and redis visibility timeout must never be less than the below value
-CELERY_LONGEST_SOFT_TIME_LIMIT = 2400
+# if you set below to more than 3600 seconds, you must also update the redis visibility timeout
+CELERY_LONGEST_SOFT_TIME_LIMIT = 3600
+# Expire locks after 1 hour, which is the longest task time limit.
+# https://github.com/steinitzu/celery-singleton#app-configuration
+CELERY_SINGLETON_LOCK_EXPIRY = CELERY_LONGEST_SOFT_TIME_LIMIT
 
 CELERY_WORKER_CONCURRENCY = 5  # defaults to CPU core count, which breaks in OpenShift
 


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI. This is needed now that we aren't failing for other reasons...it takes a long time to download and analyze all the Quay images and Git repos for certain very large services. If you'd prefer, I could also rewrite the cpu_manifest_service() task, so that it schedules individual subtasks for each component to be analyzed.

This may also help reduce the number of e.g. slow_fetch_brew_build() timeouts, although in the long-term we obviously still need a better solution. I'm going to merge this now so I can see if it worked first thing tomorrow morning, but thoughts welcome if you'd prefer a different approach.