### PR TITLE
remove memory intensive spdx schema validation

### DIFF
--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -67,6 +67,7 @@ def same_contents(existing_file: str, stream: ProductStream) -> tuple[bool, str,
             TaskResult.objects.filter(
                 task_name="corgi.tasks.manifest.cpu_update_ps_manifest",
                 task_args__contains=stream.external_name,
+                result__contains="true",
                 status="SUCCESS",
             )
             .order_by("-date_created")

--- a/corgi/web/templates/product_manifest.json
+++ b/corgi/web/templates/product_manifest.json
@@ -1,11 +1,9 @@
 {# ProductModel manifest, obj is a ProductModel subclass here #}{% extends "base_manifest.json" %}{% load base_extras %}
-{% block document %}
-  "documentDescribes": [
+{% block document %}"documentDescribes": [
     "{{document_uuid}}"
   ],
-  "documentNamespace": "https://access.redhat.com/security/data/sbom/beta/spdx/{{external_name|escapejs}}",
-  "name": "{{external_name|escapejs}}",
-{% endblock document %}
+  "documentNamespace": "https://access.redhat.com/security/data/sbom/beta/spdx/{{external_name}}",
+  "name": "{{external_name}}",{% endblock document %}
 {% block packages %}{% for component in released_components %}
     {
       "copyrightText": {% if component.copyright_text %}"{{component.copyright_text|escapejs}}"{% else %}"NOASSERTION"{% endif %},
@@ -91,7 +89,7 @@
       "licenseComments": "Licensing information is provided for individual components only at this time.",
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
-      "name": "{{external_name|escapejs}}",
+      "name": "{{external_name}}",
       "packageFileName": "NOASSERTION",
       "SPDXID": "{{document_uuid}}",
       "supplier": "Organization: Red Hat",

--- a/tests/data/manifest/sbom.json
+++ b/tests/data/manifest/sbom.json
@@ -1,5 +1,4 @@
 {
-  "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
     "created": "2024-01-22T01:23:00Z",
     "creators": [
@@ -15,7 +14,6 @@
   "name": "EXTERNAL-NAME-1.0",
   "packages": [
     {
-      "SPDXID": "SPDXRef-0cb13029-3f4e-49ed-a960-8aad455425ef",
       "copyrightText": "NOASSERTION",
       "downloadLocation": "NOASSERTION",
       "externalRefs": [
@@ -32,6 +30,7 @@
       "licenseDeclared": "NOASSERTION",
       "name": "EXTERNAL-NAME-1.0",
       "packageFileName": "NOASSERTION",
+      "SPDXID": "SPDXRef-0cb13029-3f4e-49ed-a960-8aad455425ef",
       "supplier": "Organization: Red Hat",
       "versionInfo": "1.0"
     }
@@ -43,5 +42,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT"
     }
   ],
+  "SPDXID": "SPDXRef-DOCUMENT",
   "spdxVersion": "SPDX-2.2"
 }


### PR DESCRIPTION
This does result in unicode escape sequences such as "\u000A" getting into the SBOM due to useage of 'escapejs' in the Django template, but that doesn't seem to affect JSON, or SPDX schema validation.