### PR TITLE
CORGI-956: Use  dns_canonicalize_hostname = fallback instead of true to fix ET auth

### DIFF
--- a/files/krb5.conf
+++ b/files/krb5.conf
@@ -14,7 +14,7 @@
  allow_weak_crypto = false
  ignore_acceptor_hostname = true
  udp_preference_limit = 0
- dns_canonicalize_hostname = true
+ dns_canonicalize_hostname = fallback
 
 ## realm setup
 [realms]


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI. We're completely dead in the water (all ET-related tasks / API calls are failing) since yesterday and I have to fix CORGI-934 before shutdown, which this blocks. I've tested this in stage and it does fix the issue, so I'm going to merge as-is. If it breaks other stuff too, oh well, I'll have to fix it after shutdown.