### PR TITLE
CORGI-955: Add filtering to Pyxis UMB listener and reenable collection

### DIFF
--- a/corgi/monitor/consumer.py
+++ b/corgi/monitor/consumer.py
@@ -11,8 +11,7 @@ from corgi.collectors.pnc import is_sbomer_product
 from corgi.tasks.brew import slow_fetch_brew_build, slow_update_brew_tags
 from corgi.tasks.errata_tool import slow_handle_shipped_errata
 from corgi.tasks.pnc import slow_fetch_pnc_sbom, slow_handle_pnc_errata_released
-
-# from corgi.tasks.pyxis import slow_fetch_pyxis_manifest
+from corgi.tasks.pyxis import slow_fetch_pyxis_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -206,16 +205,19 @@ class UMBReceiverHandler(MessagingHandler):
     @staticmethod
     def pyxis_manifest_create(event: Event) -> bool:
         logger.info(f"Handling UMB message for pyxis manifest {event.message.id}")
-        json.loads(event.message.body)
+        message = json.loads(event.message.body)
+
         try:
-            pass
-            # Temporarily disabled due to slowness and lots of duplicate data
-            # slow_fetch_pyxis_manifest.delay(
-            #     message["entityData"]["_id"]["$oid"],
-            # )
+            created_by = message["entityData"]["created_by"]
+            if created_by == "hacbs-release-pyxis":
+                slow_fetch_pyxis_manifest.delay(message["entityData"]["_id"]["$oid"])
+            else:
+                logger.info(f"Not scheduling pyxis manifest fetch {event.message.id}: {created_by}")
+
         except Exception as e:
             logger.error(f"Failed to schedule pyxis manifest fetch {event.message.id}: {str(e)}")
             return False
+
         else:
             return True
 

--- a/tests/data/pyxis/umb/brew_manifest_create.json
+++ b/tests/data/pyxis/umb/brew_manifest_create.json
@@ -31,7 +31,7 @@
       "_id": {
         "$oid": "64dccc646d82013739c4f7e0"
       },
-      "created_by": "hacbs-release-pyxis-staging",
+      "created_by": "metaxor",
       "created_on_behalf_of": null,
       "creation_date": {
         "$date": 1692191844148
@@ -51,7 +51,7 @@
       "last_update_date": {
         "$date": 1692191844148
       },
-      "last_updated_by": "hacbs-release-pyxis-staging",
+      "last_updated_by": "metaxor",
       "updated_on_behalf_of": null
     },
     "entityName": "contentManifest",

--- a/tests/data/pyxis/umb/rhtap_manifest_create.json
+++ b/tests/data/pyxis/umb/rhtap_manifest_create.json
@@ -1,0 +1,71 @@
+{
+  "certificate": null,
+  "crypto": null,
+  "headers": {
+    "JMSXUserID": "msg-snitch",
+    "JMS_AMQP_MESSAGE_FORMAT": "0",
+    "JMS_AMQP_NATIVE": "false",
+    "amq6100_destination": "queue://Consumer.datanommer.psi-ocp-bm-stage.VirtualTopic.eng.>",
+    "amq6100_originalDestination": "topic://VirtualTopic.eng.snitch.contentmanifest.create",
+    "correlation-id": "0a1b9095-d4c8-48e7-84a6-43106153f875",
+    "database": "data",
+    "destination": "/topic/VirtualTopic.eng.snitch.contentmanifest.create",
+    "entityName": "contentManifest",
+    "expires": "0",
+    "message-id": "ID:umb.example.com-42991-1691783981453-34:61834:0:0:1",
+    "operationType": "insert",
+    "original-destination": "/topic/VirtualTopic.eng.snitch.contentmanifest.create",
+    "priority": "4",
+    "subscription": "/queue/Consumer.datanommer.psi-ocp-bm-stage.VirtualTopic.eng.>",
+    "timestamp": "0"
+  },
+  "i": 0,
+  "msg": {
+    "database": "data",
+    "documentKey": {
+      "_id": {
+        "$oid": "64dccc646d82013739c4f7e0"
+      }
+    },
+    "entityData": {
+      "_id": {
+        "$oid": "64dccc646d82013739c4f7e0"
+      },
+      "created_by": "hacbs-release-pyxis",
+      "created_on_behalf_of": null,
+      "creation_date": {
+        "$date": 1692191844148
+      },
+      "image": {
+        "_id": {
+          "$oid": "64dccc5b6d82013739c4f7b8"
+        },
+        "repositories": [
+          {
+            "published": false,
+            "registry": "quay.io",
+            "repository": "redhat-appstudio/image-controller"
+          }
+        ]
+      },
+      "last_update_date": {
+        "$date": 1692191844148
+      },
+      "last_updated_by": "hacbs-release-pyxis",
+      "updated_on_behalf_of": null
+    },
+    "entityName": "contentManifest",
+    "operationType": "insert",
+    "updateDescription": {
+      "removedFields": [],
+      "updatedFields": {}
+    }
+  },
+  "msg_id": "ID:umb.example.com-42991-1691783981453-34:61834:0:0:1",
+  "signature": null,
+  "source_name": "datanommer",
+  "source_version": "0.9.1",
+  "timestamp": 1692191844.0,
+  "topic": "/topic/VirtualTopic.eng.snitch.contentmanifest.create",
+  "username": null
+}


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs Please review when you have some time. This should solve some of the performance issues we were previously seeing with the Pyxis collector.

Previously we would collect all builds from Pyxis, 95% of which were built in Brew (by Metaxor) and were already available / were duplicated in Corgi through the Brew collector. We only need the extra 5% of Pyxis containers which are now being built in the new RHTAP build system (and are not available at all in Brew).

The queue which processes these tasks was constantly filling up, and many tasks to fetch the manifest from Pyxis were timing out. We therefore disabled the collector to avoid blocking other tasks. This PR will help with the first problem (we will have a lot less Pyxis tasks to process), so reenabling should be relatively safe.

The issue with timeouts may be due to large Brew container builds, so will be solved by this PR to only collect RHTAP container builds. But the timeouts may also be due to general Pyxis API slowness, in which case I'll need to do more research and then open a follow-up PR. I'll keep an eye on things over the next few days to see how full the queue gets, and if the tasks to fetch RHTAP container builds are slow or time out.

The ticket also has a link to a Gchat thread where this implementation is discussed / the Pyxis team confirmed the values to filter on if you're curious.