### PR TITLE
Fix links in user guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -6,15 +6,12 @@ Component Registry exposes a REST API that any number of clients can connect to,
 front-end application to serve as a web client.
 
 For more in-depth information about the resources served by the API, see section
-(REST API Resource Definitions)[#rest-api-resource-definitions].
+[REST API Resource Definitions](#rest-api-resource-definitions).
 
-The [OpenAPI specification](https:///github.com/RedHatProductSecurity/corgi/-/blob/master/openapi.yml) provides
+The [OpenAPI specification](https:///github.com/RedHatProductSecurity/component-registry/blob/main/openapi.yml) provides
 developer level documentation for endpoint usage.
 
 ### Fetching data
-
-[REST API docs](https:///github.com/RedHatProductSecurity/corgi/-/blob/main/openapi.yml) provide detailed
-usage on all endpoints.
 
 #### Retrieving components
 


### PR DESCRIPTION
The links to the project's OpenAPI specification were broken, as they were pointing to the corgi repo (now component-registry) at the master branch (now main). This commit fixes the link to the correct one.

The anchor to the REST API product definitions was also not working, and now it correctly links to the section.

Since the same information about checking out the OpenAPI specification to learn about endpoint usage was said twice and very close together, one of the sentences has been removed to avoid redundancy.