### PR TITLE
CORGI-954 use KeyTextTranforms to avoid 

### DIFF
--- a/corgi/core/migrations/0117_fix_software_build_names.py
+++ b/corgi/core/migrations/0117_fix_software_build_names.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.db import migrations
-from django.db.models import F
+from django.db.models.fields.json import KeyTextTransform
 
 from corgi.core.models import SoftwareBuild
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def fix_softwarebuild_names(apps, schema_editor) -> None:
     for names in (
         SoftwareBuild.objects.filter(build_type="BREW")
-        .exclude(meta_attr__name=None)
+        .exclude(meta_attr__name="")
         .values("name", "meta_attr__name")
         .distinct()
     ):
@@ -23,7 +23,7 @@ def fix_softwarebuild_names(apps, schema_editor) -> None:
                 f"Updating SoftwareBuild name {names['name']} to {names['meta_attr__name']}"
             )
             SoftwareBuild.objects.filter(build_type="BREW", name=names["name"]).update(
-                name=F("meta_attr__name")
+                name=KeyTextTransform("name", "meta_attr")
             )
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/32491

This will require to fake to 0116 migration and re-run 0117 and 0118