### PR TITLE
SPDXValidation timeout

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -344,9 +344,9 @@ CELERY_RESULT_EXTENDED = True
 # @app.task(soft_time_limit=<TIME_IN_SECONDS>)
 CELERY_TASK_SOFT_TIME_LIMIT = 900
 # CELERY_SINGLETON_LOCK_EXPIRY and redis visibility timeout must never be less than the below value
-# if you set below to more than 3600 seconds, you must also update the redis visibility timeout
-CELERY_LONGEST_SOFT_TIME_LIMIT = 3600
-# Expire locks after 1 hour, which is the longest task time limit.
+# if you set below to more than 7200 seconds, you must also update the redis visibility timeout
+CELERY_LONGEST_SOFT_TIME_LIMIT = 7200
+# Expire locks after 2 hours, which is the longest task time limit.
 # https://github.com/steinitzu/celery-singleton#app-configuration
 CELERY_SINGLETON_LOCK_EXPIRY = CELERY_LONGEST_SOFT_TIME_LIMIT
 
@@ -386,6 +386,7 @@ CELERY_RESULT_EXPIRES = None
 # and 9 for bulk data processing that does not need to complete immediately
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "queue_order_strategy": "priority",
+    "visibility_timeout": CELERY_LONGEST_SOFT_TIME_LIMIT,
 }
 
 CELERY_TASK_ROUTES = (

--- a/corgi/core/files.py
+++ b/corgi/core/files.py
@@ -412,7 +412,6 @@ class ProductManifestFile(ManifestFile):
         document.relationships = relationships
 
         document.extracted_licensing_info = self.build_extracted_license_info()
-        self.validate_document(document, document_name)
 
         return DocumentConverter().convert(document)
 

--- a/corgi/core/models.py
+++ b/corgi/core/models.py
@@ -715,6 +715,8 @@ class ProductStream(ProductModel):
         )
         return (
             Component.objects.filter(pk__in=unique_provides)
+            # See CORGI-658 for the motivation
+            .exclude(purl__contains="redhat.com")
             # Remove .exclude() below when CORGI-428 is resolved
             .exclude(purl__startswith="pkg:golang/", purl__contains="./")
             .exclude(purl__startswith="pkg:golang/", purl__contains="..")

--- a/corgi/tasks/management/commands/generatemanifests.py
+++ b/corgi/tasks/management/commands/generatemanifests.py
@@ -3,11 +3,7 @@ import sys
 from django.core.management.base import BaseCommand, CommandParser
 
 from corgi.core.models import ProductStream
-from corgi.tasks.manifest import (
-    cpu_update_ps_manifest,
-    slow_ensure_root_upstreams,
-    update_manifests,
-)
+from corgi.tasks.manifest import cpu_update_ps_manifest, update_manifests
 
 
 class Command(BaseCommand):
@@ -31,14 +27,6 @@ class Command(BaseCommand):
             "re-adding the 'no_manifest' tag.",
         )
 
-        parser.add_argument(
-            "-u",
-            "--upstream_taxonomy",
-            action="store_true",
-            help="Look for manifest components with an incorrect number of upstreams"
-            " and correct them",
-        )
-
     def handle(self, *args, **options) -> None:
         if options["stream"]:
             ps = ProductStream.objects.get(name=options["stream"])
@@ -56,10 +44,6 @@ class Command(BaseCommand):
                 self.style.SUCCESS(f"Removing no_manifest tag from {options['allow-stream']}")
             )
             no_manifest_tag.delete()
-        elif options["upstream_taxonomy"]:
-            self.stdout.write(self.style.SUCCESS("Calling ensure root upstreams task"))
-            updated = slow_ensure_root_upstreams()
-            self.stdout.write(self.style.SUCCESS(f"Updated {updated} root component upstreams"))
         else:
             self.stdout.write(self.style.SUCCESS("Updating manifests for all streams"))
             update_manifests()

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -196,7 +196,7 @@ def cpu_update_ps_manifest(product_stream: str, external_name: str) -> tuple[boo
     autoretry_for=RETRYABLE_ERRORS,
     priority=6,
     retry_kwargs=RETRY_KWARGS,
-    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT
+    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
 def cpu_validate_ps_manifest(product_stream: str):
     logger.info(f"Validating manifest for {product_stream}")

--- a/corgi/tasks/manifest.py
+++ b/corgi/tasks/manifest.py
@@ -182,7 +182,6 @@ def cpu_update_ps_manifest(product_stream: str, external_name: str) -> tuple[boo
         created_at, document_uuid = _write_content(
             external_name, content, output_file, product_stream
         )
-        cpu_validate_ps_manifest.delay(product_stream)
         return True, created_at, document_uuid
     else:
         logger.info(
@@ -195,8 +194,9 @@ def cpu_update_ps_manifest(product_stream: str, external_name: str) -> tuple[boo
 @app.task(
     base=Singleton,
     autoretry_for=RETRYABLE_ERRORS,
+    priority=6,
     retry_kwargs=RETRY_KWARGS,
-    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
+    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT
 )
 def cpu_validate_ps_manifest(product_stream: str):
     logger.info(f"Validating manifest for {product_stream}")
@@ -204,7 +204,12 @@ def cpu_validate_ps_manifest(product_stream: str):
     manifest_file = ProductManifestFile(ps)
     file_name = f"{settings.STATIC_ROOT}/{ps.external_name}.json"
     document = parse_file(file_name)
-    manifest_file.validate_document(document, ps.external_name)
+    try:
+        manifest_file.validate_document(document, ps.external_name)
+    except ValueError:
+        logger.info(f"Got error validating SPDX document for {product_stream}")
+        slow_ensure_root_provides.delay(product_stream)
+        slow_ensure_root_upstreams.delay(product_stream)
 
 
 def _write_content(external_name, new_content, output_file, product_stream) -> tuple[str, str]:
@@ -213,6 +218,7 @@ def _write_content(external_name, new_content, output_file, product_stream) -> t
     created_at = new_content["creationInfo"]["created"]
     new_relationships = new_content["relationships"]
     document_uuid = get_document_uuid(new_relationships, external_name, product_stream)
+    cpu_validate_ps_manifest.delay(product_stream)
     return created_at, document_uuid
 
 
@@ -238,16 +244,34 @@ def get_document_uuid(new_relationships, external_name, product_stream):
     retry_kwargs=RETRY_KWARGS,
     soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
 )
-def slow_ensure_root_upstreams() -> int:
+def slow_ensure_root_upstreams(product_stream: str) -> int:
+    logger.info(f"slow_ensure_root_upstreams called for {product_stream}")
     saved_count = 0
-    for ps in ProductStream.objects.annotate(num_components=Count("components")).filter(
-        num_components__gt=0
+    ps = ProductStream.objects.get(name=product_stream)
+    for root_c in ps.components.filter(type=Component.Type.CONTAINER_IMAGE).manifest_components(
+        ofuri=ps.ofuri
     ):
-        for root_c in ps.components.filter(type=Component.Type.CONTAINER_IMAGE).manifest_components(
-            ofuri=ps.ofuri
-        ):
-            if root_c.get_upstreams_pks().count() != root_c.upstreams.count():
-                logger.info(f"saving component taxonomy for {root_c.purl} in stream {ps.name}")
-                root_c.save_component_taxonomy()
-                saved_count += 1
+        if root_c.get_upstreams_pks().count() != root_c.upstreams.count():
+            logger.info(f"saving component taxonomy for {root_c.purl} in stream {ps.name}")
+            root_c.save_component_taxonomy()
+            saved_count += 1
+    return saved_count
+
+
+# Added because of PSDEVOPS-1070
+@app.task(
+    base=Singleton,
+    autoretry_for=RETRYABLE_ERRORS,
+    retry_kwargs=RETRY_KWARGS,
+    soft_time_limit=settings.CELERY_LONGEST_SOFT_TIME_LIMIT,
+)
+def slow_ensure_root_provides(product_stream: str) -> int:
+    logger.info(f"slow_ensure_root_provides called for {product_stream}")
+    saved_count = 0
+    ps = ProductStream.objects.get(name=product_stream)
+    for root_c in ps.components.manifest_components(ofuri=ps.ofuri):
+        if len(root_c.get_provides_pks()) != root_c.provides.count():
+            logger.info(f"saving component taxonomy for {root_c.purl} in stream {ps.name}")
+            root_c.save_component_taxonomy()
+            saved_count += 1
     return saved_count

--- a/corgi/tasks/monitoring.py
+++ b/corgi/tasks/monitoring.py
@@ -61,7 +61,6 @@ def setup_periodic_tasks(sender, **kwargs):
     else:
         # Once a week on a Saturday fetch relations from all active CDN repos
         upsert_cron_task("pulp", "setup_pulp_relations", minute=0, hour=4, day_of_week=6)
-        upsert_cron_task("manifest", "slow_ensure_root_upstreams", minute=0, hour=8, day_of_week=6)
 
         # Daily tasks, scheduled to a specific hour. For some reason, using hours=24 may not run the
         # task at all: https://github.com/celery/django-celery-beat/issues/221


### PR DESCRIPTION
Fixes:

CORGI-1070 by called save_component_taxonomy on all root component provides to make sure the graph is the same as the foreign key relationships.

CORGI-1067 by splitting the SPDXValiation step of generating a product stream manifest to a distinct task.

Saving component taxonomy on root nodes is no longer triggered weekly, rather it's only trigger for a specific product stream only when SPDX Validation fails.