### PR TITLE
Minor: more efficient check if queryset is empty or not for paginate

### DIFF
--- a/corgi/api/pagination.py
+++ b/corgi/api/pagination.py
@@ -6,7 +6,7 @@ from rest_framework.pagination import LimitOffsetPagination
 class FasterPageNumberPagination(LimitOffsetPagination):
     def get_count(self, queryset):
         """more efficient REST API count"""
-        if not (queryset):
+        if not (queryset.exists()):
             return 0
         if not (settings.OPTIMISE_REST_API_COUNT) or "WHERE" in str(queryset.query):
             # if queryset conditions has filters then we revert to queryset count
@@ -16,6 +16,6 @@ class FasterPageNumberPagination(LimitOffsetPagination):
         # faster
         with connection.cursor() as cursor:
             cursor.execute(
-                "SELECT reltuples FROM pg_class WHERE relname = %s", [queryset.model._meta.db_table]
+                "SELECT reltuples FROM pg_class WHERE relname=%s;", [queryset.model._meta.db_table]
             )
             return int(cursor.fetchone()[0])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,6 +136,21 @@ def test_channel_detail(client, api_path):
 
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
+def test_component(client, api_path):
+    SrpmComponentFactory(name="curl")
+
+    response = client.get(f"{api_path}/components")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+
+    response = client.get(f"{api_path}/components?limit=1")
+    assert response.status_code == 200
+    response = response.json()
+    assert response["count"] == 1
+
+
+@pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_component_include_exclude_fields(client, api_path):
     SrpmComponentFactory(name="curl")
 


### PR DESCRIPTION
fixes bug on count for /api/v1/components

and will add an explicit test for this (which seems to be missing).