### PR TITLE
CORGI-990 add config to allow middleware stream manifest publishing

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -508,3 +508,10 @@ QUAY_TOKEN = os.getenv("CORGI_QUAY_TOKEN", "")
 
 # disable using reltuples in corgi.api.paginate.FasterPageNumberPagination for fast count estimates
 OPTIMISE_REST_API_COUNT = False
+
+# We only process Maven builds from SBOMer, which makes most middleware streams incomplete
+# This list allows the specified streams to have an SBOM published by SDEngine in the customer
+# portal
+ALLOWED_MIDDLEWARE_MANIFEST_STREAMS = os.environ.get(
+    "CORGI_ALLOWED_MIDDLEWARE_MANIFEST_STREAMS", ""
+).split(",")

--- a/corgi/tasks/tagging.py
+++ b/corgi/tasks/tagging.py
@@ -1,4 +1,5 @@
 from celery.utils.log import get_task_logger
+from django.conf import settings
 
 from corgi.core.models import Product, ProductStream, ProductStreamTag, ProductVersion
 
@@ -18,6 +19,8 @@ def apply_middleware_stream_no_manifest_tags(tag_name: str, tag_value: str) -> N
         "productstreams", flat=True
     ):
         stream = ProductStream.objects.get(pk=stream_pk)
+        if stream.name in settings.ALLOWED_MIDDLEWARE_MANIFEST_STREAMS:
+            continue
         _, created = ProductStreamTag.objects.get_or_create(
             name=tag_name, value=tag_value, tagged_model=stream
         )


### PR DESCRIPTION
Add an environment variable (comma separated) to overwrite the middleware 'no_manifest' tagging.