### PR TITLE
CORGI-917: Fix manifests not being generated for services, and being published by mistake

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1016,6 +1016,7 @@ class ComponentQuerySet(models.QuerySet):
             software_build__relations__type__in=(
                 ProductComponentRelation.Type.ERRATA,
                 ProductComponentRelation.Type.COMPOSE,
+                ProductComponentRelation.Type.APP_INTERFACE,
             )
         )
         if include:

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -66,7 +66,6 @@ def setup_periodic_tasks(sender, **kwargs):
         # task at all: https://github.com/celery/django-celery-beat/issues/221
         upsert_cron_task("errata_tool", "load_et_products", hour=0, minute=0)
         upsert_cron_task("prod_defs", "update_products", hour=1, minute=0)
-        upsert_cron_task("tagging", "apply_stream_no_manifest_tags", hour=1, minute=30)
         upsert_cron_task("pulp", "update_cdn_repo_channels", hour=2, minute=0)
         upsert_cron_task("rhel_compose", "save_composes", hour=3, minute=0)
         upsert_cron_task("rhel_compose", "get_builds", hour=4, minute=0)

--- a/corgi/tasks/prod_defs.py
+++ b/corgi/tasks/prod_defs.py
@@ -25,6 +25,7 @@ from corgi.core.models import (
     SoftwareBuild,
 )
 from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS, slow_save_taxonomy
+from corgi.tasks.tagging import apply_stream_no_manifest_tags
 
 logger = get_task_logger(__name__)
 # Find a substring that looks like a version (e.g. "3", "3.5", "3-5", "1.2.z") at the end of a
@@ -79,6 +80,12 @@ def update_products() -> None:
             for pd_product_version in pd_product_versions:
                 parse_product_version(pd_product_version, product, product_node)
             product.save_product_taxonomy()
+
+        # Tag all the streams we don't want to publish manifests for
+        # inline, before the transaction is committed
+        # This way there's never any window of time when the stream exists
+        # but isn't tagged and could have its manifest published by mistake
+        apply_stream_no_manifest_tags()
 
 
 def _find_by_cpe(cpe_patterns: list[str]) -> list[str]:

--- a/corgi/tasks/tagging.py
+++ b/corgi/tasks/tagging.py
@@ -1,20 +1,12 @@
 from celery.utils.log import get_task_logger
-from celery_singleton import Singleton
 
-from config.celery import app
 from corgi.core.models import Product, ProductStream, ProductStreamTag, ProductVersion
-from corgi.tasks.common import RETRY_KWARGS, RETRYABLE_ERRORS
 
 NO_MANIFEST_TAG = "no_manifest"
 
 logger = get_task_logger(__name__)
 
 
-@app.task(
-    base=Singleton,
-    autoretry_for=RETRYABLE_ERRORS,
-    retry_kwargs=RETRY_KWARGS,
-)
 def apply_stream_no_manifest_tags():
     apply_middleware_stream_no_manifest_tags(NO_MANIFEST_TAG, "")
     apply_rhel_8_9_z_stream_no_manifest_tags(NO_MANIFEST_TAG, "")


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review after shutdown. There's no reason to merge this before then and risk breakage over the holidays. This was a simple fix so I went ahead and did the PR while waiting for other tasks to finish, but I don't believe it's urgent.