### PR TITLE
PSDEVOPS-1068 SPDXValidation fails for GENERATES relationship

### DIFF
--- a/corgi/tasks/management/commands/generatemanifests.py
+++ b/corgi/tasks/management/commands/generatemanifests.py
@@ -3,7 +3,11 @@ import sys
 from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.core.models import ProductStream
-from corgi.tasks.manifest import cpu_update_ps_manifest, update_manifests
+from corgi.tasks.manifest import (
+    cpu_update_ps_manifest,
+    slow_ensure_root_upstreams,
+    update_manifests,
+)
 
 
 class Command(BaseCommand):
@@ -27,6 +31,14 @@ class Command(BaseCommand):
             "re-adding the 'no_manifest' tag.",
         )
 
+        parser.add_argument(
+            "-u",
+            "--upstream_taxonomy",
+            action="store_true",
+            help="Look for manifest components with an incorrect number of upstreams"
+            " and correct them",
+        )
+
     def handle(self, *args, **options) -> None:
         if options["stream"]:
             ps = ProductStream.objects.get(name=options["stream"])
@@ -44,6 +56,10 @@ class Command(BaseCommand):
                 self.style.SUCCESS(f"Removing no_manifest tag from {options['allow-stream']}")
             )
             no_manifest_tag.delete()
+        elif options["upstream_taxonomy"]:
+            self.stdout.write(self.style.SUCCESS("Calling ensure root upstreams task"))
+            updated = slow_ensure_root_upstreams()
+            self.stdout.write(self.style.SUCCESS(f"Updated {updated} root component upstreams"))
         else:
             self.stdout.write(self.style.SUCCESS("Updating manifests for all streams"))
             update_manifests()

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -61,6 +61,7 @@ def setup_periodic_tasks(sender, **kwargs):
     else:
         # Once a week on a Saturday fetch relations from all active CDN repos
         upsert_cron_task("pulp", "setup_pulp_relations", minute=0, hour=4, day_of_week=6)
+        upsert_cron_task("manifest", "slow_ensure_root_upstreams", minute=0, hour=8, day_of_week=6)
 
         # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
         # task at all: https://github.com/celery/django-celery-beat/issues/221


### PR DESCRIPTION
When generating stream manifests stream.upstreams_queryset returns different results to component.get_upsteams_pks(). That results in a relationship being added without the corresponding package being in the manifest. To resolve this every week we will ensure that all manifest comonents have an accurate 'upstreams' foriegn key according to the graph.