### PR TITLE
CORGI-1041 SBOM validation error on dot dot

### DIFF
--- a/corgi/collectors/syft.py
+++ b/corgi/collectors/syft.py
@@ -47,7 +47,7 @@ class Syft:
             scan_result = subprocess.check_output(  # nosec B603
                 [
                     "/usr/bin/syft",
-                    "packages",
+                    "scan",
                     "-q",
                     "-o=syft-json",
                     # see motivation for excluding test/fixtures in CORGI-510, and CORGI-824

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -716,7 +716,8 @@ class ProductStream(ProductModel):
         return (
             Component.objects.filter(pk__in=unique_provides)
             # Remove .exclude() below when CORGI-428 is resolved
-            .exclude(type=Component.Type.GOLANG, name__contains="./")
+            .exclude(purl__startswith="pkg:golang/", purl__contains="./")
+            .exclude(purl__startswith="pkg:golang/", purl__contains="..")
             .external_components()
             .using(using)
         )
@@ -2226,6 +2227,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
             .exclude(purl__contains="redhat.com")
             # Remove .exclude() below when CORGI-428 is resolved
             .exclude(purl__startswith="pkg:golang/", purl__contains="./")
+            .exclude(purl__startswith="pkg:golang/", purl__contains="..")
             .using(using)
             .values_list("purl", "type", "object_id")
             # Ensure generated manifests only change when content does

--- a/requirements/rpms.txt
+++ b/requirements/rpms.txt
@@ -14,4 +14,4 @@ openssl-devel
 python3.11
 python3.11-devel
 python3.11-pip
-https://github.com/anchore/syft/releases/download/v0.74.1/syft_0.74.1_linux_amd64.rpm
+https://github.com/anchore/syft/releases/download/v1.0.1/syft_1.0.1_linux_amd64.rpm

--- a/tests/test_sca.py
+++ b/tests/test_sca.py
@@ -628,7 +628,7 @@ def test_slow_software_composition_analysis(
         call(
             [
                 "/usr/bin/syft",
-                "packages",
+                "scan",
                 "-q",
                 "-o=syft-json",
                 "--exclude=**/vendor/**",
@@ -643,7 +643,7 @@ def test_slow_software_composition_analysis(
             call(
                 [
                     "/usr/bin/syft",
-                    "packages",
+                    "scan",
                     "-q",
                     "-o=syft-json",
                     "--exclude=**/vendor/**",


### PR DESCRIPTION
Addresses a validation error on SBOM generation where a package named "../" is excluded from the SBOM but not from the relationships section.

Also upgrades syft to the latest version which fixes CORGI-816 and prevents the component with name '../' being detected and linked by syft to the microshift RPM.