### PR TITLE
Adjust license verbage

### DIFF
--- a/tests/data/manifest/sbom.json
+++ b/tests/data/manifest/sbom.json
@@ -1,11 +1,12 @@
 {
     "SPDXID": "SPDXRef-DOCUMENT",
+    "comment": "Licensing information is automatically generated from the upstream package meta data and may not be accurate.",
     "creationInfo": {
         "created": "2024-01-31T00:22:29Z",
         "creators": [
             "Organization: Red Hat Product Security (secalert@redhat.com)"
         ],
-        "licenseListVersion": "3.8"
+        "licenseListVersion": "3.22"
     },
     "dataLicense": "CC0-1.0",
     "name": "EXTERNAL-NAME-1.0",
@@ -25,7 +26,6 @@
             ],
             "filesAnalyzed": false,
             "homepage": "https://www.redhat.com/",
-            "licenseComments": "Licensing information is provided for individual components only at this time.",
             "licenseConcluded": "NOASSERTION",
             "licenseDeclared": "NOASSERTION",
             "name": "EXTERNAL-NAME-1.0",

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -487,143 +487,76 @@ license_expressions = [
     (
         "0BSD+",
         "LicenseRef-0",
-        {
-            (
-                "0BSD+",
-                False,
-            ): 0
-        },
+        {"0BSD+": "0"},
     ),
     (
         "0BSD+ or 0BSD+",
         "LicenseRef-0 OR LicenseRef-0",
-        {
-            (
-                "0BSD+",
-                False,
-            ): 0
-        },
+        {"0BSD+": "0"},
     ),
     (
         "BSD-3-Clause or GPLv3+",
         "BSD-3-Clause OR LicenseRef-0",
-        {
-            (
-                "GPLv3+",
-                False,
-            ): 0
-        },
+        {"GPLv3+": "0"},
     ),
     (
         "BSD-3-Clause or (GPLv3+ or LGPLv3+)",
         "BSD-3-Clause OR (LicenseRef-0 OR LicenseRef-1)",
         {
-            (
-                "GPLv3+",
-                False,
-            ): 0,
-            (
-                "LGPLv3+",
-                False,
-            ): 1,
+            "GPLv3+": "0",
+            "LGPLv3+": "1",
         },
     ),
     (
         "BSD-3-Clause with exceptions",
         "LicenseRef-0",
-        {
-            (
-                "BSD-3-Clause with exceptions",
-                False,
-            ): 0
-        },
+        {"BSD-3-Clause with exceptions": "0"},
     ),
     (
         "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
         "LicenseRef-0",
-        {
-            (
-                "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
-                False,
-            ): 0,
-        },
+        {"BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain": "0"},
     ),
     # Actual license declared data examples
     (
         "(MPLv1.1 or LGPLv3+) and LGPLv3 and LGPLv2+ and BSD and (MPLv1.1 or GPLv2 or LGPLv2 or "
         "Netscape) and Public Domain and ASL 2.0 and MPLv2.0 and CC0",
-        "(LicenseRef-0 OR LicenseRef-1) AND LicenseRef-2 AND LicenseRef-3 AND LicenseRef-4 AND "
-        "(LicenseRef-0 OR LicenseRef-5 OR LicenseRef-6 OR LicenseRef-7) AND LicenseRef-8 AND "
-        "LicenseRef-9 AND LicenseRef-10 AND LicenseRef-11",
+        "(LicenseRef-MPLv1.1 OR LicenseRef-0) AND LicenseRef-LGPLv3 AND LicenseRef-1 AND "
+        "LicenseRef-BSD AND (LicenseRef-MPLv1.1 OR LicenseRef-GPLv2 OR LicenseRef-LGPLv2 OR "
+        "LicenseRef-Netscape) AND LicenseRef-2 AND LicenseRef-3 AND LicenseRef-MPLv2.0 AND "
+        "LicenseRef-CC0",
         {
-            (
-                "MPLv1.1",
-                False,
-            ): 0,
-            (
-                "LGPLv3+",
-                False,
-            ): 1,
-            (
-                "LGPLv3",
-                False,
-            ): 2,
-            (
-                "LGPLv2+",
-                False,
-            ): 3,
-            (
-                "BSD",
-                False,
-            ): 4,
-            (
-                "GPLv2",
-                False,
-            ): 5,
-            (
-                "LGPLv2",
-                False,
-            ): 6,
-            (
-                "Netscape",
-                False,
-            ): 7,
-            (
-                "Public Domain",
-                False,
-            ): 8,
-            (
-                "ASL 2.0",
-                False,
-            ): 9,
-            (
-                "MPLv2.0",
-                False,
-            ): 10,
-            (
-                "CC0",
-                False,
-            ): 11,
+            "MPLv1.1": "MPLv1.1",
+            "LGPLv3+": "0",
+            "LGPLv3": "LGPLv3",
+            "LGPLv2+": "1",
+            "BSD": "BSD",
+            "GPLv2": "GPLv2",
+            "LGPLv2": "LGPLv2",
+            "Netscape": "Netscape",
+            "Public Domain": "2",
+            "ASL 2.0": "3",
+            "MPLv2.0": "MPLv2.0",
+            "CC0": "CC0",
         },
     ),
     (
         "GPLv2 and Redistributable, no modification permitted",
         "LicenseRef-0",
-        {
-            (
-                "GPLv2 and Redistributable, no modification permitted",
-                False,
-            ): 0
-        },
+        {"GPLv2 and Redistributable, no modification permitted": "0"},
     ),
     (
         "0BSD and Bison-exception-2.2",
         "LicenseRef-0",
+        {"0BSD and Bison-exception-2.2": "0"},
+    ),
+    (
+        "BSD and LGPLv2 and GPLv2",
+        "LicenseRef-BSD AND LicenseRef-LGPLv2 AND LicenseRef-GPLv2",
         {
-            (
-                "0BSD and Bison-exception-2.2",
-                False,
-            ): 0
+            "BSD": "BSD",
+            "LGPLv2": "LGPLv2",
+            "GPLv2": "GPLv2",
         },
     ),
 ]
@@ -698,18 +631,17 @@ def test_component_manifest_properties():
     assert manifest["relationships"][-1] == document_describes_product
 
     extracted_licensing_info = manifest["hasExtractedLicensingInfos"]
-    assert len(extracted_licensing_info) == 2
+    assert len(extracted_licensing_info) == 1
+    invalid_license_declared = (
+        "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain"
+    )
     expected_extracted_licensing_info = [
         {
             "comment": component_manifest_file.LICENSE_EXTRACTED_COMMENT,
-            "extractedText": component_manifest_file.LICENSE_CONCLUDED_EXTRACTED_TEXT,
+            "extractedText": component_manifest_file.LICENSE_DECLARED_EXTRACTED_TEMPLATE.substitute(
+                license_name=invalid_license_declared
+            ),
             "licenseId": "LicenseRef-0",
-            "name": "(MIT and (ASL 2.0 or GPLv3+ with exceptions)) or LGPLv3+",
-        },
-        {
-            "comment": component_manifest_file.LICENSE_EXTRACTED_COMMENT,
-            "extractedText": component_manifest_file.LICENSE_DECLARED_EXTRACTED_TEXT,
-            "licenseId": "LicenseRef-1",
             "name": "BSD-3-Clause or (GPLv3+ with exceptions and LGPLv3+) and Public Domain",
         },
     ]


### PR DESCRIPTION
This includes the commits from [pull/753](https://github.com/RedHatProductSecurity/component-registry/pull/753), please review that one first.

Incorporates the feedback from CORGI-830 including:

- Use the invalid license as a license ref where possible
- Change the extracted text as specified
- Update the license list version
- Update the license comment in the packages list

@RedHatProductSecurity/corgi-devs please review