### PR TITLE
CORGI-1025 return 204 http response for non root component manifest

### DIFF
--- a/corgi/api/views.py
+++ b/corgi/api/views.py
@@ -544,6 +544,8 @@ class ComponentViewSet(ReadOnlyModelViewSet):  # TODO: TagViewMixin disabled unt
         obj = self.queryset.filter(pk=pk).first()
         if not obj:
             return HttpResponse(status=status.HTTP_404_NOT_FOUND)
+        if not obj.software_build:
+            return HttpResponse(status=status.HTTP_204_NO_CONTENT)
         manifest = ComponentManifestFile(obj).render_content()
         return JsonResponse(manifest)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -237,6 +237,14 @@ def test_component_detail(client, api_path):
     assert response.status_code == 200
     assert response.json()["count"] == 1
 
+    response = client.get(f"{api_path}/components/{c1.pk}/manifest")
+    assert response.status_code == 200
+
+    c1.software_build = None
+    c1.save()
+    response = client.get(f"{api_path}/components/{c1.pk}/manifest")
+    assert response.status_code == 204
+
 
 @pytest.mark.django_db(databases=("default", "read_only"), transaction=True)
 def test_latest_components_by_streams_filter(client, api_path, stored_proc):


### PR DESCRIPTION
We don't save component taxonomy for non-root components so attempting to generate a manifest for them results in a populated relations field, but nothing in the packages list. 
One way to fix this would be adjust provides relationship of component to traverse the graph instead of populating a many-to-many relationship. However since we don't need non-root component manifest for any specific business requirement at the moment I opted to just return 204 response content here indicating there is no content for the request.