### PR TITLE
CORGI-1044 Duplicate components in SBOMs causing validation failure

### DIFF
--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -282,7 +282,8 @@ class ManifestFile(ABC):
             logging.error(message.context)
             raise ValueError(
                 f"SPDX validation failed for component {document_name}: "
-                f"{message.validation_message}"
+                f"{message.validation_message}. with context:"
+                f"{message.context}"
             )
 
     def _parse_license_expression(

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1254,7 +1254,7 @@ class ComponentQuerySet(models.QuerySet):
         # Order by UUID to give stable results in manifests
         # Other querysets should not define an ordering
         # or should clear it with .order_by() if they use .distinct()
-        return roots.order_by("pk")
+        return roots.order_by("pk").distinct("pk")
 
     def srpms(self, include: bool = True) -> models.QuerySet["Component"]:
         """Show only source RPMs by default, or only non-SRPMs if include=False"""


### PR DESCRIPTION
I'm not sure what change cause this issue to surface now. It was happening in stage just before the upgrade to PG15
. However it does seem to be resolved by adding a distinct on manifest_components filter.