### PR TITLE
CORGI-1011: upgrade local dev env postgres to pg15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       resources:
         limits:
           memory: 2G
-    image: registry.redhat.io/rhel8/postgresql-13:1
+    image: registry.redhat.io/rhel8/postgresql-15:1-44
     shm_size: 1G
     hostname: corgi-db
     environment:


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs please try this out in your local dev env ... once we confirm stability, then we will upgrade stage pg.

**Note** - one may have to explicitly `>podman pull registry.redhat.io/rhel8/postgresql-15:1-44
`