### PR TITLE
CORGI-1046 only update cnode purl where component purl is updated

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1895,7 +1895,7 @@ class Component(TimeStampedModel, ProductTaxonomyMixin):
         purl = self.get_purl().to_string()
         if self.purl != purl:
             self.purl = purl
-        self.cnodes.exclude(purl=purl).update(purl=purl)
+            self.cnodes.exclude(purl=purl).update(purl=purl)
 
         self.related_url = self._build_repo_url_for_type()
 


### PR DESCRIPTION
This is part of the fix for CORGI-1046, Postgres High Disk IO. The other part is an adjustment to the index to add purl.