### PR TITLE
add LICENSE_CONCLUDED_EXTRACTED_TEXT to SBOM license-refs

### DIFF
--- a/corgi/tasks/management/commands/generatemanifests.py
+++ b/corgi/tasks/management/commands/generatemanifests.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandParser
 
+from corgi.core.models import ProductStream
 from corgi.tasks.manifest import cpu_update_ps_manifest, update_manifests
 
 
@@ -13,17 +14,12 @@ class Command(BaseCommand):
             dest="stream",
             help="Update the manifest for the named product stream",
         )
-        parser.add_argument(
-            "-f",
-            "--skip-fixups",
-            action="store_false",
-            help="Skip applying manifest fixups",
-        )
 
     def handle(self, *args, **options) -> None:
         if options["stream"]:
+            ps = ProductStream.objects.get(name=options["stream"])
             self.stdout.write(self.style.SUCCESS(f"Updating manifest for {options['stream']}"))
-            cpu_update_ps_manifest(options["stream"], fixup=options["skip_fixups"])
+            cpu_update_ps_manifest(ps.name, ps.external_name)
         else:
             self.stdout.write(self.style.SUCCESS("Updating manifests for all streams"))
-            update_manifests(fixup=options["skip_fixups"])
+            update_manifests()

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -487,25 +487,65 @@ license_expressions = [
     (
         "0BSD+",
         "LicenseRef-0",
-        {"0BSD+": 0},
+        {
+            (
+                "0BSD+",
+                False,
+            ): 0
+        },
     ),
-    ("0BSD+ or 0BSD+", "LicenseRef-0 OR LicenseRef-0", {"0BSD+": 0}),
-    ("BSD-3-Clause or GPLv3+", "BSD-3-Clause OR LicenseRef-0", {"GPLv3+": 0}),
+    (
+        "0BSD+ or 0BSD+",
+        "LicenseRef-0 OR LicenseRef-0",
+        {
+            (
+                "0BSD+",
+                False,
+            ): 0
+        },
+    ),
+    (
+        "BSD-3-Clause or GPLv3+",
+        "BSD-3-Clause OR LicenseRef-0",
+        {
+            (
+                "GPLv3+",
+                False,
+            ): 0
+        },
+    ),
     (
         "BSD-3-Clause or (GPLv3+ or LGPLv3+)",
         "BSD-3-Clause OR (LicenseRef-0 OR LicenseRef-1)",
-        {"GPLv3+": 0, "LGPLv3+": 1},
+        {
+            (
+                "GPLv3+",
+                False,
+            ): 0,
+            (
+                "LGPLv3+",
+                False,
+            ): 1,
+        },
     ),
     (
         "BSD-3-Clause with exceptions",
         "LicenseRef-0",
-        {"BSD-3-Clause with exceptions": 0},
+        {
+            (
+                "BSD-3-Clause with exceptions",
+                False,
+            ): 0
+        },
     ),
     (
         "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
         "LicenseRef-0",
         {
-            "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain": 0,
+            (
+                "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
+                False,
+            ): 0,
         },
     ),
     # Actual license declared data examples
@@ -516,29 +556,75 @@ license_expressions = [
         "(LicenseRef-0 OR LicenseRef-5 OR LicenseRef-6 OR LicenseRef-7) AND LicenseRef-8 AND "
         "LicenseRef-9 AND LicenseRef-10 AND LicenseRef-11",
         {
-            "MPLv1.1": 0,
-            "LGPLv3+": 1,
-            "LGPLv3": 2,
-            "LGPLv2+": 3,
-            "BSD": 4,
-            "GPLv2": 5,
-            "LGPLv2": 6,
-            "Netscape": 7,
-            "Public Domain": 8,
-            "ASL 2.0": 9,
-            "MPLv2.0": 10,
-            "CC0": 11,
+            (
+                "MPLv1.1",
+                False,
+            ): 0,
+            (
+                "LGPLv3+",
+                False,
+            ): 1,
+            (
+                "LGPLv3",
+                False,
+            ): 2,
+            (
+                "LGPLv2+",
+                False,
+            ): 3,
+            (
+                "BSD",
+                False,
+            ): 4,
+            (
+                "GPLv2",
+                False,
+            ): 5,
+            (
+                "LGPLv2",
+                False,
+            ): 6,
+            (
+                "Netscape",
+                False,
+            ): 7,
+            (
+                "Public Domain",
+                False,
+            ): 8,
+            (
+                "ASL 2.0",
+                False,
+            ): 9,
+            (
+                "MPLv2.0",
+                False,
+            ): 10,
+            (
+                "CC0",
+                False,
+            ): 11,
         },
     ),
     (
         "GPLv2 and Redistributable, no modification permitted",
         "LicenseRef-0",
-        {"GPLv2 and Redistributable, no modification permitted": 0},
+        {
+            (
+                "GPLv2 and Redistributable, no modification permitted",
+                False,
+            ): 0
+        },
     ),
     (
         "0BSD and Bison-exception-2.2",
         "LicenseRef-0",
-        {"0BSD and Bison-exception-2.2": 0},
+        {
+            (
+                "0BSD and Bison-exception-2.2",
+                False,
+            ): 0
+        },
     ),
 ]
 
@@ -547,8 +633,8 @@ license_expressions = [
 def test_validate_licenses(license_raw, license_valid, license_refs):
     manifest = ComponentManifestFile(ComponentFactory())
     result = str(manifest.validate_licenses(license_raw))
-    assert result == license_valid
     assert license_refs == manifest.extracted_licenses
+    assert result == license_valid
 
 
 def test_component_manifest_properties():
@@ -616,13 +702,13 @@ def test_component_manifest_properties():
     expected_extracted_licensing_info = [
         {
             "comment": component_manifest_file.LICENSE_EXTRACTED_COMMENT,
-            "extractedText": component_manifest_file.LICENSE_EXTRACTED_TEXT,
+            "extractedText": component_manifest_file.LICENSE_CONCLUDED_EXTRACTED_TEXT,
             "licenseId": "LicenseRef-0",
             "name": "(MIT and (ASL 2.0 or GPLv3+ with exceptions)) or LGPLv3+",
         },
         {
             "comment": component_manifest_file.LICENSE_EXTRACTED_COMMENT,
-            "extractedText": component_manifest_file.LICENSE_EXTRACTED_TEXT,
+            "extractedText": component_manifest_file.LICENSE_DECLARED_EXTRACTED_TEXT,
             "licenseId": "LicenseRef-1",
             "name": "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
         },


### PR DESCRIPTION
Looking over the license_concluded data, and [associated OpenLCS code](https://github.com/RedHatProductSecurity/openlcs/pull/259/files), it appears that licenses added by OpenLCS are [scancode licenses](https://scancode-licensedb.aboutcode.org/), not Fedora ones, so added a reference to that for all licenseRefs from license_concluded field.