### PR TITLE
CORGI-854: Delete inside a transaction for safety, even if it causes issues

### DIFF
--- a/corgi/tasks/managed_services.py
+++ b/corgi/tasks/managed_services.py
@@ -190,12 +190,8 @@ def cpu_manifest_service_component(
             "didn't have any child components after analyzing "
             f"its Quay ({quay_repo}) and / or Git ({git_repo}) repos"
         )
-        # Raise exceptions here if we failed to analyze a repo / image
-        if exceptions:
-            raise_multiple_exceptions(exceptions)
-        # If no exceptions, we still create the build and relations below,
-        # as well as save the taxonomy, even if there are no components
-        # just so that this root component is properly linked to the service
+        # Raise exceptions at the very end if we failed to analyze a repo / image
+        # so the root component still exists and gets linked to the service
 
     save_service_components(
         now,


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs FYI. Not sure this is right or not, but either way we still see AttributeErrors when trying to unlink older components from each service. 

These errors should fix themselves when we rerun analysis the next day. So the risk is that data may be missing or incorrectly linked for 24 hours.

The right solution is probably to simplify the mangen code - either don't delete stuff, or delete stuff in a different way. But that risks its own set of problems.

I added this cleanup logic to avoid reporting stale data. Imagine a service stops using a component, or upgrades to a newer version. If we still report the older version as "used by this service", VM will be very confused and might file lots of incorrect trackers.

I think this bug happens when two root components share some of the same child components / dependencies, and analysis runs at almost the same time. It's not happening all the time for everything, but it's happening often enough to make me concerned.

Finally, the old mangen is currently broken, so having any data at all in Corgi is likely an improvement.