### PR TITLE
CORGI-1068 remove readonly from manifest_components query

### DIFF
--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -1226,9 +1226,7 @@ class ComponentQuerySet(models.QuerySet):
     def manifest_components(self, ofuri: str, quick=False) -> "ComponentQuerySet":
         """filter latest components takes a long time, dont bother with that if we're just
         checking there is anything to manifest"""
-        non_container_source_components = self.exclude(name__endswith="-container-source").using(
-            "read_only"
-        )
+        non_container_source_components = self.exclude(name__endswith="-container-source")
         roots = non_container_source_components.root_components()
         if not settings.COMMUNITY_MODE_ENABLED:
             # Only filter in enterprise Corgi, where we have ERRATA-type relations


### PR DESCRIPTION
Running the 'generatemanifest -u' management command failed with:

`django.db.utils.InternalError: cannot execute INSERT in a read-only transaction`