### PR TITLE
Minor: mitigate intermittent perf issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Exclude modular source RPMs (type="RPM", arch="src", release__contains=".module") from manifests,
 and from the API when using the root_components=True filter
+* Set gunicorn worker_tmp_dir to use /dev/shm
 
 ## [1.4.2] - 2023-12-19
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -17,6 +17,10 @@ forwarded_allow_ips = "*"
 
 timeout = 300
 
+# the gunicorn default for worker_tmp_dir is /tmp which may not reliably
+# exist in deployment environments, setting to shm filesystem avoids this
+worker_tmp_dir = "/dev/shm"
+
 if not running_dev():
     # Saves memory in the worker process, but breaks --reload
     preload_app = True


### PR DESCRIPTION
Set gunicorn **worker_tmp_dir** to use /dev/shm

This may help some of the intermittent perf issues we have been seeing.

Inspired by https://pythonspeed.com/articles/gunicorn-in-docker/

